### PR TITLE
feat(#42): toy/compute — one-require full compute API for library consumers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -400,6 +400,18 @@ gate-full-finetune:
 gate-mixed-precision:
 	ruby prep/mixed_precision_gate.rb
 
+# toy#42 full-API require gate. Builds examples/smoke_compute_surface (which
+# requires ONLY lib/toy/compute.rb) and asserts it realizes a live engine —
+# proving the one-require compute surface co-compiles + works for a library
+# consumer. Builds the smoke itself.
+.PHONY: gate-compute-surface
+gate-compute-surface: examples/smoke_compute_surface
+	@out="$$(./examples/smoke_compute_surface 2>&1)"; \
+	echo "$$out" | tail -2; \
+	echo "$$out" | grep -q "compute-surface: ok" \
+	  && echo "GATE PASS [compute-surface]: lib/toy/compute.rb one-require surface is live" \
+	  || { echo "GATE FAIL [compute-surface]"; exit 1; }
+
 # K-quant MoE attention regression gate (the bug long misfiled as ggml#1506):
 # head_nbytes returned 0 for K-quant attention weights → per-head mmap stride
 # collapsed every head onto head 0 → degenerate repeating decode on OLMoE
@@ -660,6 +672,14 @@ example_lmc: examples/example_lmc
 
 # E2.3 (towards GH#14) — projection-lens smoke.
 examples/smoke_projection_lens: examples/smoke_projection_lens.rb lib/toy/llm/engine/llama_seq_engine.rb lib/toy/models/toy_smollm2.rb lib/toy/models/transformer.rb lib/tinynn.rb lib/toy/train/toy_drift_grad.rb tinynn/libtinynn_ggml.a $(SPINEL_DEPS)
+	$(SPINEL) $< -o $@
+
+# toy#42 full-API require gate. Compiling this proves lib/toy/compute.rb's whole
+# surface (all three engines + recipes + loaders) co-compiles in one program;
+# running it realizes a LlamaSeqEngine to prove the surface is live. The prereq
+# is just lib/toy/compute.rb — it pulls everything else transitively, and
+# $(SPINEL) follows the require graph.
+examples/smoke_compute_surface: examples/smoke_compute_surface.rb lib/toy/compute.rb tinynn/libtinynn_ggml.a $(SPINEL_DEPS)
 	$(SPINEL) $< -o $@
 
 # P2.6 — GQA-divergent (w_o) gate. Realizes a config with head_dim=24 so

--- a/docs/consuming-toy.md
+++ b/docs/consuming-toy.md
@@ -77,26 +77,32 @@ spinel experiment.rb -o experiment
 ./experiment
 ```
 
-A typical `experiment.rb`. **Note the explicit `require_relative`s** for the
-primitives you compose — `vendor/spinel/deps.rb` only pulls `toy.rb` (the
-top-level), so you pick the rest yourself (also tracked for removal, toy#42):
+A typical `experiment.rb`. One require — `toy/compute` (toy#42) — pulls the
+whole composition surface (all three engines + recipes + GGUF/tokenizer
+loaders), so you no longer hand-`require_relative` each primitive:
 
 ```ruby
-require_relative "vendor/spinel/deps"
-require_relative "vendor/spinel/toy/lib/toy/models/toy_smollm2"
-require_relative "vendor/spinel/toy/lib/toy/llm/engine/llama_seq_engine"
+require_relative "vendor/spinel/toy/lib/toy/compute"   # the full compute API
 
-cfg = Toy::SmolLM2Config.new(627, 64, 4, 4, 128, 2, 32, 10000.0, 1.0e-5)
-fcache = Toy::LLM::Engine::LlamaSeqEngine.new
-fcache.realize_for_random_init(cfg, 32, false, false, 0, 1.0)
+cfg    = Toy::SmolLM2Config.new(627, 64, 4, 4, 128, 2, 32, 10000.0, 1.0e-5)
+engine = Toy::LLM::Engine::LlamaSeqEngine.new
+engine.realize_for_random_init(cfg, 32, 1, 0, false, false, 0, 1.0)
 # … build_training_step, upload, compute, …
 ```
+
+`toy/compute` is the **Spinel-only** entry — it pulls `tinynn` (FFI) and the
+engines. The top-level `toy.rb` stays MRI-safe (Mat + Card + version, no FFI)
+so `bin/toy` can require it; don't use `toy.rb` for the compute surface. If you
+build only one engine and want to compile less (Spinel has no tree-shaking),
+require that engine's file directly instead of `toy/compute`. The
+`gate-compute-surface` make target proves the one-require surface co-compiles +
+runs (`examples/smoke_compute_surface`).
 
 From here you write your experiment loop against
 `Toy::LLM::Engine::LlamaSeqEngine` / `Toy::LLM::Engine::ViTTinyEngine` /
 `SmolLM2KVFFICache` / the GGUF loaders. `~/sites/tao_transfer` is the canonical
 worked example. To emit Tao-consumable telemetry, see [`events.md`](events.md)
-(and `Toy::Json` / `Toy::Events.add_provenance` for building it).
+(and `SpinelKit::Json::Builder` / `Toy::Events.add_provenance` for building it).
 
 ### Env knobs (`prep/post_vendor_toy.rb`)
 | Env | Purpose |

--- a/examples/smoke_compute_surface.rb
+++ b/examples/smoke_compute_surface.rb
@@ -1,0 +1,34 @@
+# examples/smoke_compute_surface.rb — proves the toy#42 full-API require
+# (lib/toy/compute.rb) compiles under Spinel and yields a working compute
+# surface from ONE require.
+#
+# The BUILD step is itself the combined-surface gate: Spinel compiles every
+# file lib/toy/compute.rb pulls, so a clean build proves all three engines +
+# recipes + loaders co-compile in one program (the runners each load only one
+# engine — this is the only place the full surface is compiled together). The
+# RUN then realizes a tiny LlamaSeqEngine to prove the surface is live.
+#
+#   make examples/smoke_compute_surface && ./examples/smoke_compute_surface
+#
+# Expected last line: "compute-surface: ok".
+
+require_relative "../lib/toy/compute"
+
+cfg = Toy::SmolLM2Config.new(627, 64, 4, 4, 128, 2, 16, 10000.0, 1.0e-5)
+
+# One require gave us the whole composition API. Instantiate each engine class
+# (proves all three co-compiled + are addressable) and realize the Llama one
+# (proves the L1 primitives / L2 block / L3 arch the engine pulls are live).
+llama = Toy::LLM::Engine::LlamaSeqEngine.new
+vit   = Toy::LLM::Engine::ViTTinyEngine.new
+gpt2  = Toy::LLM::Engine::GPT2SeqEngine.new
+
+llama.realize_for_random_init(cfg, 16, 1, 0, false, false, 0, 1.0)
+ok = llama.sess != TinyNN.tnn_null_ptr
+
+puts "compute-surface: engines=[llama,vit,gpt2] realized, sess_present=" + ok.to_s
+if ok
+  puts "compute-surface: ok"
+else
+  puts "compute-surface: FAIL (realize produced null session)"
+end

--- a/lib/toy/compute.rb
+++ b/lib/toy/compute.rb
@@ -1,0 +1,60 @@
+# lib/toy/compute.rb — the full Toy compute surface, in one require.
+#
+# WHY THIS EXISTS (toy#42). A library consumer composes models out of Toy's
+# engines / primitives / recipes / loaders. Before this file they had to
+# hand-`require_relative` each one (the generated `vendor/spinel/deps.rb` only
+# pulls the top-level `toy.rb`, which is the MRI-safe CLI surface — Mat + Card +
+# version, no FFI). This file is the SPINEL-ONLY compute entrypoint: require it
+# once and the whole public composition API is loaded.
+#
+#   require_relative "vendor/spinel/toy/lib/toy/compute"   # one require
+#   cfg    = Toy::SmolLM2Config.new(627, 64, 4, 4, 128, 2, 32, 10000.0, 1.0e-5)
+#   engine = Toy::LLM::Engine::LlamaSeqEngine.new
+#   engine.realize_for_random_init(cfg, 32, 1, 0, false, false, 0, 1.0)
+#   # … build_training_step / KV decode / GGUF load …
+#
+# MRI-SAFETY BOUNDARY. Do NOT require this from `toy.rb` or anything under
+# `lib/toy/core/` (the CRuby CLI): it pulls `tinynn` (FFI `ffi_lib`s) and the
+# engines, which only load under a Spinel build. `toy.rb` must stay loadable by
+# plain MRI so `bin/toy` can require it. This file is for Spinel consumers only.
+#
+# MINIMAL-SURFACE NOTE. Spinel has no tree-shaking, so this pulls the COMMON
+# composition surface (all three engines + recipes + loaders). A consumer that
+# only ever builds, say, a LlamaSeqEngine can still require the individual files
+# instead to compile less; this is the convenience "everything" entry. The
+# backend mirrors (`*_cuda` / `*_metal`) are NOT required here — a consumer
+# selects its backend by requiring the matching engine variant.
+
+# FFI compute layer (Mat, sessions, tnn_* ops) + the MRI-safe sugar.
+require_relative "../tinynn"
+require_relative "../toy"
+
+# Models + configs (Llama/SmolLM2, ViT) and the GGUF→engine loader.
+require_relative "models/toy_smollm2"
+require_relative "models/toy_smollm2_loader"
+require_relative "models/toy_vit"
+
+# Engines — the L4 forward/train drivers. Each pulls its L1 primitives,
+# L2 block, and L3 arch transitively.
+require_relative "llm/engine/llama_seq_engine"
+require_relative "llm/engine/vit_tiny_engine"
+require_relative "llm/engine/gpt2_seq_engine"
+
+# KV-cache decode engine (inference).
+require_relative "../toy_smollm2_ffi_kv"
+
+# Recipes — the named training/init compositions (from-scratch, LoRA,
+# warm-start, ViT). Realize-path orchestration over the engines.
+require_relative "llm/recipes/from_scratch"
+require_relative "llm/recipes/lora"
+require_relative "llm/recipes/warm_start"
+require_relative "llm/recipes/vit_tiny"
+
+# Inference I/O: GGUF model loading + the BPE tokenizer.
+require_relative "io/gguf_load"
+require_relative "io/tokenizer"
+
+# AdamW hyper-parameter value object + training labels (used when driving
+# build_training_step directly).
+require_relative "llm/adamw"
+require_relative "llm/labels"


### PR DESCRIPTION
First half of #42: the **full-API require**. Library consumers no longer hand-`require_relative` each engine/primitive — `lib/toy/compute.rb` pulls the whole composition surface in one require.

## What
- **`lib/toy/compute.rb`** — Spinel-only entry pulling all three engines (Llama/ViT/GPT-2, which transitively load L1 primitives + L2 block + L3 arch), the recipes (from-scratch/LoRA/warm-start/ViT), the KV-cache decode engine, and the GGUF + tokenizer loaders.
- **MRI-safety preserved** — `compute.rb` pulls `tinynn` (FFI), so it stays OUT of `toy.rb` / `lib/toy/core/*`; `toy.rb` remains MRI-loadable for `bin/toy`. Consumers require `toy/compute`; the CLI keeps requiring `toy.rb`.
- **`examples/smoke_compute_surface`** + **`make gate-compute-surface`** — a real Spinel build+run (requires ONLY `toy/compute`, realizes a live `LlamaSeqEngine`). The build is itself the combined-surface gate: all three engines co-compile in one program — something the runners (one engine each) never exercised.
- **docs/consuming-toy.md** — hand-require dance → single `require toy/compute` (+ MRI-safety note + compile-less escape hatch); stale `Toy::Json` → `SpinelKit::Json::Builder`.

## Verified
`make gate-compute-surface` → builds + `compute-surface: ok` (live engine, non-null session).

## Remaining #42
`toy new --lib` scaffold — separate PR (a generator; larger surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)