### PR TITLE
fix(#34) tokenizer space marker + feat(#25) flow.json from training runners

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -441,7 +441,7 @@ gate-serve:
 # pulls (the recipe → llama_seq_engine → transformer + toy + smollm2 +
 # tinynn + the L1-L3 primitives/blocks/archs; plus gguf_writer + drift_grad
 # for the checkpoint). CPU-only; NOT in MIRRORABLE (see prep/gen_cuda_mirror.rb).
-libexec/toy-train: lib/toy/run/train.rb lib/toy.rb lib/toy/models/toy_smollm2.rb \
+libexec/toy-train: lib/toy/run/train.rb lib/toy/dev/toy_describe_flow.rb lib/toy.rb lib/toy/models/toy_smollm2.rb \
 		lib/toy/io/toy_json.rb lib/toy/io/toy_events.rb lib/toy/io/toy_git.rb \
 		lib/toy/io/toy_corpus_loader.rb lib/toy/train/toy_lr_schedule.rb \
 		lib/toy/llm/engine/llama_seq_engine.rb lib/toy/llm/recipes/from_scratch.rb \
@@ -459,7 +459,7 @@ toy-train: libexec/toy-train
 # LoRA realize_for_mmap path cannot share a Spinel compilation unit with the
 # random-init path (cfg type-merge miscompile; see lib/toy/run/train_lora.rb
 # header). CPU-only; NOT in MIRRORABLE.
-libexec/toy-train-lora: lib/toy/run/train_lora.rb lib/toy/io/toy_json.rb lib/toy/io/toy_events.rb lib/toy/io/toy_git.rb lib/toy.rb lib/toy/models/toy_smollm2.rb \
+libexec/toy-train-lora: lib/toy/run/train_lora.rb lib/toy/dev/toy_describe_flow.rb lib/toy/io/toy_json.rb lib/toy/io/toy_events.rb lib/toy/io/toy_git.rb lib/toy.rb lib/toy/models/toy_smollm2.rb \
 		lib/toy/llm/engine/llama_seq_engine.rb lib/toy/llm/recipes/lora.rb \
 		lib/toy/llm/adamw.rb \
 		lib/toy/train/toy_gguf_writer.rb lib/toy/train/toy_drift_grad.rb lib/toy/models/transformer.rb \
@@ -513,7 +513,7 @@ toy-train-gpt2-metal: libexec/toy-train-gpt2-metal
 # trains random-init on the COMMITTED data/vit_smoke corpus. NO toy_gguf_writer
 # dep (cfg.vocab/d_ff poly-collide with ViTTinyConfig — #169 checkpoint
 # follow-up). CPU-only; absent from MIRRORABLE (no CUDA/Metal twin this slice).
-libexec/toy-train-vit: lib/toy/run/train_vit.rb lib/toy/io/toy_json.rb lib/toy/io/toy_events.rb lib/toy/io/toy_git.rb lib/toy/llm/recipes/vit_tiny.rb \
+libexec/toy-train-vit: lib/toy/run/train_vit.rb lib/toy/dev/toy_describe_flow.rb lib/toy/io/toy_json.rb lib/toy/io/toy_events.rb lib/toy/io/toy_git.rb lib/toy/llm/recipes/vit_tiny.rb \
 		lib/toy/llm/engine/vit_tiny_engine.rb lib/toy/models/toy_vit.rb lib/toy/models/toy_smollm2.rb \
 		lib/toy/io/toy_image_loader.rb lib/toy/train/toy_lr_schedule.rb lib/toy/train/toy_drift_grad.rb \
 		lib/toy/llm/adamw.rb \
@@ -528,7 +528,7 @@ toy-train-vit: libexec/toy-train-vit
 # checkpoint write/fuse/drift seam (dropping them breaks the writer). Links
 # the CUDA ggml backend via -Wl,-u,tnn_cuda_force_link (every cuda target).
 # CPU-only; NOT in MIRRORABLE (hand-written, see prep/gen_cuda_mirror.rb).
-libexec/toy-train-cuda: lib/toy/run/train_cuda.rb lib/toy/io/toy_json.rb lib/toy/io/toy_events.rb lib/toy/io/toy_git.rb lib/toy.rb lib/toy/models/toy_smollm2.rb \
+libexec/toy-train-cuda: lib/toy/run/train_cuda.rb lib/toy/dev/toy_describe_flow.rb lib/toy/io/toy_json.rb lib/toy/io/toy_events.rb lib/toy/io/toy_git.rb lib/toy.rb lib/toy/models/toy_smollm2.rb \
 		lib/toy/io/toy_corpus_loader.rb lib/toy/train/toy_lr_schedule.rb \
 		lib/toy/llm/engine/llama_seq_engine_cuda.rb lib/toy/llm/recipes/from_scratch_cuda.rb \
 		lib/toy/llm/recipes/warm_start_cuda.rb \
@@ -551,7 +551,7 @@ toy-train-cuda: libexec/toy-train-cuda
 # (ToyDriftGrad.params downloads via CPU TinyNN). toy_gguf_fuse is NOT a dep
 # (lora uses ToyDriftGrad.params, not the lens-fold path). Links the CUDA
 # ggml backend via -Wl,-u,tnn_cuda_force_link. NOT in MIRRORABLE (hand-written).
-libexec/toy-train-lora-cuda: lib/toy/run/train_lora_cuda.rb lib/toy/io/toy_json.rb lib/toy/io/toy_events.rb lib/toy/io/toy_git.rb lib/toy.rb lib/toy/models/toy_smollm2.rb \
+libexec/toy-train-lora-cuda: lib/toy/run/train_lora_cuda.rb lib/toy/dev/toy_describe_flow.rb lib/toy/io/toy_json.rb lib/toy/io/toy_events.rb lib/toy/io/toy_git.rb lib/toy.rb lib/toy/models/toy_smollm2.rb \
 		lib/toy/llm/engine/llama_seq_engine_cuda.rb lib/toy/llm/recipes/lora_cuda.rb \
 		lib/toy/llm/adamw.rb \
 		lib/toy/train/toy_gguf_writer.rb lib/toy/train/toy_drift_grad.rb lib/toy/models/transformer.rb \
@@ -572,7 +572,7 @@ toy-train-lora-cuda: libexec/toy-train-lora-cuda
 # (leading underscore, macOS symbol convention). libtinynn_ggml.a (CPU archive)
 # stays in deps for the write seam + base ggml. NOT in MIRRORABLE (hand-written).
 # gx10 RUNTIME-UNVERIFIED — pin baseline + gate on the Mac.
-libexec/toy-train-metal: lib/toy/run/train_metal.rb lib/toy/io/toy_json.rb lib/toy/io/toy_events.rb lib/toy/io/toy_git.rb lib/toy.rb lib/toy/models/toy_smollm2.rb \
+libexec/toy-train-metal: lib/toy/run/train_metal.rb lib/toy/dev/toy_describe_flow.rb lib/toy/io/toy_json.rb lib/toy/io/toy_events.rb lib/toy/io/toy_git.rb lib/toy.rb lib/toy/models/toy_smollm2.rb \
 		lib/toy/llm/engine/llama_seq_engine_metal.rb lib/toy/llm/recipes/from_scratch_metal.rb \
 		lib/toy/llm/adamw.rb lib/toy/llm/labels.rb \
 		lib/toy/train/toy_gguf_writer.rb lib/toy/train/toy_drift_grad.rb lib/toy/train/toy_gguf_fuse.rb lib/toy/models/transformer.rb \

--- a/examples/06_train_from_scratch.rb
+++ b/examples/06_train_from_scratch.rb
@@ -178,12 +178,7 @@ end
 # Cheap: one graph walk at startup; Tao's report/describe pipeline
 # reads `<run_dir>/flow.json` directly. Removes the need for a
 # separate TOY_DESCRIBE pre-pass.
-if TAO_RUN_DIR.length > 0
-  flow_path = TAO_RUN_DIR + "/flow.json"
-  File.open(flow_path, "w") do |f|
-    f.write(ToyDescribeFlow.json(fcache.sess))
-  end
-end
+ToyDescribeFlow.emit_flow_json(TAO_RUN_DIR, fcache.sess)
 
 # Read BATCH TinyStories sequences (flat Array<Integer> of length
 # CONTEXT*BATCH). BATCH=1 is the legacy single-line path; BATCH>1

--- a/lib/toy/dev/toy_describe_flow.rb
+++ b/lib/toy/dev/toy_describe_flow.rb
@@ -175,6 +175,20 @@ module ToyDescribeFlow
     j
   end
 
+  # tao#flow-json-emit (issue #25): write the realized graph's flow.json into
+  # `run_dir` (a no-op when run_dir is ""). Called by every training runner right
+  # after realize! so the run bundle is self-describing — parallel to events.jsonl
+  # — and Tao no longer needs a separate TOY_DESCRIBE realize-only pre-pass. One
+  # graph walk, once. Backend-agnostic: ToyDescribeFlow reads the ggml graph
+  # structure via CPU TinyNN (same seam the CUDA/Metal checkpoint writer uses).
+  def self.emit_flow_json(run_dir, sess)
+    if run_dir.length > 0
+      File.open(run_dir + "/flow.json", "w") do |ff|
+        ff.write(ToyDescribeFlow.json(sess))
+      end
+    end
+  end
+
   def self.json(sess)
     pair    = build_index(sess)
     ptrs    = pair[0]

--- a/lib/toy/io/tokenizer.rb
+++ b/lib/toy/io/tokenizer.rb
@@ -100,35 +100,25 @@ class Tokenizer
       btc.push("")
       j = j + 1
     end
-    is_kept = [false]
-    is_kept.pop
-    j = 0
-    while j < 256
-      is_kept.push(false)
-      j = j + 1
-    end
-    b = 0x21
-    while b <= 0x7E
-      is_kept[b] = true
-      btc[b] = b.chr
-      b = b + 1
-    end
-    b = 0xA1
-    while b <= 0xAC
-      is_kept[b] = true
-      btc[b] = Tokenizer.cp_to_utf8(b)
-      b = b + 1
-    end
-    b = 0xAE
-    while b <= 0xFF
-      is_kept[b] = true
-      btc[b] = Tokenizer.cp_to_utf8(b)
-      b = b + 1
-    end
+    # GPT-2 bytes_to_unicode in ONE pass with an inline "kept" boolean.
+    # Bytes in these three ranges map to their own codepoint; every other
+    # byte maps to 256, 257, … in order (so the space 0x20 → U+0120 = Ġ).
+    #
+    # SPINEL LANDMINE (the #34 root cause): the previous version used an
+    # `is_kept[]` Array<bool> seeded with `false` + a separate `if !is_kept[b]`
+    # pass. Under Spinel that else-branch NEVER ran (n_mapped stayed 0), so the
+    # mapped chars — including Ġ for 0x20 — were never built. `@byte_to_char[32]`
+    # came out empty, encode dropped every leading space and selected the
+    # space-less token (`upon`=25705 instead of `Ġupon`=1980), and decode had no
+    # marker to restore. Inline the test as a plain boolean and branch on `k`
+    # (no bool array, no `!`) — verified to produce btc[0x20]=Ġ.
     n_mapped = 0
     b = 0
     while b < 256
-      if !is_kept[b]
+      k = (b >= 0x21 && b <= 0x7E) || (b >= 0xA1 && b <= 0xAC) || (b >= 0xAE && b <= 0xFF)
+      if k
+        btc[b] = Tokenizer.cp_to_utf8(b)
+      else
         btc[b] = Tokenizer.cp_to_utf8(256 + n_mapped)
         n_mapped = n_mapped + 1
       end

--- a/lib/toy/run/train.rb
+++ b/lib/toy/run/train.rb
@@ -42,6 +42,7 @@
 require_relative "../../toy"
 require_relative "../io/toy_json"
 require_relative "../io/toy_events"
+require_relative "../dev/toy_describe_flow"
 require_relative "../models/toy_smollm2"
 require_relative "../io/toy_corpus_loader"
 require_relative "../train/toy_lr_schedule"
@@ -108,6 +109,8 @@ if RECIPE == "warm-start"
   recipe_ws.realize_scratch!(cfg_ws, CONTEXT, 1, 0, true, false, SEED, 1.0)
   # INIT=scratch: skip realize_warm! (no donor GGUF, train from random init).
   recipe_ws.build!
+  # tao#flow-json-emit (#25): self-describing run bundle, parallel to events.jsonl.
+  ToyDescribeFlow.emit_flow_json(TAO_RUN_DIR, recipe_ws.ws_cache.sess)
 
   # NAMED AdamW hp. Defaults (beta2=0.95, bias_correct=false) → slots
   # 5/6 = constant betas, byte-identical to the historical inline hp.
@@ -239,6 +242,8 @@ cfg.donor_d_in = DONOR_D
 # train_embeddings, so no extra enable_* call.
 recipe = Toy::LLM::Recipes::FromScratch.new
 recipe.realize!(cfg, CONTEXT, 1, 0, true, false, SEED, 1.0)
+# tao#flow-json-emit (#25): self-describing run bundle, parallel to events.jsonl.
+ToyDescribeFlow.emit_flow_json(TAO_RUN_DIR, recipe.fs_cache.sess)
 
 # Per-step inputs built IN THE RUNNER (the from-scratch entrypoint, the
 # fixture's analog under lib-vs-example), byte-identical to smoke L56-84.

--- a/lib/toy/run/train_cuda.rb
+++ b/lib/toy/run/train_cuda.rb
@@ -47,6 +47,7 @@
 
 require_relative "../../toy"
 require_relative "../io/toy_json"
+require_relative "../dev/toy_describe_flow"
 require_relative "../io/toy_events"
 require_relative "../models/toy_smollm2"
 require_relative "../llm/engine/llama_seq_engine_cuda"
@@ -112,6 +113,7 @@ if RECIPE == "warm-start"
   recipe_ws.realize_scratch!(cfg_ws, CONTEXT, 1, 0, true, false, SEED, 1.0)
   # INIT=scratch: skip realize_warm! (no donor GGUF, train from random init).
   recipe_ws.build!
+  ToyDescribeFlow.emit_flow_json(TAO_RUN_DIR, recipe_ws.ws_cache.sess)
 
   # NAMED AdamW hp (byte-identical twin of the CPU runner). Defaults
   # (beta2=0.95, bias_correct=false) → slots5/6=constant betas. lr
@@ -240,6 +242,7 @@ cfg.donor_d_in = DONOR_D
 # train_embeddings, so no extra enable_* call.
 recipe = Toy::LLM::Recipes::FromScratchCuda.new
 recipe.realize!(cfg, CONTEXT, 1, 0, true, false, SEED, 1.0)
+ToyDescribeFlow.emit_flow_json(TAO_RUN_DIR, recipe.fs_cache.sess)
 
 # Per-step inputs built IN THE RUNNER, byte-identical to the CPU runner.
 raw        = File.read("data/ts_seqs.txt")

--- a/lib/toy/run/train_lora.rb
+++ b/lib/toy/run/train_lora.rb
@@ -45,6 +45,7 @@
 
 require_relative "../../toy"
 require_relative "../io/toy_json"
+require_relative "../dev/toy_describe_flow"
 require_relative "../io/toy_events"
 require_relative "../models/toy_smollm2"
 require_relative "../llm/engine/llama_seq_engine"
@@ -79,6 +80,8 @@ gguf_h      = TinyNN.tnn_gguf_load(GGUF)
 recipe_lora = Toy::LLM::Recipes::LoRA.new
 recipe_lora.realize!(gguf_h, cfg_lora, TOKENS.length, lora_untied,
                      lora_qkv_bias, RANK_LORA, 42, 0.01)
+# tao#flow-json-emit (#25): self-describing run bundle, parallel to events.jsonl.
+ToyDescribeFlow.emit_flow_json(TAO_RUN_DIR, recipe_lora.lora_cache.sess)
 
 # Vocab × T one-hot labels: every position targets TARGET_ID.
 m_labels = Mat.new(TOKENS.length, cfg_lora.vocab)

--- a/lib/toy/run/train_lora_cuda.rb
+++ b/lib/toy/run/train_lora_cuda.rb
@@ -54,6 +54,7 @@
 
 require_relative "../../toy"
 require_relative "../io/toy_json"
+require_relative "../dev/toy_describe_flow"
 require_relative "../io/toy_events"
 require_relative "../models/toy_smollm2"
 require_relative "../llm/engine/llama_seq_engine_cuda"
@@ -88,6 +89,7 @@ gguf_h      = TinyNNCuda.tnn_gguf_load(GGUF)
 recipe_lora = Toy::LLM::Recipes::LoRACuda.new
 recipe_lora.realize!(gguf_h, cfg_lora, TOKENS.length, lora_untied,
                      lora_qkv_bias, RANK_LORA, 42, 0.01)
+ToyDescribeFlow.emit_flow_json(TAO_RUN_DIR, recipe_lora.lora_cache.sess)
 
 # Vocab × T one-hot labels: every position targets TARGET_ID.
 m_labels = Mat.new(TOKENS.length, cfg_lora.vocab)

--- a/lib/toy/run/train_metal.rb
+++ b/lib/toy/run/train_metal.rb
@@ -47,6 +47,7 @@
 
 require_relative "../../toy"
 require_relative "../io/toy_json"
+require_relative "../dev/toy_describe_flow"
 require_relative "../io/toy_events"
 require_relative "../models/toy_smollm2"
 require_relative "../llm/engine/llama_seq_engine_metal"
@@ -87,6 +88,7 @@ cfg.donor_d_in = DONOR_D
 # train_embeddings, so no extra enable_* call.
 recipe = Toy::LLM::Recipes::FromScratchMetal.new
 recipe.realize!(cfg, CONTEXT, 1, 0, true, false, SEED, 1.0)
+ToyDescribeFlow.emit_flow_json(TAO_RUN_DIR, recipe.fs_cache.sess)
 
 # Per-step inputs built IN THE RUNNER, byte-identical to the CPU runner.
 raw        = File.read("data/ts_seqs.txt")

--- a/lib/toy/run/train_vit.rb
+++ b/lib/toy/run/train_vit.rb
@@ -36,6 +36,7 @@
 # inside a conditional arm reads back empty at runtime); no Struct.new.
 
 require_relative "../io/toy_json"
+require_relative "../dev/toy_describe_flow"
 require_relative "../io/toy_events"
 require_relative "../models/toy_vit"
 require_relative "../llm/engine/vit_tiny_engine"
@@ -80,6 +81,8 @@ cfg = ViTTinyConfig.new(IMAGE_SIZE, PATCH_SIZE, NUM_CHAN, D_MODEL,
 
 recipe = Toy::LLM::Recipes::VitTiny.new
 recipe.realize!(cfg, SEED, 1.0)
+# tao#flow-json-emit (#25): self-describing run bundle, parallel to events.jsonl.
+ToyDescribeFlow.emit_flow_json(TAO_RUN_DIR, recipe.vt_cache.sess)
 
 # Pre-allocate buffers used every step (07_train_vit_tiny.rb:223-237).
 n_patches  = (IMAGE_SIZE / PATCH_SIZE) * (IMAGE_SIZE / PATCH_SIZE)  # 196

--- a/prep/fixtures/infer_baseline.txt
+++ b/prep/fixtures/infer_baseline.txt
@@ -16,4 +16,4 @@
 #
 # PROMPT="Once upon a time", N_NEW=8, greedy (no sampler/seed).
 smollm2-135m-f32.gguf	ids: 6403 1980 253 655 28 665 436 253 1838 8180 3365 14176 30
-smollm2-135m-tok.gguf	text: Onceuponatime,
+smollm2-135m-tok.gguf	text: Once upon a time, there was a little girl named Lily


### PR DESCRIPTION
## #34 — tokenizer drops byte-level space marker (correctness bug)
`decode(encode(text))` lost every space and the model was fed space-less tokens (`upon`=25705 instead of `Ġupon`=1980). The issue hypothesized a decode-side `Ġ→space` gap; the real cause is earlier and is a **Spinel landmine**: `build_byte_tables` built the GPT-2 bytes↔unicode map with an `is_kept` `Array<bool>` (seeded `false`) + a separate `if !is_kept[b]` pass — under Spinel that else-branch **never ran** (`n_mapped` stayed 0), so `Ġ` (U+0120) for byte `0x20` was never built and `@byte_to_char[32]` came out empty. (Vocab/converter/`cp_to_utf8` are all fine — `Ġupon`=1980 exists, GGUF has 31 985 `Ġ`-tokens.)

**Fix:** one pass over 0..255 with an inline `k = (range checks)` boolean, branch on `k` (no bool array, no `!`).

**Verified:** bench tokenizer roundtrip passes (was `RUN_ERROR`); `toy infer` on the tokenizer fixture now decodes `"Once upon a time, there was a little girl named Lily"` (was `"Onceuponatime,"`). Re-recorded the infer-gate tok baseline (buggy→correct); f32 ids-path baseline already correct.

## #25 — flow.json from production training runners
Only the `06` example emitted `flow.json`, so Tao needed a separate `TOY_DESCRIBE` pre-pass. Added `ToyDescribeFlow.emit_flow_json(run_dir, sess)` and call it after `realize!` in every runner: `train` (both arms), `train_lora`, `train_vit`, `train_cuda` (both arms), `train_metal`, `train_lora_cuda`; switched `06` to the helper. ToyDescribeFlow walks the ggml graph via CPU TinyNN, so it works on CUDA/Metal sessions too.

**Verified:** train gate (4 arms) + train-cuda gate (3 arms) byte-identical AND each run dir now has a valid `flow.json` (24KB–639KB; ViT 78KB); metal codegen-clean; verify-mirrors + poly-degrade gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)