### PR TITLE
fix(moe): K-quant attention head stride — head_nbytes returned 0 (ggml#1506 was ours)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -235,6 +235,13 @@ libexec/toy-infer: lib/toy/run/infer.rb lib/toy/models/arch.rb lib/toy/models/tr
 	$(SPINEL) $< -o $@
 toy-infer: libexec/toy-infer
 
+# Diagnostic sibling of toy-infer: enables the cache trace and dumps per-tap
+# min/max/|mean|/nan for every layer (used to localize ggml#1506 — the K-quant
+# MoE attention head_nbytes collapse). See docs/notes/mul_mat_id_quants.md.
+libexec/toy-infer-trace: lib/toy/run/infer_trace.rb lib/toy/models/arch.rb lib/toy/models/transformer_lm.rb lib/toy_smollm2_ffi_kv.rb lib/toy/models/toy_smollm2_loader.rb lib/toy/models/transformer.rb lib/toy/models/gpt2.rb lib/toy/io/gguf_load.rb lib/tinynn.rb lib/toy/io/tokenizer.rb tinynn/libtinynn_ggml.a | libexec
+	$(SPINEL) $< -o $@
+toy-infer-trace: libexec/toy-infer-trace
+
 # P4 — `toy eval` COMPUTE runner (CRuby→runner COMPUTE BRIDGE, same shape as
 # toy-infer). Spinel source lib/toy/run/eval.rb; the binary path EQUALS the
 # make target so ToyRoot.ensure_built("libexec/toy-eval") both builds and

--- a/Makefile
+++ b/Makefile
@@ -372,6 +372,17 @@ gate-lmc:
 gate-full-finetune:
 	ruby prep/full_finetune_gate.rb
 
+# K-quant MoE attention regression gate (the bug long misfiled as ggml#1506):
+# head_nbytes returned 0 for K-quant attention weights → per-head mmap stride
+# collapsed every head onto head 0 → degenerate repeating decode on OLMoE
+# Q4_K_M. Structural assertion (distinct-count + max single-token run), not
+# byte-exact, so it survives benign K-quant drift. MODEL-GATED: needs the ~4 GB
+# data/OLMoE-1b-7b-0924-Instruct-Q4_K_M.gguf (gitignored); SKIPs loudly when
+# absent. bin/toy auto-builds the infer runner. See docs/notes/mul_mat_id_quants.md.
+.PHONY: gate-moe-kquant
+gate-moe-kquant:
+	ruby prep/moe_kquant_gate.rb
+
 # CUDA from-scratch TRAINING gate (STRONG arm, no epsilon): train
 # from-scratch --device cuda --steps 5 --seed 0, assert the "step N: loss="
 # curve byte-equals prep/fixtures/train_cuda_baseline.txt, loss decreases,

--- a/docs/gating.md
+++ b/docs/gating.md
@@ -77,6 +77,23 @@ ruby prep/infer_gate.rb   # exit 0 on byte-for-byte match, 1 otherwise
 `infer`/`train`/`eval` are tep-free. `serve_gate.rb` covers the
 OpenAI-compatible HTTP path.
 
+### Model-gated regression gates
+
+Some gates exercise a REAL model whose GGUF is a gitignored multi-GB dev
+artifact (present on gx10 / Mac dev boxes, absent from a fixture-only
+checkout). These SKIP loudly (exit 0) when the model is missing rather than
+failing CI:
+
+- `make gate-full-finetune` (`prep/full_finetune_gate.rb`) — needs
+  `data/smollm2-135m-native.gguf`; byte-exact engine full-finetune CE curve.
+- `make gate-moe-kquant` (`prep/moe_kquant_gate.rb`) — needs
+  `data/OLMoE-1b-7b-0924-Instruct-Q4_K_M.gguf` (~4 GB). Regression guard for
+  the K-quant MoE attention head-stride collapse (`head_nbytes` returning 0 for
+  K-quants — the bug long misfiled as ggml#1506; see
+  `docs/notes/mul_mat_id_quants.md`). STRUCTURAL assertion (distinct-id count +
+  max single-token run on a greedy OLMoE Q4_K_M decode), not byte-exact, so it
+  guards "attention didn't collapse" without false-alarming on K-quant drift.
+
 ## Mirror gate
 
 The CPU algorithm file is the single source of truth; the CUDA and Metal

--- a/docs/notes/mul_mat_id_quants.md
+++ b/docs/notes/mul_mat_id_quants.md
@@ -1,23 +1,37 @@
-# `mul_mat_id` × K-quantized source weights — OLMoE Q4_K_M corruption
+# OLMoE Q4_K_M corruption — RESOLVED (was per-head attention stride, NOT mul_mat_id)
 
-**Status (2026-06-05): NOT a ggml bug — it's ours, and narrowed but not yet
-found.** Workaround stands: use Q8_0 for MoE expert weights. ggml#1506 is
-closeable on the ggml side (maintainer agrees).
+**Status (2026-06-05): FIXED.** Root cause was `head_nbytes()` in
+`lib/toy_smollm2_ffi_kv.rb` returning **0** for K-quant attention weights,
+collapsing every attention head onto head 0's weight slice. It had **nothing to
+do with `mul_mat_id` or the experts** — the op was correct for K-quants all
+along. ggml#1506 is a non-bug on the ggml side (closeable). Fix: generalize
+`head_nbytes` via `tnn_row_size` (correct for F32, Q8_0, and all K-quants).
 
-> **FRESH-SESSION RESUME — start here.** What's verified: the op is clean
-> (`tinynn/ggml1506_mul_mat_id_kquant_repro.c`); our loader reads expert
-> `type`+`offset`+`shape` PER TENSOR (`@d_ff=1024` is OLMoE's expert FFN length),
-> so the per-role-stride bug @devYRPauli flagged does NOT apply to us; the MoE
-> graph is identical between Q4_K_M (corrupt) and Q8_0 (coherent), so it's not a
-> pure graph bug. See the **2026-06-05 section at the bottom** for the full
-> verification + the `tinynn/gguf_expert_dump.c` metadata dump. **THE DECISIVE
-> NEXT TEST:** a ~120-line C reproducer that runs `mul_mat_id` over the REAL q6_K
-> `down_exps` bytes (read from the GGUF at `data_offset+tensor_offset`, attached
-> via `ggml_backend_tensor_alloc` like our loader's mmap path) vs an F32 dequant
-> reference (`ggml_get_type_traits(type).to_float`). Corrupt → real op bug w/
-> specific data → minimal C repro for ggml. Clean → experts fine, hunt the
-> weighted-sum / contiguity / mmap-attach path. Models: `data/OLMoE-1b-7b-0924-
-> Instruct-{Q4_K_M,q8_0}.gguf`. Repro shape: n_mats=64, n_used=8, k=1024 (down).
+> **THE ACTUAL BUG.** MoE GGUFs are force-routed through `realize_for_mmap`
+> (`load_cpu`, the `if flags.is_moe → is_native = true` branch). That path slices
+> the fused `attn_q/k/v.weight` into per-head tensors at byte offset
+> `off_base + hq * head_nbytes(type, d_head, d_model)`. `head_nbytes` only had
+> arms for F32 (type 0) and Q8_0 (type 8); **every K-quant fell to the `else → 0`**.
+> Stride 0 ⇒ all heads read head 0's slice ⇒ multi-head attention collapses ⇒
+> degenerate repeating output, compounding across 16 layers. It surfaced only on
+> K-quant **MoE** models because (a) non-MoE legacy K-quant GGUFs take the *copy*
+> loader (`realize_for` + `load_kv_cache_auto`, which never calls `head_nbytes`),
+> and (b) Q8_0 MoE GGUFs hit the working type-8 arm. The smoking gun in the trace:
+> `L0.concat` min/max == `L0.head0` (all heads identical) on Q4_K_M, but wider than
+> `head0` on Q8_0. After the fix, `concat` matches the Q8_0 reference.
+>
+> **How it was localized** (all reproducers kept in `tinynn/`):
+> - `ggml1506_mul_mat_id_kquant_repro.c` — synthetic op: K-quant `mul_mat_id` clean.
+> - `ggml1506_mmap_byo_repro.c` — REAL q6_K/q4_K `down_exps` bytes via the mmap
+>   BYO-pointer attach vs copied vs F32: bit-identical, experts definitively fine.
+> - `ggml1506_broadcast_repro.c` — the broadcast (`b->ne1==1`) gate/up call shape:
+>   also clean for K-quants.
+> - `gguf_all_types.c` — diff of Q4_K_M vs q8_0 tensor dtypes showed **all**
+>   weights differ (attn + embed + output), not just experts → premise was wrong.
+> - `gguf_requant_q4k.c` — built a non-MoE Q4_K tinyllama; it ran coherently
+>   (copy path), proving the defect was MoE-path-specific, not general K-quant.
+> - `trace_olmoe.rb` / `lib/toy/run/infer_trace.rb` (→ `libexec/toy-infer-trace`)
+>   — per-tap min/max/|mean|/nan dump; revealed the `concat == head0` collapse.
 
 **Affected**: MoE inference via `tnn_mul_mat_id` (used in OLMoE,
 Mixtral, Qwen-MoE, Granite-MoE, and any other arch with routed
@@ -62,22 +76,12 @@ This is consistent with:
   scale + per-sub-block offset that requires different per-block
   unpacking.
 
-## Workaround (current)
+## Workaround (HISTORICAL — no longer needed)
 
-1. **Convert MoE models at Q8_0 or higher**. Avoid Q4_K_M, Q5_K_M,
-   Q6_K for MoE expert weights specifically. Non-expert weights
-   (embeddings, attention, norms) can stay at K-quants — only the
-   MoE expert stacks need Q8_0.
-
-2. **Runtime warning**: `realize_for_mmap` emits a warning when
-   it detects MoE expert tensors with type ∈ {Q4_K, Q5_K, Q6_K,
-   ...K_M / K_S / K_XS variants}. The model will still load and
-   run, but output will be wrong. This makes the failure mode
-   loud rather than silent.
-
-3. **Choose your GGUF**: For OLMoE-1B-7B, `Meshwa/OLMoE-1b-7b-0924-
-   Instruct-gguf` ships both Q4_K_M and Q8_0 variants. Use the
-   Q8_0 (~7 GB, ~13 tok/s on gx10 CPU).
+Before the `head_nbytes` fix the workaround was "use Q8_0 for MoE expert
+weights." That is obsolete: K-quant MoE (incl. OLMoE Q4_K_M with its mixed
+q4_K+q6_K `down_exps`) now loads and runs coherently. The sections below are
+kept for the historical record of the (wrong) kernel-gap hypothesis.
 
 ## Reproducing
 
@@ -143,15 +147,21 @@ inspect how `realize_for_mmap` lays out the MoE expert tensors vs what the op
 expects (block alignment / per-expert stride / mixed-type stack), and build a
 toy-side op-test that feeds our mmap'd tensors directly.
 
-**The runtime warning is now MISATTRIBUTED.** `realize_for_mmap` says "ggml's
-mul_mat_id kernel produces wrong output for K-quants" — the op-level reproducer
-shows that's false. Reword it to "toy's K-quant MoE expert path produces wrong
-output (cause under investigation; use Q8_0)" until the toy-side root cause lands;
-do NOT remove it (the symptom is still live).
+**The runtime warning was MISATTRIBUTED and is now REMOVED.** It blamed ggml's
+mul_mat_id kernel; the real cause was `head_nbytes` (per-head ATTENTION stride),
+not the experts. Removed in the same change as the fix.
 
-When the toy-side root cause is fixed:
-- Update/remove the runtime warning in realize_for_mmap.
-- Add a smoke that loads OLMoE Q4_K_M and confirms coherent output.
+DONE (2026-06-05):
+- `head_nbytes` generalized via `tnn_row_size` (handles K-quants); fails loud
+  on a 0/invalid stride instead of silently collapsing heads.
+- Misleading mul_mat_id-K-quant warning removed from `realize_for_mmap`.
+- Verified: OLMoE Q4_K_M decode now coherent and tracks the q8_0 reference
+  (`510 38479 1171 33639 261 …` → varied IDs, no `20065×N` degeneration).
+- Regression-checked: Q8_0 mmap path, legacy-copy K-quant path (tinyllama Q4_K),
+  and F32 path all still coherent.
+
+Remaining nice-to-have: a committed smoke that loads OLMoE Q4_K_M and asserts
+the first generated id ≠ the degenerate token.
 
 ## Coverage-doc cross-reference
 

--- a/docs/notes/mul_mat_id_quants.md
+++ b/docs/notes/mul_mat_id_quants.md
@@ -160,8 +160,10 @@ DONE (2026-06-05):
 - Regression-checked: Q8_0 mmap path, legacy-copy K-quant path (tinyllama Q4_K),
   and F32 path all still coherent.
 
-Remaining nice-to-have: a committed smoke that loads OLMoE Q4_K_M and asserts
-the first generated id ≠ the degenerate token.
+- Committed regression gate: `make gate-moe-kquant` (`prep/moe_kquant_gate.rb`)
+  — model-gated (skips loudly when the ~4 GB OLMoE Q4_K_M dev GGUF is absent),
+  asserts a structurally non-degenerate greedy decode (distinct-id count +
+  max single-token run), not the pre-fix `20065×N` collapse. See `docs/gating.md`.
 
 ## Coverage-doc cross-reference
 

--- a/lib/toy/models/transformer_lm.rb
+++ b/lib/toy/models/transformer_lm.rb
@@ -28,6 +28,9 @@ require_relative "../dev/toy_logprobs"
 
 class ToyLM
   attr_reader :arch, :backend, :tokenizer, :max_T
+  # ggml#1506 trace localization: expose the CPU cache so a trace runner can
+  # call enable_trace! before decoding. Read-only; harmless when unused.
+  attr_reader :kv_cpu
 
   def initialize(arch, backend)
     @arch    = arch

--- a/lib/toy/run/infer_trace.rb
+++ b/lib/toy/run/infer_trace.rb
@@ -1,0 +1,37 @@
+# lib/toy/run/infer_trace.rb — ggml#1506 localization runner. Loads a GGUF,
+# enables the cache trace, and runs ONE decode_step per PROMPT_IDS token so the
+# per-tap min/max/|mean|/nan dump prints for every layer. Diff the Q4_K_M dump
+# against the q8_0 dump to find the first op where the K-quant run diverges.
+#
+#   make libexec/toy-infer-trace
+#   GGUF=data/OLMoE-...-Q4_K_M.gguf PROMPT_IDS=261 libexec/toy-infer-trace
+require_relative "../models/arch"
+require_relative "../models/transformer_lm"
+
+GGUF = ENV["GGUF"] || "data/smollm2-135m-f32.gguf"
+PROMPT_IDS = ENV["PROMPT_IDS"] || "261"
+
+arch = Arch.from_gguf(GGUF)
+if arch == nil
+  puts "infer_trace: could not load " + GGUF
+  exit 1
+end
+puts arch.summary
+
+lm = ToyLM.new(arch, :cpu)
+lm.load(GGUF)
+lm.kv_cpu.enable_trace!
+
+parts = PROMPT_IDS.split(" ")
+pos = 0
+j = 0
+while j < parts.length
+  tokstr = parts[j]
+  if tokstr.length > 0
+    tid = tokstr.to_i
+    puts "=== decode_step(token=" + tid.to_s + ", pos=" + pos.to_s + ") ==="
+    lm.decode_step(tid, pos)
+    pos = pos + 1
+  end
+  j = j + 1
+end

--- a/lib/toy_smollm2_ffi_kv.rb
+++ b/lib/toy_smollm2_ffi_kv.rb
@@ -686,22 +686,14 @@ class SmolLM2KVFFICache
         gate_exps_idx = TinyNN.tnn_gguf_find_index(gguf_handle, prefix + ".ffn_gate_exps.weight")
         up_exps_idx   = TinyNN.tnn_gguf_find_index(gguf_handle, prefix + ".ffn_up_exps.weight")
         down_exps_idx = TinyNN.tnn_gguf_find_index(gguf_handle, prefix + ".ffn_down_exps.weight")
-        # #112: warn loudly when expert weights use a K-family quant.
-        # ggml's mul_mat_id has reliable kernels for F32/F16/Q8_0
-        # source only; K-quants (Q4_K=12, Q5_K=13, Q6_K=14, *_K_S/M/L
-        # variants) produce wrong output via mul_mat_id even though
-        # the dispatch accepts them. See docs/notes/mul_mat_id_quants.md.
-        # Only warn once per realize, on layer 0.
-        if li == 0
-          gate_type = TinyNN.tnn_gguf_tensor_type(gguf_handle, gate_exps_idx)
-          if gate_type >= 10 && gate_type <= 19
-            puts "WARN: MoE expert weights are K-quantized (type=" + gate_type.to_s + ")."
-            puts "WARN: ggml's mul_mat_id kernel produces wrong output for K-quants."
-            puts "WARN: This model WILL run but the output will be incoherent."
-            puts "WARN: Use the Q8_0 variant of this GGUF, or another quant."
-            puts "WARN: See docs/notes/mul_mat_id_quants.md."
-          end
-        end
+        # #112 (RESOLVED): K-quant MoE experts work. The old warning here
+        # blamed ggml's mul_mat_id kernel for the OLMoE-Q4_K_M corruption,
+        # but the op was always correct for K-quants (verified by op-level
+        # and real-bytes reproducers in tinynn/ggml1506_*). The actual bug
+        # was head_nbytes() returning 0 for K-quant ATTENTION weights,
+        # collapsing every head onto head 0 — fixed there. K-quant expert
+        # stacks (gate/up/down, including OLMoE's mixed q4_K+q6_K down_exps)
+        # load and run coherently. See docs/notes/mul_mat_id_quants.md.
         blk.t_w_router    = TinyNN.tnn_input_2d_persistent_mmap(@sess,
                               @n_experts, @d_model,
                               TinyNN.tnn_gguf_tensor_type(gguf_handle, router_idx),
@@ -898,21 +890,31 @@ class SmolLM2KVFFICache
   end
 
   # Per-head byte stride for slicing a full [n_heads*d_head, d_model]
-  # tensor into n_heads contiguous Dh×D blocks. Matches ggml_nbytes()
-  # of a per-head ne=[d_model, d_head] tensor of `ggml_type`.
+  # tensor into n_heads contiguous Dh×D blocks. A per-head slice is
+  # d_head rows of d_model elements, so the stride is d_head row-sizes.
+  #
+  # tnn_row_size delegates to ggml_row_size, which is correct for EVERY
+  # type — F32, Q8_0, and the K-quants (Q4_K/Q5_K/Q6_K). The previous
+  # hand-coded F32/Q8_0-only branches returned 0 for any other type,
+  # which silently made the per-head offset `off_base + hq*0 == off_base`
+  # — i.e. every attention head read head 0's weight slice. That
+  # collapsed multi-head attention on K-quant MoE models (forced down the
+  # realize_for_mmap path), compounding across layers into degenerate
+  # output. This was misdiagnosed as a ggml mul_mat_id K-quant bug
+  # (ggml#1506); it was ours. Block alignment holds because each row is a
+  # whole number of quant blocks (requires d_model % block == 0, which
+  # the per-head tnn_input_2d_persistent_mmap also enforces via ne0).
   def head_nbytes(ggml_type, d_head, d_model)
-    if ggml_type == 0
-      # F32: d_head * d_model * 4
-      d_head * d_model * 4
-    elsif ggml_type == 8
-      # Q8_0: blocks of 32 elements stored as (half + 32 int8) = 34 bytes.
-      # Per-head has d_head rows of d_model elements each.
-      # bytes = d_head * (d_model / 32) * 34
-      d_head * (d_model / 32) * 34
-    else
-      # Unknown: refuse rather than guess.
-      0
+    rs = TinyNN.tnn_row_size(ggml_type, d_model)
+    if rs <= 0
+      # Fail loud per the never-mask rule: a 0 stride would collapse all
+      # heads. tnn_row_size only returns 0 on a bad type/shape.
+      puts "FATAL: head_nbytes got row_size<=0 for ggml_type=" +
+           ggml_type.to_s + " d_model=" + d_model.to_s +
+           " — per-head attention stride would collapse. Aborting."
+      exit 1
     end
+    d_head * rs
   end
 
   # CUDA-MIRROR-SKIP-BEGIN: trace-tap diagnostic ivars are CPU-only;

--- a/prep/moe_kquant_gate.rb
+++ b/prep/moe_kquant_gate.rb
@@ -1,0 +1,92 @@
+#!/usr/bin/env ruby
+# prep/moe_kquant_gate.rb — regression guard for the K-quant MoE attention
+# head-stride collapse (the bug long misfiled as ggml#1506).
+#
+# THE BUG: head_nbytes() returned 0 for K-quant attention weights, so the
+# per-head mmap slice offset `off_base + hq*0` made every attention head read
+# head 0's weight slice. On OLMoE-1B-7B Q4_K_M (forced down realize_for_mmap as
+# a MoE model) that collapsed multi-head attention into degenerate, repeating
+# output: `… 261 | 20065 20065 20065 20065 20065 42859 42859 42859 42859 42859`.
+# After the fix the same greedy decode is varied/coherent. See
+# docs/notes/mul_mat_id_quants.md and lib/toy_smollm2_ffi_kv.rb#head_nbytes.
+#
+# This is a STRUCTURAL gate, not a byte-exact one: it asserts the continuation
+# is non-degenerate (enough distinct tokens, no long single-token run) rather
+# than pinning exact ids — so it guards "attention didn't collapse" without
+# false-alarming on benign K-quant quant-noise drift across ggml versions.
+#
+# MODEL-GATED: needs data/OLMoE-1b-7b-0924-Instruct-Q4_K_M.gguf — a ~4 GB
+# gitignored dev artifact (Meshwa/OLMoE-1b-7b-0924-Instruct-gguf). When absent
+# the gate SKIPs loudly (exit 0) rather than failing a fixture-only checkout.
+#
+#   ruby prep/moe_kquant_gate.rb
+require "open3"
+
+ROOT = File.expand_path("..", __dir__)
+TOY  = File.join(ROOT, "bin", "toy")
+GGUF = File.join(ROOT, "data", "OLMoE-1b-7b-0924-Instruct-Q4_K_M.gguf")
+
+# The exact prompt + the degenerate token recorded pre-fix (token 20065 = "Dub",
+# repeated). Greedy decode, no sampler → deterministic.
+PROMPT_IDS  = "510 38479 1171 33639 261"
+N           = 10
+DEGEN_TOKEN = 20065
+MIN_DISTINCT = 5   # coherent gave 10/10 distinct; degenerate gave 2/10
+MAX_RUN      = 3   # degenerate had runs of 5; coherent has no long single-token run
+
+unless File.executable?(TOY)
+  warn "moe-kquant-gate: bin/toy not executable: #{TOY}"
+  exit 2
+end
+
+unless File.exist?(GGUF)
+  puts "SKIP [moe-kquant]: model absent (#{GGUF})."
+  puts "  This gate needs the ~4 GB OLMoE-1B-7B Q4_K_M dev GGUF (gitignored)."
+  puts "  Pull it from Meshwa/OLMoE-1b-7b-0924-Instruct-gguf to run the gate."
+  exit 0
+end
+
+out, st = Open3.capture2e(TOY, "infer", GGUF,
+                          "--prompt-ids", PROMPT_IDS, "--n", N.to_s, chdir: ROOT)
+unless st.success?
+  puts "GATE FAIL [moe-kquant]: `toy infer` exited #{st.exitstatus}"
+  puts out
+  exit 1
+end
+
+line = out.lines.find { |l| l.start_with?("ids:") }
+unless line
+  puts "GATE FAIL [moe-kquant]: no `ids:` line in output"
+  puts out
+  exit 1
+end
+
+all_ids = line.sub("ids:", "").split.map(&:to_i)
+prompt  = PROMPT_IDS.split.map(&:to_i)
+cont    = all_ids[prompt.length..] || []
+
+if cont.length < N
+  puts "GATE FAIL [moe-kquant]: expected #{N} continuation ids, got #{cont.length}"
+  puts "  ids: #{all_ids.join(' ')}"
+  exit 1
+end
+
+# longest run of a single repeated token in the continuation
+max_run = 1
+run = 1
+cont.each_cons(2) { |a, b| run = (a == b ? run + 1 : 1); max_run = [max_run, run].max }
+distinct = cont.uniq.length
+
+degenerate = (cont.first == DEGEN_TOKEN) || (distinct < MIN_DISTINCT) || (max_run > MAX_RUN)
+
+puts "[moe-kquant] continuation: #{cont.join(' ')}"
+puts "[moe-kquant] distinct=#{distinct}/#{cont.length}  max_run=#{max_run}  first=#{cont.first}"
+
+if degenerate
+  puts "GATE FAIL [moe-kquant]: degenerate output — attention head collapse regressed."
+  puts "  (pre-fix signature: token #{DEGEN_TOKEN} repeated; head_nbytes returned 0 for K-quants)"
+  exit 1
+end
+
+puts "GATE PASS [moe-kquant]: coherent K-quant MoE decode (no head-stride collapse)."
+exit 0

--- a/tinynn/ggml1506_broadcast_repro.c
+++ b/tinynn/ggml1506_broadcast_repro.c
@@ -1,0 +1,136 @@
+/* ggml#1506 — the BROADCAST path of mul_mat_id with K-quant experts.
+ *
+ * build_moe_ffn (toy_smollm2_ffi_kv.rb) calls the gate/up projections as
+ *   mul_mat_id(gate_exps, t_h2, top_idx)
+ * where t_h2 is a SINGLE token [d_model, 1] — i.e. b->ne1 == 1 while
+ * ids->ne0 == K (== n_experts_used). ggml broadcasts that one input to all K
+ * routed experts (the `ids->ne0 % b->ne1 == 0` branch).
+ *
+ * NEITHER our op reproducer NOR ggml's test-backend-ops exercises that branch:
+ * both build b with ne1 == n_used (distinct input per expert). So the broadcast
+ * branch of mul_mat_id with K-quant source weights is UNTESTED. This isolates it.
+ *
+ * Source = real OLMoE q4_K ffn_gate_exps bytes (uniform q4_K). Compare the q4_K
+ * broadcast result against the F32-dequant broadcast result of the SAME bytes,
+ * and against Q8_0 of the same bytes (the known-good control).
+ *
+ *   cc -O2 -Ivendor/ggml/include -Ivendor/ggml/src tinynn/ggml1506_broadcast_repro.c \
+ *      vendor/ggml/build/src/libggml.a vendor/ggml/build/src/libggml-cpu.a \
+ *      vendor/ggml/build/src/libggml-base.a -lstdc++ -lpthread -lm -o /tmp/bc
+ *   /tmp/bc data/OLMoE-1b-7b-0924-Instruct-Q4_K_M.gguf 0
+ */
+#include "ggml.h"
+#include "ggml-backend.h"
+#include "ggml-cpu.h"
+#include "gguf.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+
+#define N_USED 8
+#define N      5      /* tokens */
+
+static unsigned int rng = 12345u;
+static float frand(void) { rng = rng*1103515245u + 12345u; return ((float)((rng>>9)&0xFFFF)/32768.0f) - 1.0f; }
+static double nmse(const float *a, const float *b, size_t n) {
+    double se = 0, s2 = 0;
+    for (size_t i = 0; i < n; i++) { double d = (double)a[i]-b[i]; se += d*d; s2 += (double)b[i]*b[i]; }
+    return se / (s2 + 1e-12);
+}
+
+/* one run. broadcast=1 -> b->ne1==1 (toy's gate/up path); 0 -> b->ne1==N_USED. */
+static void run(enum ggml_type as_type, const void *bytes, int64_t k, int64_t m, int64_t nexp,
+                const float *bv, const int32_t *idv, int broadcast, float *out) {
+    struct ggml_init_params ip = { 256*1024*1024, NULL, true };
+    struct ggml_context *ctx = ggml_init(ip);
+    struct ggml_tensor *as = ggml_new_tensor_3d(ctx, as_type, k, m, nexp);
+    ggml_set_input(as);
+    struct ggml_tensor *ids = ggml_new_tensor_2d(ctx, GGML_TYPE_I32, nexp, N);
+    ggml_set_input(ids);
+    struct ggml_tensor *idv2 = ggml_view_2d(ctx, ids, N_USED, N, ids->nb[1], 0);
+    int64_t bne1 = broadcast ? 1 : N_USED;
+    struct ggml_tensor *b = ggml_new_tensor_3d(ctx, GGML_TYPE_F32, k, bne1, N);
+    ggml_set_input(b);
+    struct ggml_tensor *o = ggml_mul_mat_id(ctx, as, b, idv2);
+    ggml_set_output(o);
+    struct ggml_cgraph *gr = ggml_new_graph(ctx);
+    ggml_build_forward_expand(gr, o);
+    ggml_backend_t backend = ggml_backend_cpu_init();
+    ggml_backend_sched_t s = ggml_backend_sched_new(&backend, NULL, 1, ggml_graph_size(gr), false, false);
+    ggml_backend_sched_alloc_graph(s, gr);
+    ggml_backend_tensor_set(as, bytes, 0, ggml_nbytes(as));
+    ggml_backend_tensor_set(b, bv, 0, ggml_nbytes(b));
+    ggml_backend_tensor_set(ids, idv, 0, ggml_nbytes(ids));
+    ggml_backend_sched_graph_compute(s, gr);
+    ggml_backend_tensor_get(o, out, 0, (size_t)m*N_USED*N*sizeof(float));
+    ggml_backend_sched_free(s); ggml_backend_free(backend); ggml_free(ctx);
+}
+
+int main(int argc, char **argv) {
+    if (argc < 2) { fprintf(stderr, "usage: bc <model.gguf> [layer=0]\n"); return 2; }
+    int layer = (argc >= 3) ? atoi(argv[2]) : 0;
+    struct ggml_context *mc = NULL;
+    struct gguf_init_params gp; gp.no_alloc = true; gp.ctx = &mc;
+    struct gguf_context *gg = gguf_init_from_file(argv[1], gp);
+    char nm[128]; snprintf(nm, sizeof nm, "blk.%d.ffn_gate_exps.weight", layer);
+    int ti = gguf_find_tensor(gg, nm);
+    struct ggml_tensor *meta = ggml_get_tensor(mc, nm);
+    enum ggml_type qtype = meta->type;
+    int64_t k = meta->ne[0], m = meta->ne[1], nexp = meta->ne[2];   /* [d_model, d_ff, n_exp] */
+    size_t file_off = gguf_get_data_offset(gg) + gguf_get_tensor_offset(gg, ti);
+    printf("=== %s  %s  ne=[%lld,%lld,%lld] ===\n", nm, ggml_type_name(qtype),
+           (long long)k,(long long)m,(long long)nexp);
+
+    int fd = open(argv[1], O_RDONLY);
+    struct stat st; fstat(fd, &st); size_t fsize = st.st_size;
+    void *mbase = mmap(NULL, fsize, PROT_READ, MAP_PRIVATE, fd, 0);
+    const void *qsrc = (const char *)mbase + file_off;
+
+    size_t nelem = (size_t)k*m*nexp;
+    float *ref = malloc(nelem*sizeof(float));
+    ggml_get_type_traits(qtype)->to_float(qsrc, ref, (int64_t)nelem);
+    /* also a Q8_0 of the same data — the known-good control */
+    size_t q8bytes = ggml_row_size(GGML_TYPE_Q8_0, k) * m * nexp;
+    void *q8 = malloc(q8bytes);
+    ggml_quantize_chunk(GGML_TYPE_Q8_0, ref, q8, 0, (int64_t)m*nexp, k, NULL);
+
+    size_t nb = (size_t)k*N_USED*N;
+    float *bv = malloc(nb*sizeof(float));
+    for (size_t i = 0; i < nb; i++) bv[i] = frand();
+    int32_t *idv = malloc(sizeof(int32_t)*nexp*N);
+    for (int r = 0; r < N; r++) {
+        for (int i = 0; i < nexp; i++) idv[r*nexp+i] = i;
+        for (int i=(int)nexp-1;i>0;i--){ rng=rng*1103515245u+12345u; int j=(rng>>8)%(i+1);
+            int32_t t=idv[r*nexp+i]; idv[r*nexp+i]=idv[r*nexp+j]; idv[r*nexp+j]=t; }
+    }
+
+    size_t no = (size_t)m*N_USED*N;
+    float *o_qK_bc = malloc(no*4), *o_ref_bc = malloc(no*4), *o_q8_bc = malloc(no*4);
+    float *o_qK_nb = malloc(no*4), *o_ref_nb = malloc(no*4);
+
+    /* BROADCAST path (b->ne1==1) — toy's gate/up path */
+    run(qtype,           qsrc, k, m, nexp, bv, idv, 1, o_qK_bc);
+    run(GGML_TYPE_F32,   ref,  k, m, nexp, bv, idv, 1, o_ref_bc);
+    run(GGML_TYPE_Q8_0,  q8,   k, m, nexp, bv, idv, 1, o_q8_bc);
+    /* NON-broadcast path (b->ne1==N_USED) — the tested path, control */
+    run(qtype,           qsrc, k, m, nexp, bv, idv, 0, o_qK_nb);
+    run(GGML_TYPE_F32,   ref,  k, m, nexp, bv, idv, 0, o_ref_nb);
+
+    printf("\n-- BROADCAST path (b->ne1==1, ids->ne0==%d) : toy's gate/up call --\n", N_USED);
+    printf("  q-K  vs F32ref  NMSE = %.3e\n", nmse(o_qK_bc, o_ref_bc, no));
+    printf("  Q8_0 vs F32ref  NMSE = %.3e   (control)\n", nmse(o_q8_bc, o_ref_bc, no));
+    printf("-- NON-broadcast path (b->ne1==%d) : op-test path --\n", N_USED);
+    printf("  q-K  vs F32ref  NMSE = %.3e\n", nmse(o_qK_nb, o_ref_nb, no));
+
+    double ebc = nmse(o_qK_bc, o_ref_bc, no);
+    printf("\nVERDICT: %s\n", ebc > 5e-2
+        ? "BROADCAST path corrupts K-quant -> this is the bug (toy gate/up call shape)."
+        : "broadcast path clean for K-quant -> not here.");
+    munmap(mbase, fsize); close(fd);
+    return 0;
+}

--- a/tinynn/ggml1506_mmap_byo_repro.c
+++ b/tinynn/ggml1506_mmap_byo_repro.c
@@ -1,0 +1,177 @@
+/* ggml#1506 decisive test: mul_mat_id over the REAL OLMoE q6_K ffn_down_exps
+ * bytes, attached three ways, all compared against the SAME-bytes F32 dequant
+ * reference. The op-level synthetic reproducer (ggml1506_mul_mat_id_kquant_repro.c)
+ * is clean, so the defect — if it's in the experts at all — must be in either the
+ * data source (mmap BYO-pointer attach, our loader path) or the real q6_K bytes.
+ *
+ * Three source tensors, identical bytes, identical b + ids:
+ *   A) mmap BYO-pointer q6_K  — exactly tnn_input_3d_persistent_mmap:
+ *      ggml_backend_cpu_buffer_from_ptr(file) + ggml_backend_tensor_alloc(addr)
+ *   B) copied  q6_K           — sched-allocated, ggml_backend_tensor_set (op-repro path)
+ *   R) F32 dequant of A's bytes (ggml_get_type_traits(q6_K).to_float), the reference
+ *
+ * NMSE(A vs R) and NMSE(B vs R) should both be small q6_K noise (~2e-4). If A is
+ * gross but B is fine → the BYO-pointer attach corrupts mul_mat_id reads → that's
+ * the toy-side bug. If A == B (both fine) → experts are definitively correct and
+ * the corruption is in the MoE GRAPH wiring (hunt build_moe_ffn), ggml is clean.
+ *
+ *   cc -O2 -Ivendor/ggml/include -Ivendor/ggml/src tinynn/ggml1506_mmap_byo_repro.c \
+ *      vendor/ggml/build/src/libggml.a vendor/ggml/build/src/libggml-cpu.a \
+ *      vendor/ggml/build/src/libggml-base.a -lstdc++ -lpthread -lm -o /tmp/byo
+ *   /tmp/byo data/OLMoE-1b-7b-0924-Instruct-Q4_K_M.gguf 0
+ */
+#include "ggml.h"
+#include "ggml-backend.h"
+#include "ggml-cpu.h"
+#include "gguf.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+
+#define N_USED 8       /* OLMoE top-k */
+#define N      5       /* tokens */
+
+static unsigned int rng = 99991u;
+static float frand(void) { rng = rng*1103515245u + 12345u; return ((float)((rng>>9)&0xFFFF)/32768.0f) - 1.0f; }
+
+static double nmse(const float *a, const float *b, size_t n) {
+    double se = 0, s2 = 0;
+    for (size_t i = 0; i < n; i++) { double d = (double)a[i]-b[i]; se += d*d; s2 += (double)b[i]*b[i]; }
+    return se / (s2 + 1e-12);
+}
+
+int main(int argc, char **argv) {
+    if (argc < 2) { fprintf(stderr, "usage: byo <model.gguf> [layer=0]\n"); return 2; }
+    int layer = (argc >= 3) ? atoi(argv[2]) : 0;
+
+    /* --- metadata: data offset, tensor offset/type/shape --- */
+    struct ggml_context *mc = NULL;
+    struct gguf_init_params gp; gp.no_alloc = true; gp.ctx = &mc;
+    struct gguf_context *gg = gguf_init_from_file(argv[1], gp);
+    if (!gg) { fprintf(stderr, "open failed\n"); return 1; }
+
+    char nm[128];
+    snprintf(nm, sizeof nm, "blk.%d.ffn_down_exps.weight", layer);
+    int ti = gguf_find_tensor(gg, nm);
+    if (ti < 0) { fprintf(stderr, "no %s\n", nm); return 1; }
+    struct ggml_tensor *meta = ggml_get_tensor(mc, nm);
+    enum ggml_type qtype = meta->type;
+    int64_t ne0 = meta->ne[0], ne1 = meta->ne[1], ne2 = meta->ne[2]; /* [d_ff, d_model, n_exp] */
+    size_t data_off = gguf_get_data_offset(gg);
+    size_t tens_off = gguf_get_tensor_offset(gg, ti);
+    size_t file_off = data_off + tens_off;
+    size_t qbytes   = ggml_nbytes(meta);
+    printf("=== %s  %s  ne=[%lld,%lld,%lld]  file_off=%zu  nbytes=%zu ===\n",
+           nm, ggml_type_name(qtype), (long long)ne0,(long long)ne1,(long long)ne2,
+           file_off, qbytes);
+    if (qtype != GGML_TYPE_Q6_K && qtype != GGML_TYPE_Q4_K)
+        printf("(note: layer %d is %s, not a K-quant; pick a different layer)\n", layer, ggml_type_name(qtype));
+
+    /* --- mmap the whole file (page-aligned base, like the loader) --- */
+    int fd = open(argv[1], O_RDONLY);
+    struct stat stbuf; fstat(fd, &stbuf);
+    size_t fsize = (size_t)stbuf.st_size;
+    void *mbase = mmap(NULL, fsize, PROT_READ, MAP_PRIVATE, fd, 0);
+    if (mbase == MAP_FAILED) { perror("mmap"); return 1; }
+
+    /* the real q6_K bytes for this tensor */
+    const void *qsrc = (const char *)mbase + file_off;
+
+    /* --- F32 dequant reference of those same bytes --- */
+    const struct ggml_type_traits *tr = ggml_get_type_traits(qtype);
+    size_t nelem = (size_t)ne0*ne1*ne2;
+    float *ref_f32 = malloc(nelem * sizeof(float));
+    /* dequant row by row (to_float works on a full contiguous block here) */
+    tr->to_float(qsrc, ref_f32, (int64_t)nelem);
+
+    /* --- shared random b + ids (scattered experts per token) --- */
+    size_t nb = (size_t)ne0*N_USED*N;
+    float *bv = malloc(nb*sizeof(float));
+    for (size_t i = 0; i < nb; i++) bv[i] = frand();
+    int32_t *idv = malloc(sizeof(int32_t)*ne2*N);
+    for (int r = 0; r < N; r++) {
+        for (int i = 0; i < ne2; i++) idv[r*ne2+i] = i;
+        for (int i = (int)ne2-1; i > 0; i--) {
+            rng = rng*1103515245u + 12345u;
+            int j = (rng >> 8) % (i+1);
+            int32_t t = idv[r*ne2+i]; idv[r*ne2+i] = idv[r*ne2+j]; idv[r*ne2+j] = t;
+        }
+    }
+
+    size_t no = (size_t)ne1*N_USED*N;
+    float *out[3]; for (int i=0;i<3;i++) out[i]=malloc(no*sizeof(float));
+    const char *label[3] = { "A mmap-BYO q-K ", "B copied  q-K  ", "R F32 dequant  " };
+
+    ggml_backend_t backend = ggml_backend_cpu_init();
+
+    /* run one of the three paths; path: 0=BYO mmap, 1=copied quant, 2=F32 ref */
+    for (int path = 0; path < 3; path++) {
+        struct ggml_init_params ip = { 64*1024*1024, NULL, true /*no_alloc*/ };
+        struct ggml_context *ctx = ggml_init(ip);
+
+        enum ggml_type as_type = (path == 2) ? GGML_TYPE_F32 : qtype;
+        struct ggml_tensor *as = ggml_new_tensor_3d(ctx, as_type, ne0, ne1, ne2);
+
+        struct ggml_tensor *ids = ggml_new_tensor_2d(ctx, GGML_TYPE_I32, ne2, N);
+        ggml_set_input(ids);
+        struct ggml_tensor *idv2 = ggml_view_2d(ctx, ids, N_USED, N, ids->nb[1], 0);
+        struct ggml_tensor *b = ggml_new_tensor_3d(ctx, GGML_TYPE_F32, ne0, N_USED, N);
+        ggml_set_input(b);
+
+        struct ggml_tensor *o = ggml_mul_mat_id(ctx, as, b, idv2);
+        ggml_set_output(o);
+
+        struct ggml_cgraph *gr = ggml_new_graph(ctx);
+        ggml_build_forward_expand(gr, o);
+
+        /* Path A: attach `as` to the mmap region BEFORE sched alloc, exactly
+         * like tnn_input_3d_persistent_mmap. The other tensors stay sched-managed. */
+        ggml_backend_buffer_t mmapbuf = NULL;
+        if (path == 0) {
+            mmapbuf = ggml_backend_cpu_buffer_from_ptr(mbase, fsize);
+            void *addr = (char *)ggml_backend_buffer_get_base(mmapbuf) + file_off;
+            if (ggml_backend_tensor_alloc(mmapbuf, as, addr) != GGML_STATUS_SUCCESS) {
+                printf("tensor_alloc failed\n"); return 3;
+            }
+        } else {
+            ggml_set_input(as);
+        }
+
+        ggml_backend_sched_t s = ggml_backend_sched_new(&backend, NULL, 1, ggml_graph_size(gr), false, false);
+        if (!ggml_backend_sched_alloc_graph(s, gr)) { printf("alloc failed\n"); return 2; }
+
+        if (path == 1) ggml_backend_tensor_set(as, qsrc,    0, qbytes);          /* copied quant */
+        if (path == 2) ggml_backend_tensor_set(as, ref_f32, 0, nelem*sizeof(float)); /* F32 ref */
+        ggml_backend_tensor_set(b,   bv,  0, ggml_nbytes(b));
+        ggml_backend_tensor_set(ids, idv, 0, ggml_nbytes(ids));
+
+        ggml_backend_sched_graph_compute(s, gr);
+        ggml_backend_tensor_get(o, out[path], 0, no*sizeof(float));
+
+        ggml_backend_sched_free(s);
+        if (mmapbuf) ggml_backend_buffer_free(mmapbuf);
+        ggml_free(ctx);
+    }
+
+    double eA = nmse(out[0], out[2], no);   /* mmap-BYO vs F32 ref */
+    double eB = nmse(out[1], out[2], no);   /* copied   vs F32 ref */
+    double eAB= nmse(out[0], out[1], no);   /* mmap-BYO vs copied  */
+    printf("\n%s  NMSE(vs F32 ref) = %.3e\n", label[0], eA);
+    printf("%s  NMSE(vs F32 ref) = %.3e\n", label[1], eB);
+    printf("mmap-BYO vs copied-quant      NMSE = %.3e  (should be ~0: same bytes, same op)\n", eAB);
+
+    int grossA = eA > 5e-2, grossB = eB > 5e-2;
+    printf("\nVERDICT: ");
+    if (grossA && !grossB)      printf("BYO-POINTER PATH IS THE BUG (mmap attach corrupts the op).\n");
+    else if (!grossA && !grossB) printf("EXPERTS FINE both ways -> corruption is GRAPH-side (hunt build_moe_ffn).\n");
+    else if (grossA && grossB)  printf("BOTH q-K paths corrupt vs F32 -> real op/data bug with these bytes.\n");
+    else                        printf("copied corrupt but BYO fine -> unexpected; investigate.\n");
+
+    munmap(mbase, fsize); close(fd);
+    return 0;
+}

--- a/tinynn/gguf_all_types.c
+++ b/tinynn/gguf_all_types.c
@@ -1,0 +1,22 @@
+/* gguf_all_types.c — list every tensor name + quant type in a GGUF.
+ * Used to diff Q4_K_M vs q8_0 OLMoE: find which tensors (besides the
+ * experts) actually change dtype between the two files. */
+#include "ggml.h"
+#include "gguf.h"
+#include <stdio.h>
+
+int main(int argc, char **argv) {
+    if (argc < 2) { fprintf(stderr, "usage: %s <model.gguf>\n", argv[0]); return 2; }
+    struct ggml_context *mc = NULL;
+    struct gguf_init_params p; p.no_alloc = true; p.ctx = &mc;
+    struct gguf_context *g = gguf_init_from_file(argv[1], p);
+    if (!g) { fprintf(stderr, "open failed\n"); return 1; }
+    int64_t n = gguf_get_n_tensors(g);
+    for (int64_t i = 0; i < n; i++) {
+        const char *name = gguf_get_tensor_name(g, i);
+        struct ggml_tensor *t = ggml_get_tensor(mc, name);
+        printf("%-40s %s\n", name, ggml_type_name(t->type));
+    }
+    gguf_free(g);
+    return 0;
+}

--- a/tinynn/gguf_requant_q4k.c
+++ b/tinynn/gguf_requant_q4k.c
@@ -1,0 +1,61 @@
+/* gguf_requant_q4k.c — requantize every q8_0 2-D weight tensor in a GGUF to
+ * Q4_K (rows whose ne0 % 256 == 0), copying all metadata and other tensors
+ * verbatim. Purpose: produce a NON-MoE K-quant model to test whether toy's
+ * end-to-end K-quant inference path is correct (ggml#1506 isolation).
+ *
+ *   cc -O2 -Ivendor/ggml/include -Ivendor/ggml/src tinynn/gguf_requant_q4k.c \
+ *      vendor/ggml/build/src/libggml.a vendor/ggml/build/src/libggml-cpu.a \
+ *      vendor/ggml/build/src/libggml-base.a -lstdc++ -lpthread -lm -o /tmp/rq
+ *   /tmp/rq data/tinyllama-1.1b-q8_0.gguf /tmp/tinyllama-q4k.gguf
+ */
+#include "ggml.h"
+#include "gguf.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+int main(int argc, char **argv) {
+    if (argc < 3) { fprintf(stderr, "usage: rq <in.gguf> <out.gguf>\n"); return 2; }
+    struct ggml_context *src_ctx = NULL;
+    struct gguf_init_params p; p.no_alloc = false; p.ctx = &src_ctx;
+    struct gguf_context *src = gguf_init_from_file(argv[1], p);
+    if (!src) { fprintf(stderr, "open failed\n"); return 1; }
+
+    struct gguf_context *out = gguf_init_empty();
+    gguf_set_kv(out, src);   /* copy ALL key/value metadata verbatim */
+
+    /* a scratch ggml ctx to hold the requantized tensors */
+    size_t overhead = ggml_tensor_overhead() * (gguf_get_n_tensors(src) + 16);
+    struct ggml_init_params ip = { overhead, NULL, true /*no_alloc: we set data ptrs*/ };
+    struct ggml_context *work = ggml_init(ip);
+
+    int64_t n = gguf_get_n_tensors(src);
+    int requant = 0, kept = 0;
+    for (int64_t i = 0; i < n; i++) {
+        const char *name = gguf_get_tensor_name(src, i);
+        struct ggml_tensor *t = ggml_get_tensor(src_ctx, name);
+        int do_q4k = (t->type == GGML_TYPE_Q8_0) && (t->ne[0] % 256 == 0) && (t->ne[1] >= 1);
+        if (do_q4k) {
+            int64_t k = t->ne[0], rows = t->ne[1]*t->ne[2]*t->ne[3];
+            float *f32 = malloc((size_t)k*rows*sizeof(float));
+            const struct ggml_type_traits *tr = ggml_get_type_traits(t->type);
+            tr->to_float(t->data, f32, (int64_t)k*rows);
+            size_t q4bytes = ggml_row_size(GGML_TYPE_Q4_K, k) * rows;
+            void *q4 = malloc(q4bytes);
+            ggml_quantize_chunk(GGML_TYPE_Q4_K, f32, q4, 0, rows, k, NULL);
+            free(f32);
+            struct ggml_tensor *nt = ggml_new_tensor(work, GGML_TYPE_Q4_K, GGML_MAX_DIMS, t->ne);
+            ggml_set_name(nt, name);
+            nt->data = q4;   /* gguf_add_tensor reads ->data at write time */
+            gguf_add_tensor(out, nt);
+            requant++;
+        } else {
+            gguf_add_tensor(out, t);   /* verbatim (data ptr from src_ctx) */
+            kept++;
+        }
+    }
+    printf("requantized %d tensors to Q4_K, kept %d verbatim\n", requant, kept);
+    if (!gguf_write_to_file(out, argv[2], false)) { fprintf(stderr, "write failed\n"); return 1; }
+    printf("wrote %s\n", argv[2]);
+    return 0;
+}


### PR DESCRIPTION
## What

OLMoE Q4_K_M produced degenerate repeating output (`… 261 | 20065×5 42859×5`) while q8_0 was coherent. This was long misattributed to ggml's `mul_mat_id` K-quant kernel (**ggml#1506**). It was never the experts or the op — it's a per-head **attention** stride bug in our loader.

## Root cause

`head_nbytes()` only had arms for F32 (type 0) and Q8_0 (type 8) and returned **0** for every K-quant. MoE GGUFs are force-routed through `realize_for_mmap`, which slices the fused `attn_q/k/v.weight` into per-head tensors at `off_base + hq*head_nbytes(…)`. Stride 0 ⇒ **every head reads head 0's slice** ⇒ multi-head attention collapses, compounding across 16 layers into garbage. Silent, too (violated the fail-loud rule).

It looked MoE-specific only because non-MoE legacy K-quant GGUFs take the *copy* loader (`realize_for` + `load_kv_cache_auto`, which never calls `head_nbytes`), and Q8_0 MoE hit the working type-8 arm.

## Fix

`head_nbytes = d_head * tnn_row_size(type, d_model)` — correct for F32, Q8_0, and all K-quants — and **fail loud** on a 0/invalid stride instead of collapsing heads. Removed the false `mul_mat_id`-K-quant runtime warning. Mirrored to CUDA/Metal via `prep/gen_cuda_mirror.rb` (generated mirrors are gitignored).

## How it was localized (after op/expert hypotheses came back clean)

- `tinynn/ggml1506_mmap_byo_repro.c` — real q6_K/q4_K `down_exps` via the mmap BYO-pointer attach == F32 ref → **experts fine**
- `tinynn/ggml1506_broadcast_repro.c` — broadcast (`b->ne1==1`) gate/up shape also clean
- `tinynn/gguf_all_types.c` — Q4_K_M vs q8_0 dtype diff: **all** weights differ, not just experts
- `tinynn/gguf_requant_q4k.c` — non-MoE Q4_K tinyllama runs coherently (copy path) → MoE-path-specific
- `lib/toy/run/infer_trace.rb` + `make toy-infer-trace` — per-tap dump; smoking gun `L0.concat == L0.head0`

## Verification

- OLMoE Q4_K_M now coherent and tracks the q8_0 reference (`261 → 2320 658 15 11368 3 …`, no `20065×N` degeneration).
- Trace: `concat` now matches the q8_0 reference (heads distinct).
- Regressions clean: Q8_0 mmap path, legacy-copy K-quant (tinyllama Q4_K), F32 path.

ggml#1506 is closeable (non-bug on the ggml side). Full writeup in `docs/notes/mul_mat_id_quants.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)