### PR TITLE
refactor(events): Toy::Git + Toy::Events.add_provenance — dedup run_start boilerplate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -259,7 +259,7 @@ toy-eval: libexec/toy-eval
 # Deps mirror example_lmc (Makefile:479) NOT toy-eval; order-only | libexec (no
 # $(SPINEL_DEPS)) like the CPU toy-eval runner. CPU-only; NOT in MIRRORABLE (see
 # prep/gen_cuda_mirror.rb); a cuda LMC twin is a later slice.
-libexec/toy-eval-lmc: lib/toy/run/eval_lmc.rb lib/toy/io/toy_json.rb lib/toy/llm/engine/llama_seq_engine.rb lib/toy/models/toy_smollm2.rb lib/toy.rb lib/toy/models/transformer.rb lib/toy/train/toy_drift_grad.rb lib/tinynn.rb tinynn/libtinynn_ggml.a | libexec
+libexec/toy-eval-lmc: lib/toy/run/eval_lmc.rb lib/toy/io/toy_json.rb lib/toy/io/toy_git.rb lib/toy/llm/engine/llama_seq_engine.rb lib/toy/models/toy_smollm2.rb lib/toy.rb lib/toy/models/transformer.rb lib/toy/train/toy_drift_grad.rb lib/tinynn.rb tinynn/libtinynn_ggml.a | libexec
 	$(SPINEL) $< -o $@
 toy-eval-lmc: libexec/toy-eval-lmc
 
@@ -433,7 +433,7 @@ gate-serve:
 # tinynn + the L1-L3 primitives/blocks/archs; plus gguf_writer + drift_grad
 # for the checkpoint). CPU-only; NOT in MIRRORABLE (see prep/gen_cuda_mirror.rb).
 libexec/toy-train: lib/toy/run/train.rb lib/toy.rb lib/toy/models/toy_smollm2.rb \
-		lib/toy/io/toy_json.rb \
+		lib/toy/io/toy_json.rb lib/toy/io/toy_git.rb \
 		lib/toy/io/toy_corpus_loader.rb lib/toy/train/toy_lr_schedule.rb \
 		lib/toy/llm/engine/llama_seq_engine.rb lib/toy/llm/recipes/from_scratch.rb \
 		lib/toy/llm/recipes/warm_start.rb \
@@ -450,7 +450,7 @@ toy-train: libexec/toy-train
 # LoRA realize_for_mmap path cannot share a Spinel compilation unit with the
 # random-init path (cfg type-merge miscompile; see lib/toy/run/train_lora.rb
 # header). CPU-only; NOT in MIRRORABLE.
-libexec/toy-train-lora: lib/toy/run/train_lora.rb lib/toy/io/toy_json.rb lib/toy.rb lib/toy/models/toy_smollm2.rb \
+libexec/toy-train-lora: lib/toy/run/train_lora.rb lib/toy/io/toy_json.rb lib/toy/io/toy_git.rb lib/toy.rb lib/toy/models/toy_smollm2.rb \
 		lib/toy/llm/engine/llama_seq_engine.rb lib/toy/llm/recipes/lora.rb \
 		lib/toy/llm/adamw.rb \
 		lib/toy/train/toy_gguf_writer.rb lib/toy/train/toy_drift_grad.rb lib/toy/models/transformer.rb \
@@ -504,7 +504,7 @@ toy-train-gpt2-metal: libexec/toy-train-gpt2-metal
 # trains random-init on the COMMITTED data/vit_smoke corpus. NO toy_gguf_writer
 # dep (cfg.vocab/d_ff poly-collide with ViTTinyConfig — #169 checkpoint
 # follow-up). CPU-only; absent from MIRRORABLE (no CUDA/Metal twin this slice).
-libexec/toy-train-vit: lib/toy/run/train_vit.rb lib/toy/io/toy_json.rb lib/toy/llm/recipes/vit_tiny.rb \
+libexec/toy-train-vit: lib/toy/run/train_vit.rb lib/toy/io/toy_json.rb lib/toy/io/toy_git.rb lib/toy/llm/recipes/vit_tiny.rb \
 		lib/toy/llm/engine/vit_tiny_engine.rb lib/toy/models/toy_vit.rb lib/toy/models/toy_smollm2.rb \
 		lib/toy/io/toy_image_loader.rb lib/toy/train/toy_lr_schedule.rb lib/toy/train/toy_drift_grad.rb \
 		lib/toy/llm/adamw.rb \
@@ -519,7 +519,7 @@ toy-train-vit: libexec/toy-train-vit
 # checkpoint write/fuse/drift seam (dropping them breaks the writer). Links
 # the CUDA ggml backend via -Wl,-u,tnn_cuda_force_link (every cuda target).
 # CPU-only; NOT in MIRRORABLE (hand-written, see prep/gen_cuda_mirror.rb).
-libexec/toy-train-cuda: lib/toy/run/train_cuda.rb lib/toy/io/toy_json.rb lib/toy.rb lib/toy/models/toy_smollm2.rb \
+libexec/toy-train-cuda: lib/toy/run/train_cuda.rb lib/toy/io/toy_json.rb lib/toy/io/toy_git.rb lib/toy.rb lib/toy/models/toy_smollm2.rb \
 		lib/toy/io/toy_corpus_loader.rb lib/toy/train/toy_lr_schedule.rb \
 		lib/toy/llm/engine/llama_seq_engine_cuda.rb lib/toy/llm/recipes/from_scratch_cuda.rb \
 		lib/toy/llm/recipes/warm_start_cuda.rb \
@@ -542,7 +542,7 @@ toy-train-cuda: libexec/toy-train-cuda
 # (ToyDriftGrad.params downloads via CPU TinyNN). toy_gguf_fuse is NOT a dep
 # (lora uses ToyDriftGrad.params, not the lens-fold path). Links the CUDA
 # ggml backend via -Wl,-u,tnn_cuda_force_link. NOT in MIRRORABLE (hand-written).
-libexec/toy-train-lora-cuda: lib/toy/run/train_lora_cuda.rb lib/toy/io/toy_json.rb lib/toy.rb lib/toy/models/toy_smollm2.rb \
+libexec/toy-train-lora-cuda: lib/toy/run/train_lora_cuda.rb lib/toy/io/toy_json.rb lib/toy/io/toy_git.rb lib/toy.rb lib/toy/models/toy_smollm2.rb \
 		lib/toy/llm/engine/llama_seq_engine_cuda.rb lib/toy/llm/recipes/lora_cuda.rb \
 		lib/toy/llm/adamw.rb \
 		lib/toy/train/toy_gguf_writer.rb lib/toy/train/toy_drift_grad.rb lib/toy/models/transformer.rb \
@@ -563,7 +563,7 @@ toy-train-lora-cuda: libexec/toy-train-lora-cuda
 # (leading underscore, macOS symbol convention). libtinynn_ggml.a (CPU archive)
 # stays in deps for the write seam + base ggml. NOT in MIRRORABLE (hand-written).
 # gx10 RUNTIME-UNVERIFIED — pin baseline + gate on the Mac.
-libexec/toy-train-metal: lib/toy/run/train_metal.rb lib/toy/io/toy_json.rb lib/toy.rb lib/toy/models/toy_smollm2.rb \
+libexec/toy-train-metal: lib/toy/run/train_metal.rb lib/toy/io/toy_json.rb lib/toy/io/toy_git.rb lib/toy.rb lib/toy/models/toy_smollm2.rb \
 		lib/toy/llm/engine/llama_seq_engine_metal.rb lib/toy/llm/recipes/from_scratch_metal.rb \
 		lib/toy/llm/adamw.rb lib/toy/llm/labels.rb \
 		lib/toy/train/toy_gguf_writer.rb lib/toy/train/toy_drift_grad.rb lib/toy/train/toy_gguf_fuse.rb lib/toy/models/transformer.rb \
@@ -588,7 +588,7 @@ toy-train-metal: libexec/toy-train-metal
 # on a fresh tree; needs ../tep + ../spinelgems siblings). Deps mirror the
 # tep_demo recipe (Makefile:486) + the KV stack. CPU-only; NOT in
 # MIRRORABLE (see prep/gen_cuda_mirror.rb).
-libexec/toy-serve: lib/toy/run/serve.rb lib/toy/io/toy_json.rb \
+libexec/toy-serve: lib/toy/run/serve.rb lib/toy/io/toy_json.rb lib/toy/io/toy_git.rb \
 		lib/toy/serve/openai/server.rb lib/toy/serve/openai/api_json.rb \
 		lib/toy/serve/openai/handlers.rb lib/toy/serve/openai/embeddings_handler.rb \
 		vendor/spinel/tep/lib/tep.rb \
@@ -777,9 +777,9 @@ example_inference_metal: examples/example_inference_metal
 # toy#train-device-select-cuda follow-up. The dispatcher errors
 # cleanly on DEVICE=cuda so Tao's `run_start.backend.kind=="cuda"`
 # acceptance fails honestly rather than silently emitting cpu data.
-examples/example_train_from_scratch_cpu: examples/06_train_from_scratch.rb lib/toy/io/toy_json.rb lib/toy/llm/engine/llama_seq_engine.rb lib/toy/models/toy_smollm2.rb lib/toy/models/transformer.rb lib/tinynn.rb lib/toy/dev/toy_describe_flow.rb lib/toy/train/toy_drift_grad.rb lib/toy/train/toy_gguf_writer.rb lib/toy/dev/toy_tap.rb tinynn/libtinynn_ggml.a $(SPINEL_DEPS)
+examples/example_train_from_scratch_cpu: examples/06_train_from_scratch.rb lib/toy/io/toy_json.rb lib/toy/io/toy_git.rb lib/toy/llm/engine/llama_seq_engine.rb lib/toy/models/toy_smollm2.rb lib/toy/models/transformer.rb lib/tinynn.rb lib/toy/dev/toy_describe_flow.rb lib/toy/train/toy_drift_grad.rb lib/toy/train/toy_gguf_writer.rb lib/toy/dev/toy_tap.rb tinynn/libtinynn_ggml.a $(SPINEL_DEPS)
 	$(SPINEL) $< -o $@
-examples/example_train_from_scratch_cuda: examples/06_train_from_scratch_cuda.rb lib/toy/io/toy_json.rb lib/toy/llm/engine/llama_seq_engine_cuda.rb lib/toy/models/toy_smollm2.rb lib/toy/models/transformer.rb lib/tinynn_cuda.rb lib/toy/dev/toy_describe_flow.rb lib/toy/train/toy_drift_grad.rb lib/toy/train/toy_gguf_writer.rb lib/toy/dev/toy_tap.rb tinynn/libtinynn_ggml.a tinynn/libtinynn_ggml_cuda.a $(SPINEL_DEPS)
+examples/example_train_from_scratch_cuda: examples/06_train_from_scratch_cuda.rb lib/toy/io/toy_json.rb lib/toy/io/toy_git.rb lib/toy/llm/engine/llama_seq_engine_cuda.rb lib/toy/models/toy_smollm2.rb lib/toy/models/transformer.rb lib/tinynn_cuda.rb lib/toy/dev/toy_describe_flow.rb lib/toy/train/toy_drift_grad.rb lib/toy/train/toy_gguf_writer.rb lib/toy/dev/toy_tap.rb tinynn/libtinynn_ggml.a tinynn/libtinynn_ggml_cuda.a $(SPINEL_DEPS)
 	$(SPINEL) --cc='cc -Wl,-u,tnn_cuda_force_link' $< -o $@
 examples/example_train_from_scratch: examples/example_train_from_scratch_cpu
 	@printf '#!/bin/sh\n# Auto-generated by Makefile. DEVICE selects the backend binary.\n# Edit examples/06_train_from_scratch.rb (cpu) for behaviour; CUDA mirror is auto-generated by prep/gen_cuda_mirror.rb.\ncase "$${DEVICE:-cpu}" in\n  cpu|"") exec "$$(dirname "$$0")/example_train_from_scratch_cpu" "$$@" ;;\n  cuda)   exec "$$(dirname "$$0")/example_train_from_scratch_cuda" "$$@" ;;\n  metal)  echo "DEVICE=metal not yet supported for training (inference only)" >&2; exit 2 ;;\n  *)      echo "DEVICE=$${DEVICE} not recognised (want cpu|cuda)" >&2; exit 2 ;;\nesac\n' > $@

--- a/Makefile
+++ b/Makefile
@@ -259,7 +259,7 @@ toy-eval: libexec/toy-eval
 # Deps mirror example_lmc (Makefile:479) NOT toy-eval; order-only | libexec (no
 # $(SPINEL_DEPS)) like the CPU toy-eval runner. CPU-only; NOT in MIRRORABLE (see
 # prep/gen_cuda_mirror.rb); a cuda LMC twin is a later slice.
-libexec/toy-eval-lmc: lib/toy/run/eval_lmc.rb lib/toy/io/toy_json.rb lib/toy/io/toy_git.rb lib/toy/llm/engine/llama_seq_engine.rb lib/toy/models/toy_smollm2.rb lib/toy.rb lib/toy/models/transformer.rb lib/toy/train/toy_drift_grad.rb lib/tinynn.rb tinynn/libtinynn_ggml.a | libexec
+libexec/toy-eval-lmc: lib/toy/run/eval_lmc.rb lib/toy/io/toy_json.rb lib/toy/io/toy_events.rb lib/toy/io/toy_git.rb lib/toy/llm/engine/llama_seq_engine.rb lib/toy/models/toy_smollm2.rb lib/toy.rb lib/toy/models/transformer.rb lib/toy/train/toy_drift_grad.rb lib/tinynn.rb tinynn/libtinynn_ggml.a | libexec
 	$(SPINEL) $< -o $@
 toy-eval-lmc: libexec/toy-eval-lmc
 
@@ -433,7 +433,7 @@ gate-serve:
 # tinynn + the L1-L3 primitives/blocks/archs; plus gguf_writer + drift_grad
 # for the checkpoint). CPU-only; NOT in MIRRORABLE (see prep/gen_cuda_mirror.rb).
 libexec/toy-train: lib/toy/run/train.rb lib/toy.rb lib/toy/models/toy_smollm2.rb \
-		lib/toy/io/toy_json.rb lib/toy/io/toy_git.rb \
+		lib/toy/io/toy_json.rb lib/toy/io/toy_events.rb lib/toy/io/toy_git.rb \
 		lib/toy/io/toy_corpus_loader.rb lib/toy/train/toy_lr_schedule.rb \
 		lib/toy/llm/engine/llama_seq_engine.rb lib/toy/llm/recipes/from_scratch.rb \
 		lib/toy/llm/recipes/warm_start.rb \
@@ -450,7 +450,7 @@ toy-train: libexec/toy-train
 # LoRA realize_for_mmap path cannot share a Spinel compilation unit with the
 # random-init path (cfg type-merge miscompile; see lib/toy/run/train_lora.rb
 # header). CPU-only; NOT in MIRRORABLE.
-libexec/toy-train-lora: lib/toy/run/train_lora.rb lib/toy/io/toy_json.rb lib/toy/io/toy_git.rb lib/toy.rb lib/toy/models/toy_smollm2.rb \
+libexec/toy-train-lora: lib/toy/run/train_lora.rb lib/toy/io/toy_json.rb lib/toy/io/toy_events.rb lib/toy/io/toy_git.rb lib/toy.rb lib/toy/models/toy_smollm2.rb \
 		lib/toy/llm/engine/llama_seq_engine.rb lib/toy/llm/recipes/lora.rb \
 		lib/toy/llm/adamw.rb \
 		lib/toy/train/toy_gguf_writer.rb lib/toy/train/toy_drift_grad.rb lib/toy/models/transformer.rb \
@@ -504,7 +504,7 @@ toy-train-gpt2-metal: libexec/toy-train-gpt2-metal
 # trains random-init on the COMMITTED data/vit_smoke corpus. NO toy_gguf_writer
 # dep (cfg.vocab/d_ff poly-collide with ViTTinyConfig — #169 checkpoint
 # follow-up). CPU-only; absent from MIRRORABLE (no CUDA/Metal twin this slice).
-libexec/toy-train-vit: lib/toy/run/train_vit.rb lib/toy/io/toy_json.rb lib/toy/io/toy_git.rb lib/toy/llm/recipes/vit_tiny.rb \
+libexec/toy-train-vit: lib/toy/run/train_vit.rb lib/toy/io/toy_json.rb lib/toy/io/toy_events.rb lib/toy/io/toy_git.rb lib/toy/llm/recipes/vit_tiny.rb \
 		lib/toy/llm/engine/vit_tiny_engine.rb lib/toy/models/toy_vit.rb lib/toy/models/toy_smollm2.rb \
 		lib/toy/io/toy_image_loader.rb lib/toy/train/toy_lr_schedule.rb lib/toy/train/toy_drift_grad.rb \
 		lib/toy/llm/adamw.rb \
@@ -519,7 +519,7 @@ toy-train-vit: libexec/toy-train-vit
 # checkpoint write/fuse/drift seam (dropping them breaks the writer). Links
 # the CUDA ggml backend via -Wl,-u,tnn_cuda_force_link (every cuda target).
 # CPU-only; NOT in MIRRORABLE (hand-written, see prep/gen_cuda_mirror.rb).
-libexec/toy-train-cuda: lib/toy/run/train_cuda.rb lib/toy/io/toy_json.rb lib/toy/io/toy_git.rb lib/toy.rb lib/toy/models/toy_smollm2.rb \
+libexec/toy-train-cuda: lib/toy/run/train_cuda.rb lib/toy/io/toy_json.rb lib/toy/io/toy_events.rb lib/toy/io/toy_git.rb lib/toy.rb lib/toy/models/toy_smollm2.rb \
 		lib/toy/io/toy_corpus_loader.rb lib/toy/train/toy_lr_schedule.rb \
 		lib/toy/llm/engine/llama_seq_engine_cuda.rb lib/toy/llm/recipes/from_scratch_cuda.rb \
 		lib/toy/llm/recipes/warm_start_cuda.rb \
@@ -542,7 +542,7 @@ toy-train-cuda: libexec/toy-train-cuda
 # (ToyDriftGrad.params downloads via CPU TinyNN). toy_gguf_fuse is NOT a dep
 # (lora uses ToyDriftGrad.params, not the lens-fold path). Links the CUDA
 # ggml backend via -Wl,-u,tnn_cuda_force_link. NOT in MIRRORABLE (hand-written).
-libexec/toy-train-lora-cuda: lib/toy/run/train_lora_cuda.rb lib/toy/io/toy_json.rb lib/toy/io/toy_git.rb lib/toy.rb lib/toy/models/toy_smollm2.rb \
+libexec/toy-train-lora-cuda: lib/toy/run/train_lora_cuda.rb lib/toy/io/toy_json.rb lib/toy/io/toy_events.rb lib/toy/io/toy_git.rb lib/toy.rb lib/toy/models/toy_smollm2.rb \
 		lib/toy/llm/engine/llama_seq_engine_cuda.rb lib/toy/llm/recipes/lora_cuda.rb \
 		lib/toy/llm/adamw.rb \
 		lib/toy/train/toy_gguf_writer.rb lib/toy/train/toy_drift_grad.rb lib/toy/models/transformer.rb \
@@ -563,7 +563,7 @@ toy-train-lora-cuda: libexec/toy-train-lora-cuda
 # (leading underscore, macOS symbol convention). libtinynn_ggml.a (CPU archive)
 # stays in deps for the write seam + base ggml. NOT in MIRRORABLE (hand-written).
 # gx10 RUNTIME-UNVERIFIED — pin baseline + gate on the Mac.
-libexec/toy-train-metal: lib/toy/run/train_metal.rb lib/toy/io/toy_json.rb lib/toy/io/toy_git.rb lib/toy.rb lib/toy/models/toy_smollm2.rb \
+libexec/toy-train-metal: lib/toy/run/train_metal.rb lib/toy/io/toy_json.rb lib/toy/io/toy_events.rb lib/toy/io/toy_git.rb lib/toy.rb lib/toy/models/toy_smollm2.rb \
 		lib/toy/llm/engine/llama_seq_engine_metal.rb lib/toy/llm/recipes/from_scratch_metal.rb \
 		lib/toy/llm/adamw.rb lib/toy/llm/labels.rb \
 		lib/toy/train/toy_gguf_writer.rb lib/toy/train/toy_drift_grad.rb lib/toy/train/toy_gguf_fuse.rb lib/toy/models/transformer.rb \
@@ -588,7 +588,7 @@ toy-train-metal: libexec/toy-train-metal
 # on a fresh tree; needs ../tep + ../spinelgems siblings). Deps mirror the
 # tep_demo recipe (Makefile:486) + the KV stack. CPU-only; NOT in
 # MIRRORABLE (see prep/gen_cuda_mirror.rb).
-libexec/toy-serve: lib/toy/run/serve.rb lib/toy/io/toy_json.rb lib/toy/io/toy_git.rb \
+libexec/toy-serve: lib/toy/run/serve.rb lib/toy/io/toy_json.rb lib/toy/io/toy_events.rb lib/toy/io/toy_git.rb \
 		lib/toy/serve/openai/server.rb lib/toy/serve/openai/api_json.rb \
 		lib/toy/serve/openai/handlers.rb lib/toy/serve/openai/embeddings_handler.rb \
 		vendor/spinel/tep/lib/tep.rb \
@@ -777,9 +777,9 @@ example_inference_metal: examples/example_inference_metal
 # toy#train-device-select-cuda follow-up. The dispatcher errors
 # cleanly on DEVICE=cuda so Tao's `run_start.backend.kind=="cuda"`
 # acceptance fails honestly rather than silently emitting cpu data.
-examples/example_train_from_scratch_cpu: examples/06_train_from_scratch.rb lib/toy/io/toy_json.rb lib/toy/io/toy_git.rb lib/toy/llm/engine/llama_seq_engine.rb lib/toy/models/toy_smollm2.rb lib/toy/models/transformer.rb lib/tinynn.rb lib/toy/dev/toy_describe_flow.rb lib/toy/train/toy_drift_grad.rb lib/toy/train/toy_gguf_writer.rb lib/toy/dev/toy_tap.rb tinynn/libtinynn_ggml.a $(SPINEL_DEPS)
+examples/example_train_from_scratch_cpu: examples/06_train_from_scratch.rb lib/toy/io/toy_json.rb lib/toy/io/toy_events.rb lib/toy/io/toy_git.rb lib/toy/llm/engine/llama_seq_engine.rb lib/toy/models/toy_smollm2.rb lib/toy/models/transformer.rb lib/tinynn.rb lib/toy/dev/toy_describe_flow.rb lib/toy/train/toy_drift_grad.rb lib/toy/train/toy_gguf_writer.rb lib/toy/dev/toy_tap.rb tinynn/libtinynn_ggml.a $(SPINEL_DEPS)
 	$(SPINEL) $< -o $@
-examples/example_train_from_scratch_cuda: examples/06_train_from_scratch_cuda.rb lib/toy/io/toy_json.rb lib/toy/io/toy_git.rb lib/toy/llm/engine/llama_seq_engine_cuda.rb lib/toy/models/toy_smollm2.rb lib/toy/models/transformer.rb lib/tinynn_cuda.rb lib/toy/dev/toy_describe_flow.rb lib/toy/train/toy_drift_grad.rb lib/toy/train/toy_gguf_writer.rb lib/toy/dev/toy_tap.rb tinynn/libtinynn_ggml.a tinynn/libtinynn_ggml_cuda.a $(SPINEL_DEPS)
+examples/example_train_from_scratch_cuda: examples/06_train_from_scratch_cuda.rb lib/toy/io/toy_json.rb lib/toy/io/toy_events.rb lib/toy/io/toy_git.rb lib/toy/llm/engine/llama_seq_engine_cuda.rb lib/toy/models/toy_smollm2.rb lib/toy/models/transformer.rb lib/tinynn_cuda.rb lib/toy/dev/toy_describe_flow.rb lib/toy/train/toy_drift_grad.rb lib/toy/train/toy_gguf_writer.rb lib/toy/dev/toy_tap.rb tinynn/libtinynn_ggml.a tinynn/libtinynn_ggml_cuda.a $(SPINEL_DEPS)
 	$(SPINEL) --cc='cc -Wl,-u,tnn_cuda_force_link' $< -o $@
 examples/example_train_from_scratch: examples/example_train_from_scratch_cpu
 	@printf '#!/bin/sh\n# Auto-generated by Makefile. DEVICE selects the backend binary.\n# Edit examples/06_train_from_scratch.rb (cpu) for behaviour; CUDA mirror is auto-generated by prep/gen_cuda_mirror.rb.\ncase "$${DEVICE:-cpu}" in\n  cpu|"") exec "$$(dirname "$$0")/example_train_from_scratch_cpu" "$$@" ;;\n  cuda)   exec "$$(dirname "$$0")/example_train_from_scratch_cuda" "$$@" ;;\n  metal)  echo "DEVICE=metal not yet supported for training (inference only)" >&2; exit 2 ;;\n  *)      echo "DEVICE=$${DEVICE} not recognised (want cpu|cuda)" >&2; exit 2 ;;\nesac\n' > $@

--- a/examples/06_train_from_scratch.rb
+++ b/examples/06_train_from_scratch.rb
@@ -24,6 +24,7 @@
 
 require_relative "../lib/toy"
 require_relative "../lib/toy/io/toy_json"
+require_relative "../lib/toy/io/toy_git"
 require_relative "../lib/toy/models/toy_smollm2"
 require_relative "../lib/toy/llm/engine/llama_seq_engine"
 require_relative "../lib/toy/dev/toy_describe_flow"
@@ -262,35 +263,9 @@ losses = [0.0]; losses.pop
 # the cwd's .git/. If we're run from outside the toy repo, falls back
 # to "unknown" without aborting (the field is for diagnostics, not
 # load-bearing). Tao's acceptance only requires git.sha to be present.
-git_sha    = "unknown"
-git_branch = "unknown"
-if File.exist?(".git/HEAD")
-  head = File.read(".git/HEAD")
-  # Strip trailing newline manually — Spinel-friendly.
-  if head.length > 0 && head[head.length - 1...head.length] == "\n"
-    head = head[0...head.length - 1]
-  end
-  if head.length > 5 && head[0...5] == "ref: "
-    ref_rel = head[5...head.length]              # e.g. "refs/heads/main"
-    parts   = ref_rel.split("/")
-    if parts.length >= 3
-      git_branch = parts[parts.length - 1]
-    end
-    ref_path = ".git/" + ref_rel
-    if File.exist?(ref_path)
-      sha = File.read(ref_path)
-      if sha.length >= 40
-        git_sha = sha[0...40]
-      end
-    end
-  else
-    # Detached HEAD: contents IS the SHA.
-    if head.length >= 40
-      git_sha    = head[0...40]
-      git_branch = "HEAD"
-    end
-  end
-end
+gp = Toy::Git.read
+git_sha    = gp.gi_sha
+git_branch = gp.gi_branch
 
 # Open the events stream (docs/events-schema.md v1). Emit run_start
 # with full provenance per tao#run-start-provenance: started_at,

--- a/examples/06_train_from_scratch.rb
+++ b/examples/06_train_from_scratch.rb
@@ -24,7 +24,7 @@
 
 require_relative "../lib/toy"
 require_relative "../lib/toy/io/toy_json"
-require_relative "../lib/toy/io/toy_git"
+require_relative "../lib/toy/io/toy_events"
 require_relative "../lib/toy/models/toy_smollm2"
 require_relative "../lib/toy/llm/engine/llama_seq_engine"
 require_relative "../lib/toy/dev/toy_describe_flow"
@@ -263,9 +263,6 @@ losses = [0.0]; losses.pop
 # the cwd's .git/. If we're run from outside the toy repo, falls back
 # to "unknown" without aborting (the field is for diagnostics, not
 # load-bearing). Tao's acceptance only requires git.sha to be present.
-gp = Toy::Git.read
-git_sha    = gp.gi_sha
-git_branch = gp.gi_branch
 
 # Open the events stream (docs/events-schema.md v1). Emit run_start
 # with full provenance per tao#run-start-provenance: started_at,
@@ -285,18 +282,10 @@ if EVENTS.length > 0
     rs.j_str("started_at", TinyNN.tnn_events_iso8601_now)
     rs.j_str("run_id", rid)
     rs.j_str("phase", "train")
-    host = Toy::Json.new
-    host.j_str("name", TinyNN.tnn_provenance_host_name)
-    host.j_str("os",   TinyNN.tnn_provenance_host_os)
-    host.j_str("arch", TinyNN.tnn_provenance_host_arch)
-    rs.j_obj("host", host)
-    backend = Toy::Json.new
-    backend.j_str("kind", TinyNN.tnn_backend_name(fcache.sess))
-    rs.j_obj("backend", backend)
-    git = Toy::Json.new
-    git.j_str("sha",    git_sha)
-    git.j_str("branch", git_branch)
-    rs.j_obj("git", git)
+    Toy::Events.add_provenance(rs,
+      TinyNN.tnn_provenance_host_name, TinyNN.tnn_provenance_host_os,
+      TinyNN.tnn_provenance_host_arch,
+      TinyNN.tnn_backend_name(fcache.sess))
     model = Toy::Json.new
     model.j_str("arch", "llama")
     model.j_str("name", "from-scratch-tinystories")

--- a/examples/07_train_vit_tiny.rb
+++ b/examples/07_train_vit_tiny.rb
@@ -15,7 +15,7 @@
 #   STEPS=200 TAO_RUN_DIR=/tmp/vit ./examples/example_train_vit_tiny
 
 require_relative "../lib/toy/io/toy_json"
-require_relative "../lib/toy/io/toy_git"
+require_relative "../lib/toy/io/toy_events"
 require_relative "../lib/toy/models/toy_vit"
 require_relative "../lib/toy/llm/engine/vit_tiny_engine"
 require_relative "../lib/toy/io/toy_image_loader"
@@ -140,9 +140,6 @@ end
 
 # Read git state for run_start.provenance.git — same recipe as
 # 06_train_from_scratch.rb so Tao's parser gets the same fields.
-gp = Toy::Git.read
-git_sha    = gp.gi_sha
-git_branch = gp.gi_branch
 
 # Events stream — full run-start-provenance per tao#run-start-provenance
 # (matches the 06_train_from_scratch.rb contract: schema, host, git,
@@ -162,18 +159,10 @@ if EVENTS.length > 0
     rs.j_str("run_id", rid)
     rs.j_str("phase", "train")
     rs.j_str("name", "vit-tiny")
-    host = Toy::Json.new
-    host.j_str("name", TinyNN.tnn_provenance_host_name)
-    host.j_str("os",   TinyNN.tnn_provenance_host_os)
-    host.j_str("arch", TinyNN.tnn_provenance_host_arch)
-    rs.j_obj("host", host)
-    backend = Toy::Json.new
-    backend.j_str("kind", TinyNN.tnn_backend_name(cache.sess))
-    rs.j_obj("backend", backend)
-    git = Toy::Json.new
-    git.j_str("sha",    git_sha)
-    git.j_str("branch", git_branch)
-    rs.j_obj("git", git)
+    Toy::Events.add_provenance(rs,
+      TinyNN.tnn_provenance_host_name, TinyNN.tnn_provenance_host_os,
+      TinyNN.tnn_provenance_host_arch,
+      TinyNN.tnn_backend_name(cache.sess))
     model = Toy::Json.new
     model.j_str("arch", "vit")
     model.j_str("name", "vit-tiny")

--- a/examples/07_train_vit_tiny.rb
+++ b/examples/07_train_vit_tiny.rb
@@ -15,6 +15,7 @@
 #   STEPS=200 TAO_RUN_DIR=/tmp/vit ./examples/example_train_vit_tiny
 
 require_relative "../lib/toy/io/toy_json"
+require_relative "../lib/toy/io/toy_git"
 require_relative "../lib/toy/models/toy_vit"
 require_relative "../lib/toy/llm/engine/vit_tiny_engine"
 require_relative "../lib/toy/io/toy_image_loader"
@@ -139,33 +140,9 @@ end
 
 # Read git state for run_start.provenance.git — same recipe as
 # 06_train_from_scratch.rb so Tao's parser gets the same fields.
-git_sha    = "unknown"
-git_branch = "unknown"
-if File.exist?(".git/HEAD")
-  head = File.read(".git/HEAD")
-  if head.length > 0 && head[head.length - 1...head.length] == "\n"
-    head = head[0...head.length - 1]
-  end
-  if head.length > 5 && head[0...5] == "ref: "
-    ref_rel = head[5...head.length]
-    parts   = ref_rel.split("/")
-    if parts.length >= 3
-      git_branch = parts[parts.length - 1]
-    end
-    ref_path = ".git/" + ref_rel
-    if File.exist?(ref_path)
-      sha = File.read(ref_path)
-      if sha.length >= 40
-        git_sha = sha[0...40]
-      end
-    end
-  else
-    if head.length >= 40
-      git_sha    = head[0...40]
-      git_branch = "HEAD"
-    end
-  end
-end
+gp = Toy::Git.read
+git_sha    = gp.gi_sha
+git_branch = gp.gi_branch
 
 # Events stream — full run-start-provenance per tao#run-start-provenance
 # (matches the 06_train_from_scratch.rb contract: schema, host, git,

--- a/lib/toy/io/toy_events.rb
+++ b/lib/toy/io/toy_events.rb
@@ -1,0 +1,47 @@
+# lib/toy/io/toy_events.rb — Toy::Events, shared toy/v1 run_start provenance.
+#
+# WHY THIS EXISTS. Every runner/example run_start event carried the SAME three
+# provenance sub-objects in the SAME order — host{name,os,arch}, backend{kind},
+# git{sha,branch} — built inline (~12 lines + a Toy::Git.read) in 11 places. This
+# folds that into one call:
+#
+#   rs = Toy::Json.new
+#   rs.j_str("kind", "run_start"); rs.j_str("schema", "toy/v1")
+#   rs.j_num("t", now); rs.j_str("started_at", iso); rs.j_str("run_id", rid)
+#   rs.j_str("phase", "train")
+#   Toy::Events.add_provenance(rs, host_name, host_os, host_arch, backend_kind)
+#   # ... caller appends model{} / config{} / schedule{} ...
+#   TinyNN.tnn_events_emit(rs.j_dump)
+#
+# The host/backend values are PASSED IN: they come from the backend-specific
+# TinyNN / TinyNNCuda / TinyNNMetal module the caller is bound to, which a shared
+# helper can't name. git is backend-agnostic (pure file read) so it's read here.
+# Key order is preserved exactly → byte-identical events for ASCII-clean values.
+#
+# Pure Ruby (no FFI) → compiles under Spinel, no mirror. Spinel naming discipline:
+# the module method's params carry an `ev_` prefix so they can't widen an
+# unrelated host_name/backend_kind elsewhere (landmines #12/#16).
+require_relative "toy_json"
+require_relative "toy_git"
+
+module Toy
+  module Events
+    # Append host{}, backend{}, git{} (the canonical run_start provenance) to an
+    # in-progress Toy::Json run_start builder, in order. Mutates ev_rs.
+    def self.add_provenance(ev_rs, ev_host_name, ev_host_os, ev_host_arch, ev_backend_kind)
+      ev_host = Toy::Json.new
+      ev_host.j_str("name", ev_host_name)
+      ev_host.j_str("os",   ev_host_os)
+      ev_host.j_str("arch", ev_host_arch)
+      ev_rs.j_obj("host", ev_host)
+      ev_backend = Toy::Json.new
+      ev_backend.j_str("kind", ev_backend_kind)
+      ev_rs.j_obj("backend", ev_backend)
+      ev_gp = Toy::Git.read
+      ev_git = Toy::Json.new
+      ev_git.j_str("sha",    ev_gp.gi_sha)
+      ev_git.j_str("branch", ev_gp.gi_branch)
+      ev_rs.j_obj("git", ev_git)
+    end
+  end
+end

--- a/lib/toy/io/toy_git.rb
+++ b/lib/toy/io/toy_git.rb
@@ -1,0 +1,71 @@
+# lib/toy/io/toy_git.rb — Toy::Git, git provenance read from .git/HEAD.
+#
+# WHY THIS EXISTS. Every tep-free runner and training example that emits a
+# `run_start` event stamped its `git:{sha,branch}` provenance by inlining the
+# SAME ~25-line .git/HEAD parse — copy-pasted across 9 files. This is that block,
+# once. Pure Ruby (no FFI), so it compiles under Spinel and needs no mirror.
+#
+# Behaviour (unchanged from the inlined block): reads .git/HEAD; if it's a
+# `ref: refs/heads/<branch>` pointer, the branch is the last path segment and the
+# 40-char sha is read from the pointed-at ref file; if HEAD is detached (a raw
+# sha), sha = that, branch = "HEAD". Anything missing/short → "unknown". Caller-
+# facing default stays "unknown"/"unknown" so a non-repo checkout is non-fatal
+# (Tao's acceptance only needs git.sha present).
+#
+# SPINEL NAMING DISCIPLINE: whole-program inference is keyed partly on method-
+# and local-variable NAMES (landmines #12/#16). The reader members and every
+# local carry a `gi_` prefix so they can't widen an unrelated `head`/`sha`/`pp`
+# elsewhere in a compiled runner.
+#
+# USAGE (keeps the historical local-variable names so call sites are untouched):
+#   gp = Toy::Git.read
+#   git_sha    = gp.gi_sha
+#   git_branch = gp.gi_branch
+module Toy
+  class Git
+    def initialize(gi_sha, gi_branch)
+      @gi_sha    = gi_sha
+      @gi_branch = gi_branch
+    end
+
+    def gi_sha
+      @gi_sha
+    end
+
+    def gi_branch
+      @gi_branch
+    end
+
+    # Read provenance from ./.git/HEAD. Returns a Toy::Git (gi_sha/gi_branch).
+    def self.read
+      gi_s = "unknown"
+      gi_b = "unknown"
+      if File.exist?(".git/HEAD")
+        gi_head = File.read(".git/HEAD")
+        if gi_head.length > 0 && gi_head[gi_head.length - 1...gi_head.length] == "\n"
+          gi_head = gi_head[0...gi_head.length - 1]
+        end
+        if gi_head.length > 5 && gi_head[0...5] == "ref: "
+          gi_ref_rel = gi_head[5...gi_head.length]
+          gi_pp = gi_ref_rel.split("/")
+          if gi_pp.length >= 3
+            gi_b = gi_pp[gi_pp.length - 1]
+          end
+          gi_ref_path = ".git/" + gi_ref_rel
+          if File.exist?(gi_ref_path)
+            gi_sha_raw = File.read(gi_ref_path)
+            if gi_sha_raw.length >= 40
+              gi_s = gi_sha_raw[0...40]
+            end
+          end
+        else
+          if gi_head.length >= 40
+            gi_s = gi_head[0...40]
+            gi_b = "HEAD"
+          end
+        end
+      end
+      Toy::Git.new(gi_s, gi_b)
+    end
+  end
+end

--- a/lib/toy/run/serve.rb
+++ b/lib/toy/run/serve.rb
@@ -27,6 +27,7 @@
 
 require_relative "../../toy_smollm2_ffi_kv"
 require_relative "../io/toy_json"
+require_relative "../io/toy_git"
 require_relative "../models/toy_smollm2_loader"
 require_relative "../../../vendor/spinel/deps"
 require_relative "../serve/openai/api_json"
@@ -47,33 +48,9 @@ EVENTS      = TAO_RUN_DIR.length > 0 ? (TAO_RUN_DIR + "/events.jsonl") : ""
 
 # git provenance read pure-Ruby from .git/HEAD (COPIED VERBATIM from
 # train.rb:124-151; resolves ref: → 40-char sha; defaults "unknown").
-git_sha    = "unknown"
-git_branch = "unknown"
-if File.exist?(".git/HEAD")
-  head = File.read(".git/HEAD")
-  if head.length > 0 && head[head.length - 1...head.length] == "\n"
-    head = head[0...head.length - 1]
-  end
-  if head.length > 5 && head[0...5] == "ref: "
-    ref_rel = head[5...head.length]
-    pp = ref_rel.split("/")
-    if pp.length >= 3
-      git_branch = pp[pp.length - 1]
-    end
-    ref_path = ".git/" + ref_rel
-    if File.exist?(ref_path)
-      sha = File.read(ref_path)
-      if sha.length >= 40
-        git_sha = sha[0...40]
-      end
-    end
-  else
-    if head.length >= 40
-      git_sha    = head[0...40]
-      git_branch = "HEAD"
-    end
-  end
-end
+gp = Toy::Git.read
+git_sha    = gp.gi_sha
+git_branch = gp.gi_branch
 
 # PORT hoisted ABOVE the run_start emit so config.port is available. No side
 # effects, so the hoist is safe (the Tep.run! call below still binds it).

--- a/lib/toy/run/serve.rb
+++ b/lib/toy/run/serve.rb
@@ -27,7 +27,7 @@
 
 require_relative "../../toy_smollm2_ffi_kv"
 require_relative "../io/toy_json"
-require_relative "../io/toy_git"
+require_relative "../io/toy_events"
 require_relative "../models/toy_smollm2_loader"
 require_relative "../../../vendor/spinel/deps"
 require_relative "../serve/openai/api_json"
@@ -48,9 +48,6 @@ EVENTS      = TAO_RUN_DIR.length > 0 ? (TAO_RUN_DIR + "/events.jsonl") : ""
 
 # git provenance read pure-Ruby from .git/HEAD (COPIED VERBATIM from
 # train.rb:124-151; resolves ref: → 40-char sha; defaults "unknown").
-gp = Toy::Git.read
-git_sha    = gp.gi_sha
-git_branch = gp.gi_branch
 
 # PORT hoisted ABOVE the run_start emit so config.port is available. No side
 # effects, so the hoist is safe (the Tep.run! call below still binds it).
@@ -71,18 +68,10 @@ if EVENTS.length > 0
     rs.j_str("started_at", TinyNN.tnn_events_iso8601_now)
     rs.j_str("run_id", rid)
     rs.j_str("phase", "serve")
-    host = Toy::Json.new
-    host.j_str("name", TinyNN.tnn_provenance_host_name)
-    host.j_str("os",   TinyNN.tnn_provenance_host_os)
-    host.j_str("arch", TinyNN.tnn_provenance_host_arch)
-    rs.j_obj("host", host)
-    backend = Toy::Json.new
-    backend.j_str("kind", TinyNN.tnn_backend_name(STATE.kv.sess))
-    rs.j_obj("backend", backend)
-    git = Toy::Json.new
-    git.j_str("sha",    git_sha)
-    git.j_str("branch", git_branch)
-    rs.j_obj("git", git)
+    Toy::Events.add_provenance(rs,
+      TinyNN.tnn_provenance_host_name, TinyNN.tnn_provenance_host_os,
+      TinyNN.tnn_provenance_host_arch,
+      TinyNN.tnn_backend_name(STATE.kv.sess))
     model = Toy::Json.new
     model.j_str("arch", "llama")
     model.j_str("name", STATE.model_name)

--- a/lib/toy/run/train.rb
+++ b/lib/toy/run/train.rb
@@ -41,6 +41,7 @@
 
 require_relative "../../toy"
 require_relative "../io/toy_json"
+require_relative "../io/toy_git"
 require_relative "../models/toy_smollm2"
 require_relative "../io/toy_corpus_loader"
 require_relative "../train/toy_lr_schedule"
@@ -119,33 +120,9 @@ if RECIPE == "warm-start"
   p = 0; while p < CONTEXT; positions.push(p); p = p + 1; end
 
   # --- Events (EVENTS hoisted to top-level; FILE only). ---
-  git_sha    = "unknown"
-  git_branch = "unknown"
-  if File.exist?(".git/HEAD")
-    head = File.read(".git/HEAD")
-    if head.length > 0 && head[head.length - 1...head.length] == "\n"
-      head = head[0...head.length - 1]
-    end
-    if head.length > 5 && head[0...5] == "ref: "
-      ref_rel = head[5...head.length]
-      pp = ref_rel.split("/")
-      if pp.length >= 3
-        git_branch = pp[pp.length - 1]
-      end
-      ref_path = ".git/" + ref_rel
-      if File.exist?(ref_path)
-        sha = File.read(ref_path)
-        if sha.length >= 40
-          git_sha = sha[0...40]
-        end
-      end
-    else
-      if head.length >= 40
-        git_sha    = head[0...40]
-        git_branch = "HEAD"
-      end
-    end
-  end
+  gp = Toy::Git.read
+  git_sha    = gp.gi_sha
+  git_branch = gp.gi_branch
 
   if EVENTS.length > 0
     rc = TinyNN.tnn_events_open(EVENTS)
@@ -302,33 +279,9 @@ m_hp = Toy::AdamW.new.hp(0)
 # --- Events (EVENTS hoisted to top-level; cheap-when-off; FILE only). ---
 
 # git provenance read pure-Ruby from .git/HEAD (06:264-292).
-git_sha    = "unknown"
-git_branch = "unknown"
-if File.exist?(".git/HEAD")
-  head = File.read(".git/HEAD")
-  if head.length > 0 && head[head.length - 1...head.length] == "\n"
-    head = head[0...head.length - 1]
-  end
-  if head.length > 5 && head[0...5] == "ref: "
-    ref_rel = head[5...head.length]
-    pp = ref_rel.split("/")
-    if pp.length >= 3
-      git_branch = pp[pp.length - 1]
-    end
-    ref_path = ".git/" + ref_rel
-    if File.exist?(ref_path)
-      sha = File.read(ref_path)
-      if sha.length >= 40
-        git_sha = sha[0...40]
-      end
-    end
-  else
-    if head.length >= 40
-      git_sha    = head[0...40]
-      git_branch = "HEAD"
-    end
-  end
-end
+gp = Toy::Git.read
+git_sha    = gp.gi_sha
+git_branch = gp.gi_branch
 
 if EVENTS.length > 0
   rc = TinyNN.tnn_events_open(EVENTS)

--- a/lib/toy/run/train.rb
+++ b/lib/toy/run/train.rb
@@ -41,7 +41,7 @@
 
 require_relative "../../toy"
 require_relative "../io/toy_json"
-require_relative "../io/toy_git"
+require_relative "../io/toy_events"
 require_relative "../models/toy_smollm2"
 require_relative "../io/toy_corpus_loader"
 require_relative "../train/toy_lr_schedule"
@@ -120,9 +120,6 @@ if RECIPE == "warm-start"
   p = 0; while p < CONTEXT; positions.push(p); p = p + 1; end
 
   # --- Events (EVENTS hoisted to top-level; FILE only). ---
-  gp = Toy::Git.read
-  git_sha    = gp.gi_sha
-  git_branch = gp.gi_branch
 
   if EVENTS.length > 0
     rc = TinyNN.tnn_events_open(EVENTS)
@@ -135,18 +132,10 @@ if RECIPE == "warm-start"
       rs.j_str("started_at", TinyNN.tnn_events_iso8601_now)
       rs.j_str("run_id", rid)
       rs.j_str("phase", "train")
-      host = Toy::Json.new
-      host.j_str("name", TinyNN.tnn_provenance_host_name)
-      host.j_str("os",   TinyNN.tnn_provenance_host_os)
-      host.j_str("arch", TinyNN.tnn_provenance_host_arch)
-      rs.j_obj("host", host)
-      backend = Toy::Json.new
-      backend.j_str("kind", TinyNN.tnn_backend_name(recipe_ws.ws_cache.sess))
-      rs.j_obj("backend", backend)
-      git = Toy::Json.new
-      git.j_str("sha",    git_sha)
-      git.j_str("branch", git_branch)
-      rs.j_obj("git", git)
+      Toy::Events.add_provenance(rs,
+        TinyNN.tnn_provenance_host_name, TinyNN.tnn_provenance_host_os,
+        TinyNN.tnn_provenance_host_arch,
+        TinyNN.tnn_backend_name(recipe_ws.ws_cache.sess))
       model = Toy::Json.new
       model.j_str("arch", "llama")
       model.j_str("name", "warm-start-scratch-tinystories")
@@ -279,9 +268,6 @@ m_hp = Toy::AdamW.new.hp(0)
 # --- Events (EVENTS hoisted to top-level; cheap-when-off; FILE only). ---
 
 # git provenance read pure-Ruby from .git/HEAD (06:264-292).
-gp = Toy::Git.read
-git_sha    = gp.gi_sha
-git_branch = gp.gi_branch
 
 if EVENTS.length > 0
   rc = TinyNN.tnn_events_open(EVENTS)
@@ -294,18 +280,10 @@ if EVENTS.length > 0
     rs.j_str("started_at", TinyNN.tnn_events_iso8601_now)
     rs.j_str("run_id", rid)
     rs.j_str("phase", "train")
-    host = Toy::Json.new
-    host.j_str("name", TinyNN.tnn_provenance_host_name)
-    host.j_str("os",   TinyNN.tnn_provenance_host_os)
-    host.j_str("arch", TinyNN.tnn_provenance_host_arch)
-    rs.j_obj("host", host)
-    backend = Toy::Json.new
-    backend.j_str("kind", TinyNN.tnn_backend_name(recipe.fs_cache.sess))
-    rs.j_obj("backend", backend)
-    git = Toy::Json.new
-    git.j_str("sha",    git_sha)
-    git.j_str("branch", git_branch)
-    rs.j_obj("git", git)
+    Toy::Events.add_provenance(rs,
+      TinyNN.tnn_provenance_host_name, TinyNN.tnn_provenance_host_os,
+      TinyNN.tnn_provenance_host_arch,
+      TinyNN.tnn_backend_name(recipe.fs_cache.sess))
     model = Toy::Json.new
     model.j_str("arch", "llama")
     model.j_str("name", "from-scratch-tinystories")

--- a/lib/toy/run/train_cuda.rb
+++ b/lib/toy/run/train_cuda.rb
@@ -47,7 +47,7 @@
 
 require_relative "../../toy"
 require_relative "../io/toy_json"
-require_relative "../io/toy_git"
+require_relative "../io/toy_events"
 require_relative "../models/toy_smollm2"
 require_relative "../llm/engine/llama_seq_engine_cuda"
 require_relative "../llm/recipes/from_scratch_cuda"
@@ -123,9 +123,6 @@ if RECIPE == "warm-start"
   p = 0; while p < CONTEXT; positions.push(p); p = p + 1; end
 
   # --- Events (EVENTS hoisted to top-level; FILE only). ---
-  gp = Toy::Git.read
-  git_sha    = gp.gi_sha
-  git_branch = gp.gi_branch
 
   if EVENTS.length > 0
     rc = TinyNNCuda.tnn_events_open(EVENTS)
@@ -138,18 +135,10 @@ if RECIPE == "warm-start"
       rs.j_str("started_at", TinyNNCuda.tnn_events_iso8601_now)
       rs.j_str("run_id", rid)
       rs.j_str("phase", "train")
-      host = Toy::Json.new
-      host.j_str("name", TinyNNCuda.tnn_provenance_host_name)
-      host.j_str("os",   TinyNNCuda.tnn_provenance_host_os)
-      host.j_str("arch", TinyNNCuda.tnn_provenance_host_arch)
-      rs.j_obj("host", host)
-      backend = Toy::Json.new
-      backend.j_str("kind", TinyNNCuda.tnn_backend_name(recipe_ws.ws_cache.sess))
-      rs.j_obj("backend", backend)
-      git = Toy::Json.new
-      git.j_str("sha",    git_sha)
-      git.j_str("branch", git_branch)
-      rs.j_obj("git", git)
+      Toy::Events.add_provenance(rs,
+        TinyNNCuda.tnn_provenance_host_name, TinyNNCuda.tnn_provenance_host_os,
+        TinyNNCuda.tnn_provenance_host_arch,
+        TinyNNCuda.tnn_backend_name(recipe_ws.ws_cache.sess))
       model = Toy::Json.new
       model.j_str("arch", "llama")
       model.j_str("name", "warm-start-scratch-tinystories")
@@ -279,9 +268,6 @@ m_hp = Toy::AdamW.new.hp(0)
 # --- Events (EVENTS hoisted to top-level; cheap-when-off; FILE only). ---
 
 # git provenance read pure-Ruby from .git/HEAD.
-gp = Toy::Git.read
-git_sha    = gp.gi_sha
-git_branch = gp.gi_branch
 
 if EVENTS.length > 0
   rc = TinyNNCuda.tnn_events_open(EVENTS)
@@ -294,18 +280,10 @@ if EVENTS.length > 0
     rs.j_str("started_at", TinyNNCuda.tnn_events_iso8601_now)
     rs.j_str("run_id", rid)
     rs.j_str("phase", "train")
-    host = Toy::Json.new
-    host.j_str("name", TinyNNCuda.tnn_provenance_host_name)
-    host.j_str("os",   TinyNNCuda.tnn_provenance_host_os)
-    host.j_str("arch", TinyNNCuda.tnn_provenance_host_arch)
-    rs.j_obj("host", host)
-    backend = Toy::Json.new
-    backend.j_str("kind", TinyNNCuda.tnn_backend_name(recipe.fs_cache.sess))
-    rs.j_obj("backend", backend)
-    git = Toy::Json.new
-    git.j_str("sha",    git_sha)
-    git.j_str("branch", git_branch)
-    rs.j_obj("git", git)
+    Toy::Events.add_provenance(rs,
+      TinyNNCuda.tnn_provenance_host_name, TinyNNCuda.tnn_provenance_host_os,
+      TinyNNCuda.tnn_provenance_host_arch,
+      TinyNNCuda.tnn_backend_name(recipe.fs_cache.sess))
     model = Toy::Json.new
     model.j_str("arch", "llama")
     model.j_str("name", "from-scratch-tinystories")

--- a/lib/toy/run/train_cuda.rb
+++ b/lib/toy/run/train_cuda.rb
@@ -47,6 +47,7 @@
 
 require_relative "../../toy"
 require_relative "../io/toy_json"
+require_relative "../io/toy_git"
 require_relative "../models/toy_smollm2"
 require_relative "../llm/engine/llama_seq_engine_cuda"
 require_relative "../llm/recipes/from_scratch_cuda"
@@ -122,33 +123,9 @@ if RECIPE == "warm-start"
   p = 0; while p < CONTEXT; positions.push(p); p = p + 1; end
 
   # --- Events (EVENTS hoisted to top-level; FILE only). ---
-  git_sha    = "unknown"
-  git_branch = "unknown"
-  if File.exist?(".git/HEAD")
-    head = File.read(".git/HEAD")
-    if head.length > 0 && head[head.length - 1...head.length] == "\n"
-      head = head[0...head.length - 1]
-    end
-    if head.length > 5 && head[0...5] == "ref: "
-      ref_rel = head[5...head.length]
-      pp = ref_rel.split("/")
-      if pp.length >= 3
-        git_branch = pp[pp.length - 1]
-      end
-      ref_path = ".git/" + ref_rel
-      if File.exist?(ref_path)
-        sha = File.read(ref_path)
-        if sha.length >= 40
-          git_sha = sha[0...40]
-        end
-      end
-    else
-      if head.length >= 40
-        git_sha    = head[0...40]
-        git_branch = "HEAD"
-      end
-    end
-  end
+  gp = Toy::Git.read
+  git_sha    = gp.gi_sha
+  git_branch = gp.gi_branch
 
   if EVENTS.length > 0
     rc = TinyNNCuda.tnn_events_open(EVENTS)
@@ -302,33 +279,9 @@ m_hp = Toy::AdamW.new.hp(0)
 # --- Events (EVENTS hoisted to top-level; cheap-when-off; FILE only). ---
 
 # git provenance read pure-Ruby from .git/HEAD.
-git_sha    = "unknown"
-git_branch = "unknown"
-if File.exist?(".git/HEAD")
-  head = File.read(".git/HEAD")
-  if head.length > 0 && head[head.length - 1...head.length] == "\n"
-    head = head[0...head.length - 1]
-  end
-  if head.length > 5 && head[0...5] == "ref: "
-    ref_rel = head[5...head.length]
-    pp = ref_rel.split("/")
-    if pp.length >= 3
-      git_branch = pp[pp.length - 1]
-    end
-    ref_path = ".git/" + ref_rel
-    if File.exist?(ref_path)
-      sha = File.read(ref_path)
-      if sha.length >= 40
-        git_sha = sha[0...40]
-      end
-    end
-  else
-    if head.length >= 40
-      git_sha    = head[0...40]
-      git_branch = "HEAD"
-    end
-  end
-end
+gp = Toy::Git.read
+git_sha    = gp.gi_sha
+git_branch = gp.gi_branch
 
 if EVENTS.length > 0
   rc = TinyNNCuda.tnn_events_open(EVENTS)

--- a/lib/toy/run/train_lora.rb
+++ b/lib/toy/run/train_lora.rb
@@ -45,6 +45,7 @@
 
 require_relative "../../toy"
 require_relative "../io/toy_json"
+require_relative "../io/toy_git"
 require_relative "../models/toy_smollm2"
 require_relative "../llm/engine/llama_seq_engine"
 require_relative "../llm/recipes/lora"
@@ -103,33 +104,9 @@ positions = [0, 1, 2, 3]
 # --- Events (FILE only when TAO_RUN_DIR set). ---
 EVENTS = TAO_RUN_DIR.length > 0 ? (TAO_RUN_DIR + "/events.jsonl") : ""
 
-git_sha    = "unknown"
-git_branch = "unknown"
-if File.exist?(".git/HEAD")
-  head = File.read(".git/HEAD")
-  if head.length > 0 && head[head.length - 1...head.length] == "\n"
-    head = head[0...head.length - 1]
-  end
-  if head.length > 5 && head[0...5] == "ref: "
-    ref_rel = head[5...head.length]
-    pp = ref_rel.split("/")
-    if pp.length >= 3
-      git_branch = pp[pp.length - 1]
-    end
-    ref_path = ".git/" + ref_rel
-    if File.exist?(ref_path)
-      sha = File.read(ref_path)
-      if sha.length >= 40
-        git_sha = sha[0...40]
-      end
-    end
-  else
-    if head.length >= 40
-      git_sha    = head[0...40]
-      git_branch = "HEAD"
-    end
-  end
-end
+gp = Toy::Git.read
+git_sha    = gp.gi_sha
+git_branch = gp.gi_branch
 
 if EVENTS.length > 0
   rc = TinyNN.tnn_events_open(EVENTS)

--- a/lib/toy/run/train_lora.rb
+++ b/lib/toy/run/train_lora.rb
@@ -45,7 +45,7 @@
 
 require_relative "../../toy"
 require_relative "../io/toy_json"
-require_relative "../io/toy_git"
+require_relative "../io/toy_events"
 require_relative "../models/toy_smollm2"
 require_relative "../llm/engine/llama_seq_engine"
 require_relative "../llm/recipes/lora"
@@ -104,9 +104,6 @@ positions = [0, 1, 2, 3]
 # --- Events (FILE only when TAO_RUN_DIR set). ---
 EVENTS = TAO_RUN_DIR.length > 0 ? (TAO_RUN_DIR + "/events.jsonl") : ""
 
-gp = Toy::Git.read
-git_sha    = gp.gi_sha
-git_branch = gp.gi_branch
 
 if EVENTS.length > 0
   rc = TinyNN.tnn_events_open(EVENTS)
@@ -119,18 +116,10 @@ if EVENTS.length > 0
     rs.j_str("started_at", TinyNN.tnn_events_iso8601_now)
     rs.j_str("run_id", rid)
     rs.j_str("phase", "train")
-    host = Toy::Json.new
-    host.j_str("name", TinyNN.tnn_provenance_host_name)
-    host.j_str("os",   TinyNN.tnn_provenance_host_os)
-    host.j_str("arch", TinyNN.tnn_provenance_host_arch)
-    rs.j_obj("host", host)
-    backend = Toy::Json.new
-    backend.j_str("kind", TinyNN.tnn_backend_name(recipe_lora.lora_cache.sess))
-    rs.j_obj("backend", backend)
-    git = Toy::Json.new
-    git.j_str("sha",    git_sha)
-    git.j_str("branch", git_branch)
-    rs.j_obj("git", git)
+    Toy::Events.add_provenance(rs,
+      TinyNN.tnn_provenance_host_name, TinyNN.tnn_provenance_host_os,
+      TinyNN.tnn_provenance_host_arch,
+      TinyNN.tnn_backend_name(recipe_lora.lora_cache.sess))
     model = Toy::Json.new
     model.j_str("arch", "llama")
     model.j_str("name", "smollm2-135m")

--- a/lib/toy/run/train_lora_cuda.rb
+++ b/lib/toy/run/train_lora_cuda.rb
@@ -54,7 +54,7 @@
 
 require_relative "../../toy"
 require_relative "../io/toy_json"
-require_relative "../io/toy_git"
+require_relative "../io/toy_events"
 require_relative "../models/toy_smollm2"
 require_relative "../llm/engine/llama_seq_engine_cuda"
 require_relative "../llm/recipes/lora_cuda"
@@ -114,9 +114,6 @@ positions = [0, 1, 2, 3]
 # --- Events (FILE only when TAO_RUN_DIR set). ---
 EVENTS = TAO_RUN_DIR.length > 0 ? (TAO_RUN_DIR + "/events.jsonl") : ""
 
-gp = Toy::Git.read
-git_sha    = gp.gi_sha
-git_branch = gp.gi_branch
 
 if EVENTS.length > 0
   rc = TinyNNCuda.tnn_events_open(EVENTS)
@@ -129,18 +126,10 @@ if EVENTS.length > 0
     rs.j_str("started_at", TinyNNCuda.tnn_events_iso8601_now)
     rs.j_str("run_id", rid)
     rs.j_str("phase", "train")
-    host = Toy::Json.new
-    host.j_str("name", TinyNNCuda.tnn_provenance_host_name)
-    host.j_str("os",   TinyNNCuda.tnn_provenance_host_os)
-    host.j_str("arch", TinyNNCuda.tnn_provenance_host_arch)
-    rs.j_obj("host", host)
-    backend = Toy::Json.new
-    backend.j_str("kind", TinyNNCuda.tnn_backend_name(recipe_lora.lora_cache.sess))
-    rs.j_obj("backend", backend)
-    git = Toy::Json.new
-    git.j_str("sha",    git_sha)
-    git.j_str("branch", git_branch)
-    rs.j_obj("git", git)
+    Toy::Events.add_provenance(rs,
+      TinyNNCuda.tnn_provenance_host_name, TinyNNCuda.tnn_provenance_host_os,
+      TinyNNCuda.tnn_provenance_host_arch,
+      TinyNNCuda.tnn_backend_name(recipe_lora.lora_cache.sess))
     model = Toy::Json.new
     model.j_str("arch", "llama")
     model.j_str("name", "smollm2-135m")

--- a/lib/toy/run/train_lora_cuda.rb
+++ b/lib/toy/run/train_lora_cuda.rb
@@ -54,6 +54,7 @@
 
 require_relative "../../toy"
 require_relative "../io/toy_json"
+require_relative "../io/toy_git"
 require_relative "../models/toy_smollm2"
 require_relative "../llm/engine/llama_seq_engine_cuda"
 require_relative "../llm/recipes/lora_cuda"
@@ -113,33 +114,9 @@ positions = [0, 1, 2, 3]
 # --- Events (FILE only when TAO_RUN_DIR set). ---
 EVENTS = TAO_RUN_DIR.length > 0 ? (TAO_RUN_DIR + "/events.jsonl") : ""
 
-git_sha    = "unknown"
-git_branch = "unknown"
-if File.exist?(".git/HEAD")
-  head = File.read(".git/HEAD")
-  if head.length > 0 && head[head.length - 1...head.length] == "\n"
-    head = head[0...head.length - 1]
-  end
-  if head.length > 5 && head[0...5] == "ref: "
-    ref_rel = head[5...head.length]
-    pp = ref_rel.split("/")
-    if pp.length >= 3
-      git_branch = pp[pp.length - 1]
-    end
-    ref_path = ".git/" + ref_rel
-    if File.exist?(ref_path)
-      sha = File.read(ref_path)
-      if sha.length >= 40
-        git_sha = sha[0...40]
-      end
-    end
-  else
-    if head.length >= 40
-      git_sha    = head[0...40]
-      git_branch = "HEAD"
-    end
-  end
-end
+gp = Toy::Git.read
+git_sha    = gp.gi_sha
+git_branch = gp.gi_branch
 
 if EVENTS.length > 0
   rc = TinyNNCuda.tnn_events_open(EVENTS)

--- a/lib/toy/run/train_metal.rb
+++ b/lib/toy/run/train_metal.rb
@@ -47,6 +47,7 @@
 
 require_relative "../../toy"
 require_relative "../io/toy_json"
+require_relative "../io/toy_git"
 require_relative "../models/toy_smollm2"
 require_relative "../llm/engine/llama_seq_engine_metal"
 require_relative "../llm/recipes/from_scratch_metal"
@@ -114,33 +115,9 @@ m_hp = Toy::AdamW.new.hp(0)
 # --- Events (EVENTS hoisted to top-level; cheap-when-off; FILE only). ---
 
 # git provenance read pure-Ruby from .git/HEAD.
-git_sha    = "unknown"
-git_branch = "unknown"
-if File.exist?(".git/HEAD")
-  head = File.read(".git/HEAD")
-  if head.length > 0 && head[head.length - 1...head.length] == "\n"
-    head = head[0...head.length - 1]
-  end
-  if head.length > 5 && head[0...5] == "ref: "
-    ref_rel = head[5...head.length]
-    pp = ref_rel.split("/")
-    if pp.length >= 3
-      git_branch = pp[pp.length - 1]
-    end
-    ref_path = ".git/" + ref_rel
-    if File.exist?(ref_path)
-      sha = File.read(ref_path)
-      if sha.length >= 40
-        git_sha = sha[0...40]
-      end
-    end
-  else
-    if head.length >= 40
-      git_sha    = head[0...40]
-      git_branch = "HEAD"
-    end
-  end
-end
+gp = Toy::Git.read
+git_sha    = gp.gi_sha
+git_branch = gp.gi_branch
 
 if EVENTS.length > 0
   rc = TinyNNMetal.tnn_events_open(EVENTS)

--- a/lib/toy/run/train_metal.rb
+++ b/lib/toy/run/train_metal.rb
@@ -47,7 +47,7 @@
 
 require_relative "../../toy"
 require_relative "../io/toy_json"
-require_relative "../io/toy_git"
+require_relative "../io/toy_events"
 require_relative "../models/toy_smollm2"
 require_relative "../llm/engine/llama_seq_engine_metal"
 require_relative "../llm/recipes/from_scratch_metal"
@@ -115,9 +115,6 @@ m_hp = Toy::AdamW.new.hp(0)
 # --- Events (EVENTS hoisted to top-level; cheap-when-off; FILE only). ---
 
 # git provenance read pure-Ruby from .git/HEAD.
-gp = Toy::Git.read
-git_sha    = gp.gi_sha
-git_branch = gp.gi_branch
 
 if EVENTS.length > 0
   rc = TinyNNMetal.tnn_events_open(EVENTS)
@@ -130,18 +127,10 @@ if EVENTS.length > 0
     rs.j_str("started_at", TinyNNMetal.tnn_events_iso8601_now)
     rs.j_str("run_id", rid)
     rs.j_str("phase", "train")
-    host = Toy::Json.new
-    host.j_str("name", TinyNNMetal.tnn_provenance_host_name)
-    host.j_str("os",   TinyNNMetal.tnn_provenance_host_os)
-    host.j_str("arch", TinyNNMetal.tnn_provenance_host_arch)
-    rs.j_obj("host", host)
-    backend = Toy::Json.new
-    backend.j_str("kind", TinyNNMetal.tnn_backend_name(recipe.fs_cache.sess))
-    rs.j_obj("backend", backend)
-    git = Toy::Json.new
-    git.j_str("sha",    git_sha)
-    git.j_str("branch", git_branch)
-    rs.j_obj("git", git)
+    Toy::Events.add_provenance(rs,
+      TinyNNMetal.tnn_provenance_host_name, TinyNNMetal.tnn_provenance_host_os,
+      TinyNNMetal.tnn_provenance_host_arch,
+      TinyNNMetal.tnn_backend_name(recipe.fs_cache.sess))
     model = Toy::Json.new
     model.j_str("arch", "llama")
     model.j_str("name", "from-scratch-tinystories")

--- a/lib/toy/run/train_vit.rb
+++ b/lib/toy/run/train_vit.rb
@@ -36,6 +36,7 @@
 # inside a conditional arm reads back empty at runtime); no Struct.new.
 
 require_relative "../io/toy_json"
+require_relative "../io/toy_git"
 require_relative "../models/toy_vit"
 require_relative "../llm/engine/vit_tiny_engine"
 require_relative "../io/toy_image_loader"
@@ -123,33 +124,9 @@ if probe_got != record_f
 end
 
 # git provenance read pure-Ruby from .git/HEAD (07:140-167).
-git_sha    = "unknown"
-git_branch = "unknown"
-if File.exist?(".git/HEAD")
-  head = File.read(".git/HEAD")
-  if head.length > 0 && head[head.length - 1...head.length] == "\n"
-    head = head[0...head.length - 1]
-  end
-  if head.length > 5 && head[0...5] == "ref: "
-    ref_rel = head[5...head.length]
-    pp = ref_rel.split("/")
-    if pp.length >= 3
-      git_branch = pp[pp.length - 1]
-    end
-    ref_path = ".git/" + ref_rel
-    if File.exist?(ref_path)
-      sha = File.read(ref_path)
-      if sha.length >= 40
-        git_sha = sha[0...40]
-      end
-    end
-  else
-    if head.length >= 40
-      git_sha    = head[0...40]
-      git_branch = "HEAD"
-    end
-  end
-end
+gp = Toy::Git.read
+git_sha    = gp.gi_sha
+git_branch = gp.gi_branch
 
 # --- run_start event (FILE only; arch=vit). ---
 if EVENTS.length > 0

--- a/lib/toy/run/train_vit.rb
+++ b/lib/toy/run/train_vit.rb
@@ -36,7 +36,7 @@
 # inside a conditional arm reads back empty at runtime); no Struct.new.
 
 require_relative "../io/toy_json"
-require_relative "../io/toy_git"
+require_relative "../io/toy_events"
 require_relative "../models/toy_vit"
 require_relative "../llm/engine/vit_tiny_engine"
 require_relative "../io/toy_image_loader"
@@ -124,9 +124,6 @@ if probe_got != record_f
 end
 
 # git provenance read pure-Ruby from .git/HEAD (07:140-167).
-gp = Toy::Git.read
-git_sha    = gp.gi_sha
-git_branch = gp.gi_branch
 
 # --- run_start event (FILE only; arch=vit). ---
 if EVENTS.length > 0
@@ -141,18 +138,10 @@ if EVENTS.length > 0
     rs.j_str("run_id", rid)
     rs.j_str("phase", "train")
     rs.j_str("name", "vit-tiny")
-    host = Toy::Json.new
-    host.j_str("name", TinyNN.tnn_provenance_host_name)
-    host.j_str("os",   TinyNN.tnn_provenance_host_os)
-    host.j_str("arch", TinyNN.tnn_provenance_host_arch)
-    rs.j_obj("host", host)
-    backend = Toy::Json.new
-    backend.j_str("kind", TinyNN.tnn_backend_name(recipe.vt_cache.sess))
-    rs.j_obj("backend", backend)
-    git = Toy::Json.new
-    git.j_str("sha",    git_sha)
-    git.j_str("branch", git_branch)
-    rs.j_obj("git", git)
+    Toy::Events.add_provenance(rs,
+      TinyNN.tnn_provenance_host_name, TinyNN.tnn_provenance_host_os,
+      TinyNN.tnn_provenance_host_arch,
+      TinyNN.tnn_backend_name(recipe.vt_cache.sess))
     model = Toy::Json.new
     model.j_str("arch", "vit")
     model.j_str("name", "vit-tiny")


### PR DESCRIPTION
Follow-up cleanup after the Toy::Json migration — same class of smell (copy-pasted boilerplate → helper), in the event emitters.

## Toy::Git (`lib/toy/io/toy_git.rb`)
The identical ~25-line `.git/HEAD` parse was inlined in **11 places across 9 files** to stamp `git:{sha,branch}`. Extracted once; call sites that still need the raw values use `Toy::Git.read` → `gi_sha`/`gi_branch`. **~190 LOC removed.** Behaviour byte-identical (same last-path-segment branch slicing + "unknown"/"HEAD" fallbacks).

## Toy::Events.add_provenance (`lib/toy/io/toy_events.rb`)
Every `run_start` built the same `host{} + backend{} + git{}` trio inline (~12 lines + a git read). Folded into one call:
```ruby
Toy::Events.add_provenance(rs, host_name, host_os, host_arch, backend_kind)
```
host/backend values are passed in (backend-specific `TinyNN`/`TinyNNCuda`/`TinyNNMetal`); git is read internally. Key order preserved → **byte-identical events**.

The residual `if EVENTS; rc = <MOD>.tnn_events_open; … else puts fail` control flow is backend-coupled and wraps the unique model/config build, so it's left inline rather than forced behind a leaky module-passing wrapper. `eval_lmc` keeps its inline host+backend (it emits no git/model — a different event shape).

## Spinel discipline
Both helpers are pure Ruby (no FFI, no mirror). All members/params carry `gi_`/`ev_`/`tj_` prefixes to avoid the name-keyed cross-module inference widening that bit the Toy::Json work (landmines #12/#16).

## Verification
- `make gate-train` (4 arms) + `make gate-train-cuda` (3 arms) — byte-identical, valid `events.jsonl`
- GPU runners codegen-clean; `make verify-mirrors` green (06 mirrors regenerated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)