### PR TITLE
docs: refresh pass — sync to merged reality, surface new helpers, rewrite consuming-toy

### DIFF
--- a/docs/authoring.md
+++ b/docs/authoring.md
@@ -138,8 +138,14 @@ The shipped recipes are `from_scratch.rb`, `lora.rb`, `warm_start.rb`
 ```ruby
 r = Toy::LLM::Recipes::FromScratch.new
 r.realize!(cfg, t_seq, t_batch, weight_dtype, untied, qkv_bias, seed, init_scale)
-loss = r.step!(seq_ids, positions, m_labels, m_hp, is_first)  # one step
+adamw = Toy::AdamW.new                          # named hyper-params, not a raw Mat
+loss = r.step!(seq_ids, positions, m_labels, adamw.hp(step), is_first)  # one step
 ```
+
+`m_hp` is the AdamW hyper-parameter vector `Mat(1,7)`. Build it with the
+`Toy::AdamW` value object (`lib/toy/llm/adamw.rb`) — `adamw.hp(step)` — rather
+than hand-filling `m_hp.flat[0..6]` with magic slot indices (slots 5/6 carry a
+recipe-dependent dual meaning; AdamW models both via `bias_correct`).
 
 `realize!` delegates to the cache (`realize_for_random_init` then
 `build_training_step`); `step!` runs one step (reset, four ordered

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -59,20 +59,27 @@ graph-walk that infers the model's shape and capabilities).
 Download a GGUF from a HuggingFace repo into the cache and add a `data/`
 symlink. The second positional selects a specific `.gguf` file within the repo.
 
-### `infer <model> [--prompt TEXT] [--n N] [--json]`
-Greedy decode from a GGUF model.
-Defaults: `--prompt "Once upon a time"`, `--n 16`.
+### `infer <model> [--prompt TEXT] [--prompt-ids "ID ID …"] [--n N] [--device cpu|cuda|metal] [--json]`
+Greedy decode from a GGUF model. `--prompt-ids` drives tokenizer-less models with
+explicit numeric token IDs (overrides `--prompt`; the runners fail loud on a
+tokenizer-less model with neither). `--device cuda|metal` selects the per-device
+runner (`metal` is macOS-only). Defaults: `--prompt "Once upon a time"`, `--n 16`,
+`--device cpu`.
 
-### `train <recipe> [--steps N] [--seed S] [--out DIR] [--json]`
+### `train <recipe> [--steps N] [--seed S] [--arch llama|gpt2] [--device cpu|cuda|metal] [--out DIR] [--json]`
 Train a model from scratch and record a run bundle.
-`<recipe>` is required; only `from-scratch` is accepted in this slice (other
-recipes are rejected with a bad-input error).
-Defaults: `--steps 5`, `--seed 0`, `--out runs/<id>`.
+`<recipe>` is required; `from-scratch` is the accepted recipe (other recipes are
+rejected with a bad-input error). `--arch gpt2` trains the from-scratch GPT-2
+arch (CPU); `--device cuda|metal` selects the per-device runner (`metal` is
+macOS-only; GPT-2 is CPU-only).
+Defaults: `--steps 5`, `--seed 0`, `--arch llama`, `--device cpu`, `--out runs/<id>`.
 Writes the run bundle (see [Run bundle layout](#run-bundle-layout)) and echoes
 the byte-deterministic loss curve to stdout.
 
-### `eval <model> [--top-k K] [--json]`
-Score a GGUF model: per-token logprobs. Default `--top-k 5`.
+### `eval <model> [--top-k K] [--device cpu|cuda|metal] [--json]`
+Score a GGUF model: per-token logprobs. Default `--top-k 5`, `--device cpu`.
+Two-checkpoint Linear Mode Connectivity is a subcommand:
+`eval lmc --ckpt A --other B [--alphas "0,0.25,…"]`.
 
 ### `serve <model> [--port PORT] [--name NAME]`
 Serve a GGUF model over an OpenAI-compatible HTTP API (CPU). Default
@@ -80,9 +87,11 @@ Serve a GGUF model over an OpenAI-compatible HTTP API (CPU). Default
 basename). The serve stack lives at `lib/toy/serve/openai/` and is driven by
 `lib/toy/run/serve.rb` → `libexec/toy-serve`.
 
-> Known issue: serving currently hits a TLS-symbol blocker from a stale
-> vendored `tep/net.rb`; the fix is a tep re-vendor. `infer`/`train`/`eval` are
-> tep-free and unaffected. See [reference/coverage.md](coverage.md).
+> Known issue: `libexec/toy-serve` currently fails to compile in tep's scheduler
+> (`Tep::Scheduler.spawn_fiber` → `FiberSlot.new` incompatible-pointer under
+> Spinel) — a tep-side codegen bug, tracked as
+> [OriPekelman/tep#198](https://github.com/OriPekelman/tep/issues/198) (gates
+> toy#30). `infer`/`train`/`eval` are tep-free and unaffected.
 
 ## Project config — `toy.yml`
 
@@ -108,13 +117,15 @@ the project cwd, and shells the runner with a controlled env. The bundle:
 ```
 runs/<id>/
   events.jsonl            # toy/v1 event stream (see events.md)
+  flow.json               # the realized compute-graph DAG (toy/v1) — written
+                          #   once at startup so the bundle is self-describing
   weights/
     step_<N>.gguf         # checkpoints
     latest                # symlink to the most recent checkpoint
 ```
 
-Events and weights are written file-side only — never to stdout. For the
-event schema see [events.md](events.md).
+Events, `flow.json`, and weights are written file-side only — never to stdout.
+For the event schema see [events.md](events.md).
 
 ## Build path
 
@@ -134,8 +145,10 @@ Runners read config from a controlled env hash (e.g. `STEPS`, `SEED`,
 `TAO_RUN_DIR`, `TOY_RUN_ID`) passed via `Open3`, so a stale caller environment
 cannot leak in.
 
-Runners are **CPU-only**. GPU runners (a `--device` flag) are deferred — see
-[roadmap.md](roadmap.md).
+`infer` / `train` / `eval` accept `--device cuda|metal`, which selects a separate
+per-device runner binary (e.g. `libexec/toy-infer-cuda`, `libexec/toy-train-cuda`;
+`metal` is macOS-only). They are single-type binaries by Spinel necessity (one
+backend module per binary), built on demand the same way. `serve` is CPU-only.
 
 ## Examples
 

--- a/docs/consuming-toy.md
+++ b/docs/consuming-toy.md
@@ -1,79 +1,85 @@
-# Consuming `toy` as a vendored gem
+# Consuming `toy` as a library
 
-**Status:** current reference (toy#19 shipped 2026-05-27).
-**Audience:** maintainers of research projects (e.g. `tao_transfer`)
-who want to compose toy's primitives into their own Spinel-compiled
-experiment, rather than fork toy or hand-path `require_relative`s
+**Audience:** maintainers of research projects (e.g. `tao_transfer`) who want to
+**compose toy's primitives** — engines, KV caches, GGUF loaders — into their own
+Spinel-compiled experiment, rather than fork toy or hand-path `require_relative`s
 into toy's tree.
 
-This doc covers the recipe end-to-end. Skim it once, then bookmark
-the "Quick reference" at the bottom for routine re-runs.
+> Not what you want? If you just want to **run** models (infer / train / eval /
+> serve a GGUF), use the `toy` **CLI** — `toy new`, `toy infer model.gguf`, … —
+> which is clean and self-contained. See [`cli.md`](cli.md). This doc is the
+> *library-composition* surface, which is a different (and, today, rougher) path.
 
-## Why vendor instead of `require_relative` toy directly?
+## Status: transitional — the current recipe works, but it's rougher than it should be
 
-You _can_ run `spinel my_experiment.rb -o exp` with a
-`require_relative "../toy/lib/toy/llm/engine/llama_seq_engine"` line — but
-when toy's own build runs, it's compiled with a particular layout
-of relative paths in `ffi_cflags`. A consumer running from a
-different working directory gets stale link paths AND, more subtly,
-hits a Spinel poly-dispatch crash around `Mat` (the failure mode
-toy#19 was filed on). The vendored layout sidesteps both: every
-consumer sees the same `vendor/spinel/toy/lib/` tree, with link
-paths rewritten to absolute references into toy's own checkout.
+The honest state of play: the recipe below **works** and is what `tao_transfer`
+uses, but it's more brittle and contrived than consuming a normal gem — a copied
+post-vendor hook, absolute paths into toy's checkout, a manifest "canary", and
+manual `require_relative`s. All of that traces to **one root cause**: toy doesn't
+yet own its native-extension build the way [tep](https://rubygems.org/gems/tep)
+does (toy ships no `spinel-ext.json`, so the vendor step can't build/link toy's
+native archive into your tree). The cleanup is tracked across three repos —
+see [The target, and how we get there](#the-target-and-how-we-get-there).
 
-The convention is `bundler-spinel` / [spinelgems](https://github.com/OriPekelman/spinelgems);
-toy is the second flagship consumer after tep. See
-[`docs/archive/spinelgems-tep-adoption-2026-05-27.md`](archive/spinelgems-tep-adoption-2026-05-27.md)
-for the broader convention.
-
-## Prereqs (one-time)
-
-- A working toy checkout at e.g. `~/sites/toy`,
-  with `make tinynn/libtinynn_ggml.a` already run (so the `.a`
-  archives the consumer links against exist). For CUDA/Metal,
-  `make setup-ggml-cuda` / `setup-ggml-metal` similarly.
-- Ruby ≥ 3.2.0 on the consumer side (`bundle lock` resolves under
-  CRuby; the engine marker only fires under `bundle install`).
-- Bundler installed: `gem install --user-install bundler`.
-- spinelgems checkout at `~/sites/spinelgems` (or set
-  `SPINEL_DIR=…` if elsewhere).
-
-## The five-step workflow
+## The target (where this is going)
 
 ```sh
-# 1. Declare toy as a path: gem.
-cat > Gemfile <<'EOF'
-source "https://rubygems.org"
-ruby "3.2.3", engine: "spinel", engine_version: "0.0.0"
-
-gem "toy", path: "../toy"   # or "../toy" if symlinked
-EOF
-
-# 2. Resolve — produces Gemfile.lock with a PATH source.
+# Gemfile:  gem "toy", "~> X"        # published to RubyGems, like tep
 bundle lock
-
-# 3. Vendor — copies toy/lib/*.rb into vendor/spinel/toy/lib/ +
-#    writes vendor/spinel/deps.rb (which requires the top-level
-#    vendor/spinel/toy/lib/toy.rb).
-SPINEL_DIR=~/sites/spinel ~/sites/spinelgems/exe/spinel-compat vendor
-
-# 4. Rewrite link paths — turns toy's relative `-L.` / `-Ltinynn`
-#    flags into absolute paths anchored at TOY_SRC. Copy this hook
-#    from toy's prep/ into your own prep/ (it's a template — same
-#    shape for every consumer):
-mkdir -p prep
-cp ../toy/prep/post_vendor_toy.rb prep/
-./prep/post_vendor_toy.rb         # uses TOY_SRC=~/sites/toy
-
-# 5. Compile your experiment.
+spinel-compat vendor                 # copies lib/ AND builds toy's native archive
+                                     #   INTO vendor/, wiring relative link paths
+# experiment.rb:
+#   require_relative "vendor/spinel/deps"   # pulls the full Toy compute surface
 spinel experiment.rb -o experiment
 ./experiment
 ```
 
-A typical `experiment.rb` looks like this. **Note the explicit
-`require_relative`s** for the specific primitives you compose —
-the auto-generated `vendor/spinel/deps.rb` only pulls in
-`toy/lib/toy.rb` (the top-level), so you pick the rest yourself:
+Three steps, no post-vendor hook, no absolute paths into toy's checkout, no
+manifest canary, no `require_relative` soup. That's the bar: as friendly as the
+CLI.
+
+## The current recipe (works today)
+
+### Prereqs (one-time)
+- A toy checkout (e.g. `~/sites/toy`) with `make tinynn/libtinynn_ggml.a` already
+  run (so the `.a` the consumer links against exists). For CUDA/Metal,
+  `make setup-ggml-cuda` / `setup-ggml-metal`.
+- Ruby ≥ 3.2 on the consumer side (`bundle lock` resolves under CRuby).
+- Bundler (`gem install --user-install bundler`).
+- A [spinelgems](https://github.com/OriPekelman/spinelgems) checkout at
+  `~/sites/spinelgems` (the vendor tool), or set `SPINEL_DIR=…`.
+
+### The five steps
+```sh
+# 1. Declare toy as a path: gem (a published gem is the target; see above).
+cat > Gemfile <<'EOF'
+source "https://rubygems.org"
+ruby "3.2.3", engine: "spinel", engine_version: "0.0.0"
+
+gem "toy", path: "../toy"
+EOF
+
+# 2. Resolve.
+bundle lock
+
+# 3. Vendor — copies toy/lib/*.rb into vendor/spinel/toy/lib/ + writes
+#    vendor/spinel/deps.rb (which requires vendor/spinel/toy/lib/toy.rb).
+SPINEL_DIR=~/sites/spinel ~/sites/spinelgems/exe/spinel-compat vendor
+
+# 4. (THE CONTRIVED STEP — tracked for removal, toy#42) Rewrite link paths:
+#    turns toy's relative -L flags into absolute paths anchored at TOY_SRC.
+#    Copy the hook template from toy's prep/ into your own prep/:
+mkdir -p prep && cp ../toy/prep/post_vendor_toy.rb prep/
+./prep/post_vendor_toy.rb                 # uses TOY_SRC=~/sites/toy
+
+# 5. Compile.
+spinel experiment.rb -o experiment
+./experiment
+```
+
+A typical `experiment.rb`. **Note the explicit `require_relative`s** for the
+primitives you compose — `vendor/spinel/deps.rb` only pulls `toy.rb` (the
+top-level), so you pick the rest yourself (also tracked for removal, toy#42):
 
 ```ruby
 require_relative "vendor/spinel/deps"
@@ -86,113 +92,71 @@ fcache.realize_for_random_init(cfg, 32, false, false, 0, 1.0)
 # … build_training_step, upload, compute, …
 ```
 
-That's it. From here you write whatever experiment loop you want
-against `Toy::LLM::Engine::LlamaSeqEngine` / `Toy::LLM::Engine::ViTTinyEngine` /
-`SmolLM2KVFFICache` / the GGUF loaders. The Tao project at
-`~/sites/tao_transfer` is the canonical worked example.
+From here you write your experiment loop against
+`Toy::LLM::Engine::LlamaSeqEngine` / `Toy::LLM::Engine::ViTTinyEngine` /
+`SmolLM2KVFFICache` / the GGUF loaders. `~/sites/tao_transfer` is the canonical
+worked example. To emit Tao-consumable telemetry, see [`events.md`](events.md)
+(and `Toy::Json` / `Toy::Events.add_provenance` for building it).
 
-## Env knobs
-
-`prep/post_vendor_toy.rb` recognises:
-
+### Env knobs (`prep/post_vendor_toy.rb`)
 | Env | Purpose |
 | --- | --- |
-| `TOY_SRC=…` | Absolute path to toy's checkout. Defaults to `~/sites/toy`. The `-L` rewrites anchor here. |
-| `TOY_DISABLE=cuda,metal` | Skip rewriting backend files you don't compile. CPU is always rewritten. |
-| `CUDA_DIR_LIB=…` | Override the absolute CUDA libdir baked into `tinynn_cuda.rb`. Defaults to `/usr/local/cuda/lib64`. |
+| `TOY_SRC=…` | Absolute path to toy's checkout. Default `~/sites/toy`. The `-L` rewrites anchor here. |
+| `TOY_DISABLE=cuda,metal` | Skip rewriting backend files you don't compile. CPU always rewritten. |
+| `CUDA_DIR_LIB=…` | Override the absolute CUDA libdir baked into `tinynn_cuda.rb`. Default `/usr/local/cuda/lib64`. |
 
-## What gets vendored, what doesn't
-
+### What gets vendored, what doesn't
 `spinel-compat vendor` copies the gem's `lib/` verbatim into
-`vendor/spinel/toy/lib/`. That includes all 46 `lib/**/*.rb` files
-plus `lib/toy/version.rb` + `lib/toy/ffi_manifest.rb`.
+`vendor/spinel/toy/lib/`. It does **not** copy `vendor/ggml/build/` (6 MB),
+`data/`/weights, or `tinynn/libtinynn_ggml.a` — those are referenced by the
+absolute paths step 4 writes (pointing into toy's own tree). **This is the
+brittleness:** delete toy's checkout and your consumer breaks. Re-run the
+workflow against a fresh toy checkout to repoint. (The fix — build the archive
+*into your vendor tree* — is spinelgems#14 + toy#42.)
 
-It does NOT copy:
-
-- `vendor/ggml/build/` — 6 MB of build artifacts. The link paths
-  rewritten by step 4 point at toy's own `vendor/ggml/build/src`
-  (no copy; toy keeps owning the artifact).
-- `data/`, model weights, pretokenized corpora. Caller-managed.
-- `tinynn/libtinynn_ggml.a` itself — also referenced via absolute
-  path. The consumer's link command picks it up from toy's tree.
-
-Practically: if you delete toy's checkout, your consumer breaks
-(the absolute paths in vendored `tinynn.rb` go stale). Re-run
-the workflow against a fresh toy checkout to repoint.
-
-## Updating toy on the consumer side
-
-When toy moves (new commits in toy's tree), the consumer's vendored
-copy goes stale. Re-run steps 2-4:
-
+### Updating when toy moves
+Re-run steps 2–4:
 ```sh
-bundle lock                                                # refresh PATH spec metadata
-SPINEL_DIR=~/sites/spinel ~/sites/spinelgems/exe/spinel-compat vendor
-./prep/post_vendor_toy.rb
-spinel experiment.rb -o experiment                         # rebuild
-```
-
-If toy's `lib/tinynn.rb` ever changes the literal `ffi_cflags`
-string, `post_vendor_toy.rb` will warn that no substitution
-matched. That means `lib/toy/ffi_manifest.rb`'s
-`CURRENT_FFI_CFLAGS` constant is out of sync with the source — bump
-both in lockstep in a single toy commit. The warning is the
-canary; honor it.
-
-## Disabling Tep batteries (Pg / Sqlite)
-
-Toy includes tep_demo/* apps that link `Tep::PG` and `Tep::Sqlite`
-batteries via the tep vendored tree.
-If your downstream box lacks libpq / libsqlite3, set
-`TEP_DISABLE=pg` (or `pg,sqlite`) **on the toy side's
-post-vendor**, not the toy#19 hook — toy's post_vendor_toy.rb
-doesn't touch tep, only the tinynn link paths.
-
-In practice: most research consumers don't use the tep_demo
-HTTP-serving apps. They use the training cache classes directly.
-No tep dependency at all from a pure training experiment.
-
-## Why this matters (the "no Mat landmine" half)
-
-Tao tried before this work landed: hand-pathed
-`require_relative "../toy/lib/toy/models/toy_smollm2"` etc. Compile-time it
-PASSED, but generated a Spinel poly-dispatch crash referencing an
-undefined `sp_Mat` type in an Array<Mat> declaration. Root cause:
-when toy's `lib/toy/models/transformer.rb` (where Mat lives) is loaded via a
-non-vendored relative path, Spinel's whole-program inference
-fragments the type table differently than for toy's own builds.
-The vendored layout — same tree shape for every consumer — keeps
-inference monomorphic in the way toy's own build expects.
-
-If you ever see `sp_Mat undeclared` from your consumer compile,
-that's the smell. Confirm you're using the vendored layout (not a
-hand-pathed `require_relative` into toy's tree).
-
-## Quick reference
-
-```sh
-# Initial:
-gem build ../toy/toy.gemspec   # optional — produces a .gem
-                                                   # for off-machine consumption.
-                                                   # For path:-based consumers
-                                                   # (siblings on the same host)
-                                                   # this isn't needed.
-
-# Every consumer cycle (when toy moves or your experiment changes):
 bundle lock
 SPINEL_DIR=~/sites/spinel ~/sites/spinelgems/exe/spinel-compat vendor
 ./prep/post_vendor_toy.rb
 spinel experiment.rb -o experiment
-./experiment
 ```
+If toy's `lib/tinynn.rb` changes its literal `ffi_cflags`, `post_vendor_toy.rb`
+warns that no substitution matched — that means `lib/toy/ffi_manifest.rb`'s
+`CURRENT_FFI_CFLAGS` is out of sync with the source; bump both in one toy commit.
+The warning is the canary; honor it. (This canary, too, disappears once toy owns
+its ext wiring — toy#42.)
+
+## The `sp_Mat undeclared` landmine
+
+If your consumer compile fails with `sp_Mat undeclared` (or a poly-dispatch crash
+around an `Array<Mat>`), you've hand-pathed a `require_relative` into toy's tree
+instead of using the vendored layout. Root cause: Spinel's whole-program
+inference is **require-path/layout sensitive** — loading `transformer.rb` (where
+`Mat` lives) via a non-vendored path fragments the type table differently than
+toy's own build. The vendored layout (same tree shape for every consumer) keeps
+inference monomorphic the way toy's build expects. This layout-sensitivity is the
+deeper root of *why* vendoring has to exist — filed as **matz/spinel#1367**.
+toy's `make gate-poly-degrade` guards regressions of the related emit-0 class but
+not this root.
+
+## The target, and how we get there
+
+Everything brittle above is a workaround for one gap — **toy doesn't own its
+native-ext wiring like tep does**. The cleanup, tracked across three repos:
+
+| Repo | Issue | What it unblocks |
+| --- | --- | --- |
+| spinelgems | **#14** | a native **build-step** in `spinel-ext.json` (build + link archives *into* the vendor tree), not just per-`.c` placeholder substitution — toy's ggml CMake build needs this. **The keystone.** |
+| toy | **#42** | author `spinel-ext.json` (→ retire `post_vendor_toy.rb` + the `ffi_manifest` canary); a Spinel-only full-API `require`; **publish to RubyGems**; `toy new --lib` scaffold. Depends on #14. |
+| matz/spinel | **#1367** | stable package identity so a user class (`Mat`) types the same regardless of require path — removes the layout-sensitivity the vendored layout works around. |
+
+When #14 + #42 land, this doc collapses to the three-step
+[target](#the-target-where-this-is-going) above.
 
 ## See also
-
-- [`archive/spinelgems-tep-adoption-2026-05-27.md`](archive/spinelgems-tep-adoption-2026-05-27.md)
-  — the broader convention, originally written for tep.
-- `lib/toy/ffi_manifest.rb` — the toy-side analog of
-  `Tep::FFIManifest` (the FFI-manifest design).
-- [`events-schema.md`](events.md) — the `toy/v1` event
-  contract your consumer can emit (`run_start`, `step`, `eval`,
-  `tap`, `run_end`) for Tao-side consumption.
-- toy#19, tep#97, spinelgems#3 — the issue trail.
+- [`cli.md`](cli.md) — the friendly *app* surface (run models without any of this).
+- [`events.md`](events.md) — the `toy/v1` event contract your consumer can emit.
+- [`dependencies.md`](dependencies.md) — how toy itself consumes tep (the model toy is following).
+- toy#19 (the original "no Mat landmine" work), tep#97, spinelgems#3 — the issue trail.

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -20,11 +20,12 @@ top of these ops are tracked separately in `docs/models-verified.md`.
 
 Backend caveats not captured by the table:
 
-- **`MUL_MAT_ID` × Q4_K / Q6_K source weights**: ggml's mul_mat_id
-  kernel produces garbage on K-quantized expert tensors. Q8_0 / F16 /
-  F32 sources work. Tracked in `docs/notes/mul_mat_id_quant.md` once
-  we write it; for now see commit `42b8609` (M2.3) for the
-  repro/workaround.
+- **`MUL_MAT_ID` × Q4_K / Q6_K source weights — RESOLVED (was ours, not
+  ggml's).** OLMoE-Q4_K_M produced degenerate output and was long misfiled as a
+  ggml mul_mat_id K-quant kernel bug (ggml#1506). The op is correct for K-quants;
+  the real cause was `head_nbytes` returning 0 for K-quant ATTENTION weights,
+  collapsing every head onto head 0 (fixed). K-quant MoE experts load and run
+  coherently. See `docs/notes/mul_mat_id_quants.md` + `make gate-moe-kquant`.
 - **`FLASH_ATTN_BACK`**: ggml's backward kernel calls `GGML_ABORT` at
   runtime (see `vendor/ggml/src/ggml.c::ggml_flash_attn_back`). The
   op is "missing" for us, but it's also broken upstream — wait for

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -6,7 +6,7 @@ vendored-ggml C divergences that live in `vendor/`.
 
 ---
 
-## tep — consumed as a gem from `main` via spinelgems
+## tep — consumed as a released RubyGems gem via spinelgems
 
 `tep` is the **only** external Ruby dependency, and it is a
 **build-dep, used by `serve` alone**. `infer`, `train`, and `eval`
@@ -20,11 +20,17 @@ are tep-free. tep is consumed through the
 source "https://rubygems.org"
 ruby "3.2.3", engine: "spinel", engine_version: "0.0.0"
 
-gem "tep", git: "https://github.com/OriPekelman/tep.git", branch: "main"
+gem "tep", "~> 0.11.2"
 ```
 
-`git:` (not `path:`) is deliberate — it gives a reproducible
-cross-machine lock.
+The **released gem** (https://rubygems.org/gems/tep) is the reproducible
+cross-machine path — `Gemfile.lock` pins the version with a RubyGems sha256.
+(The pre-publish `git: …branch: "main"` pin is retired.) tep ships a
+`spinel-ext.json` so `spinel-compat vendor` natively compiles + wires its C
+extensions; no `@TEP_*@` post-vendor substitution.
+
+> serve is currently blocked tep-side (a Spinel codegen bug in tep's scheduler,
+> OriPekelman/tep#198); see `cli.md`.
 
 ### The flow (`make vendor-tep`)
 

--- a/docs/events.md
+++ b/docs/events.md
@@ -27,8 +27,14 @@ A run lives under `runs/<run_id>/` in the project (the directory holding
 runs/
   <run_id>/
     events.jsonl        # the structured event stream (this doc)
+    flow.json           # the realized compute-graph DAG (toy/v1, ToyDescribeFlow)
     weights/            # checkpoint snapshot(s), GGUF
 ```
+
+`flow.json` is written once at startup (right after `realize!`) by every training
+runner, so the run bundle is self-describing — a consumer reads the arch DAG
+without a separate `TOY_DESCRIBE` pre-pass. Emitted via
+`ToyDescribeFlow.emit_flow_json(run_dir, sess)`.
 
 `run_id` is generated from `run_id_template` in `toy.yml`
 (`lib/toy/core/config.rb`; default `{arch}-{date}-{seq}`, e.g.
@@ -319,6 +325,18 @@ with `phase:"serve"` and `name:"request"`:
 (held-out evaluation during training). The `extra` open-bag carries
 caller-specific fields without bloating the schema; consumers route on
 `extra.request_id` for request-keyed aggregation.
+
+## Emitting events (producer side)
+
+Runners build event JSON with the tep-free `Toy::Json` ordered-object builder
+(`lib/toy/io/toy_json.rb`) and emit it via `TinyNN.tnn_events_emit(j.j_dump)` —
+**not** hand-concatenated strings (which were unescaped and comma-fragile). The
+shared `run_start` provenance — `host{}` + `backend{}` + `git{}` — is one call,
+`Toy::Events.add_provenance(rs, host_name, host_os, host_arch, backend_kind)`
+(`lib/toy/io/toy_events.rb`), which reads git via `Toy::Git`
+(`lib/toy/io/toy_git.rb`). Hyper-parameter vectors use the `Toy::AdamW` value
+object (`adamw.hp(step)`), not a hand-filled `Mat(1,7)`. All four are pure-Ruby
+(no FFI), Spinel-compiled, and shared across the CPU/CUDA/Metal runners.
 
 ## Producer guarantees
 

--- a/docs/gating.md
+++ b/docs/gating.md
@@ -170,5 +170,7 @@ the work stabilises.
   Q8_0 through the graph.
 
 For known numerical-divergence issues currently masked rather than fixed
-(CPU/CUDA LoRA-train grad aliasing, MoE K-quant `mul_mat_id`), see the
-"Known issues" notes in `docs/roadmap.md`.
+(CPU/CUDA LoRA-train grad aliasing), see the "Known issues" notes in
+`docs/roadmap.md`. (The MoE K-quant `mul_mat_id` "bug" was resolved — it was
+`head_nbytes` collapsing K-quant attention heads, not the op; guarded by
+`make gate-moe-kquant`.)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -135,20 +135,22 @@ block phases — they land inside the layered structure when picked up.
   the toy forward is rope-angle-insensitive at the logit level), and
   GQA-divergent on mmap/q8 (no divergent-head GGUF to gate against). The
   `full_finetune` 6th gate is built (`prep/full_finetune_gate.rb`).
-- **MoE.** OLMoE Q4_K_M decode is incoherent. **2026-06-04 reframe: this
-  is a toy-side loader/graph bug, NOT a ggml op bug** — an op-level
-  `ggml_mul_mat_id` reproducer at OLMoE topology (`tinynn/ggml1506_*`) is
-  clean (within quant noise) while end-to-end still corrupts; there are no
-  CPU `mul_mat_id` changes between our ggml pin and master. Root-cause moves
-  to `realize_for_mmap`'s K-quant expert tensor layout. Workaround: **Q8_0
-  experts**. `realize_for_mmap` warns loud (the warning's "ggml's kernel is
-  wrong" wording is now misattributed — reword). See `docs/notes/mul_mat_id_quants.md`,
-  ggml-org/ggml#1506.
+- **MoE — RESOLVED (2026-06-05).** OLMoE Q4_K_M decode was incoherent and was
+  long misfiled as a ggml `mul_mat_id` K-quant kernel bug (ggml#1506). The op is
+  correct for K-quants (op-level + real-bytes reproducers in `tinynn/ggml1506_*`
+  all clean); the real cause was `head_nbytes` returning 0 for K-quant ATTENTION
+  weights, collapsing every attention head onto head 0. Fixed. K-quant MoE
+  experts (incl. OLMoE's mixed q4_K+q6_K `down_exps`) now decode coherently; the
+  misleading runtime warning was removed and `make gate-moe-kquant` guards it.
+  ggml#1506 is closeable upstream as a non-bug. See `docs/notes/mul_mat_id_quants.md`.
 - **Tep, then Tao, re-adaptation** — deferred until Toy is fully
-  stabilized. The serve convergence onto tep's `Backend` (#30 / PR #33)
-  is **blocked** by a Spinel monomorphization miscompile in the live
-  serve binary (blank-key JSON via polymorphic `Tep::Handler` dispatch);
-  `main` keeps its hand-rolled handlers. Tep is a build-dep only today.
+  stabilized. The serve convergence onto tep's `Backend` (#30) is
+  **blocked** tep-side: `libexec/toy-serve` won't even compile —
+  `Tep::Scheduler.spawn_fiber` → `FiberSlot.new` incompatible-pointer under
+  Spinel (filed as OriPekelman/tep#198), and 0.11.3 additionally blank-keys
+  JSON via a polymorphic-dispatch monomorphization. `main` keeps its
+  hand-rolled handlers until a tep release builds + serves correctly. tep is
+  consumed as the released RubyGems gem (#31 done).
 
 ---
 
@@ -162,8 +164,8 @@ touching kernels.
 1. **Bind `MUL_MAT_ID` + `ADD_ID` + `TOP_K` + `ARGSORT`** (sparse MoE
    expert dispatch + router). All exist in ggml; we have zero bindings.
    Unblocks **five families**: Mixtral, Qwen3-MoE, DeepSeek-V3 FFN,
-   Llama-4-MoE, GLM-MoE. (Carries the K-quant-expert caveat above —
-   ship with Q8_0 experts until ggml#1506 lands.)
+   Llama-4-MoE, GLM-MoE. (K-quant experts work — the OLMoE corruption was
+   the `head_nbytes` attention-stride bug above, now fixed.)
 
 2. **Apply the widened RoPE.** The C and Ruby `tnn_rope_ext` binding
    *already* exposes `freq_scale`, `ext_factor`, `attn_factor`,

--- a/lib/toy/core/cli.rb
+++ b/lib/toy/core/cli.rb
@@ -72,7 +72,9 @@ module Toy
           summary: "Generate text from a GGUF model (greedy decode)",
           args:  [{ name: "model", required: true, desc: "path to a .gguf file" }],
           flags: [{ name: "--prompt", desc: "prompt text (default \"Once upon a time\")" },
+                  { name: "--prompt-ids", desc: "space-separated token IDs (tokenizer-less models; overrides --prompt)" },
                   { name: "--n", desc: "tokens to generate (default 16)" },
+                  { name: "--device", desc: "cpu (default) | cuda | metal (macOS)" },
                   { name: "--json", desc: "machine output" }]
         },
         "train" => {
@@ -82,14 +84,16 @@ module Toy
           flags: [{ name: "--steps", desc: "training steps (default 5)" },
                   { name: "--seed", desc: "random-init seed (default 0)" },
                   { name: "--arch", desc: "llama (default) | gpt2 (from-scratch, CPU)" },
+                  { name: "--device", desc: "cpu (default) | cuda | metal (macOS)" },
                   { name: "--out", desc: "run dir override (default runs/<id>)" },
                   { name: "--json", desc: "machine output" }]
         },
         "eval" => {
           class: Eval,
-          summary: "Score a GGUF model (per-token logprobs)",
+          summary: "Score a GGUF model (per-token logprobs; `eval lmc` for two-checkpoint LMC)",
           args:  [{ name: "model", required: true, desc: "path to a .gguf file" }],
           flags: [{ name: "--top-k", desc: "top-K logprobs to report (default 5)" },
+                  { name: "--device", desc: "cpu (default) | cuda | metal (macOS)" },
                   { name: "--json", desc: "machine output" }]
         },
         "serve" => {


### PR DESCRIPTION
Full documentation pass: make recent refactoring well-represented and everything up to date.

## Truth-syncing (docs lagged merged work)
- **CLI registry** (`lib/toy/core/cli.rb`) — declare flags the commands already parse but `--manifest` omitted: `infer --prompt-ids/--device`, `train --device`, `eval --device` (+ note `eval lmc`). Restores cli.md's "no drift between --help, --manifest, dispatch" invariant.
- **cli.md** — `--prompt-ids`/`--device`/`eval lmc`; serve known-issue is now the tep#198 FiberSlot codegen (not the old TLS story); `flow.json` in the run bundle; `--device` is shipped, not "deferred".
- **coverage.md / gating.md / roadmap.md** — the MoE `mul_mat_id` K-quant "bug" is RESOLVED (it was `head_nbytes` collapsing K-quant attention heads, not the op; gated by `gate-moe-kquant`). Dropped the stale "ship Q8_0 experts" workaround.
- **dependencies.md** — tep is the released RubyGems gem (`~> 0.11.2`), not `git:main`.

## New helpers surfaced (were undocumented)
- **events.md** — `flow.json` sibling artifact; a producer-side section (`Toy::Json` / `Toy::Events.add_provenance` / `Toy::Git` / `Toy::AdamW`, not string-concat).
- **authoring.md** — build `m_hp` via `Toy::AdamW`, not hand-filled slots.

## consuming-toy.md — rewritten
Led with the target state, kept the working recipe but labeled the contrived bits and pointed each at its tracking issue. Diagnosed the single root (toy doesn't own its native-ext wiring like tep does) and filed the cross-repo fix:
- **spinelgems#14** — native build-step in `spinel-ext.json` (keystone)
- **toy#42** — `spinel-ext.json` + full-API require + publish + `toy new --lib`
- **matz/spinel#1367** — require-path-sensitive inference (the `sp_Mat` landmine root)

architecture.md reviewed — already current (layered L1–L4, no stale paths).

🤖 Generated with [Claude Code](https://claude.com/claude-code)