### PR TITLE
fix(#42): toy/compute recipe-path clean (exclude lora, spinel-dev#11) + toy new --lib

### DIFF
--- a/docs/consuming-toy.md
+++ b/docs/consuming-toy.md
@@ -96,7 +96,13 @@ so `bin/toy` can require it; don't use `toy.rb` for the compute surface. If you
 build only one engine and want to compile less (Spinel has no tree-shaking),
 require that engine's file directly instead of `toy/compute`. The
 `gate-compute-surface` make target proves the one-require surface co-compiles +
-runs (`examples/smoke_compute_surface`).
+runs a from-scratch training step (`examples/smoke_compute_surface`).
+
+> One exception: `toy/compute` does **not** pull `recipes/lora` — loading it
+> uncalled trips a Spinel analyzer bug that poisons `cfg` to poly program-wide
+> ([spinel-dev#11](https://github.com/OriPekelman/spinel-dev/issues/11);
+> re-add tracked by toy#52). A consumer that trains LoRA requires
+> `toy/llm/recipes/lora` itself (and calls it, which pins the type).
 
 From here you write your experiment loop against
 `Toy::LLM::Engine::LlamaSeqEngine` / `Toy::LLM::Engine::ViTTinyEngine` /

--- a/examples/smoke_compute_surface.rb
+++ b/examples/smoke_compute_surface.rb
@@ -1,12 +1,15 @@
 # examples/smoke_compute_surface.rb — proves the toy#42 full-API require
 # (lib/toy/compute.rb) compiles under Spinel and yields a working compute
-# surface from ONE require.
+# surface from ONE require, via the RECIPE path.
 #
-# The BUILD step is itself the combined-surface gate: Spinel compiles every
-# file lib/toy/compute.rb pulls, so a clean build proves all three engines +
-# recipes + loaders co-compile in one program (the runners each load only one
-# engine — this is the only place the full surface is compiled together). The
-# RUN then realizes a tiny LlamaSeqEngine to prove the surface is live.
+# WHY THE RECIPE PATH (not just an engine). An earlier version drove the engine
+# directly (realize_for_random_init) and compiled even while a recipe-path
+# consumer did NOT — Spinel poly-degradation (OriPekelman/spinel-dev#11) only
+# bites once a recipe co-loads with the full surface. So this gate trains via
+# Toy::LLM::Recipes::FromScratch (realize! + step!), the exact shape the
+# `toy new --lib` scaffold and a real consumer use. The BUILD is the
+# combined-surface gate (every file compute.rb pulls co-compiles); the RUN
+# proves the surface is live.
 #
 #   make examples/smoke_compute_surface && ./examples/smoke_compute_surface
 #
@@ -14,21 +17,45 @@
 
 require_relative "../lib/toy/compute"
 
-cfg = Toy::SmolLM2Config.new(627, 64, 4, 4, 128, 2, 16, 10000.0, 1.0e-5)
+VOCAB   = 627
+CONTEXT = 16
+STEPS   = 5
 
-# One require gave us the whole composition API. Instantiate each engine class
-# (proves all three co-compiled + are addressable) and realize the Llama one
-# (proves the L1 primitives / L2 block / L3 arch the engine pulls are live).
+cfg = Toy::SmolLM2Config.new(VOCAB, 64, 4, 4, 128, 2, CONTEXT, 10000.0, 1.0e-5)
+
+# Engines co-compiled (instantiate all three — proves they're addressable from
+# the one require), then train via the L4 recipe.
 llama = Toy::LLM::Engine::LlamaSeqEngine.new
 vit   = Toy::LLM::Engine::ViTTinyEngine.new
 gpt2  = Toy::LLM::Engine::GPT2SeqEngine.new
 
-llama.realize_for_random_init(cfg, 16, 1, 0, false, false, 0, 1.0)
-ok = llama.sess != TinyNN.tnn_null_ptr
+recipe = Toy::LLM::Recipes::FromScratch.new
+recipe.realize!(cfg, CONTEXT, 1, 0, false, false, 0, 1.0)
 
-puts "compute-surface: engines=[llama,vit,gpt2] realized, sess_present=" + ok.to_s
-if ok
+seq_ids = [0]
+seq_ids.pop
+positions = [0]
+positions.pop
+i = 0
+while i < CONTEXT
+  seq_ids.push(i % VOCAB)
+  positions.push(i)
+  i = i + 1
+end
+
+m_labels = Toy::Labels.next_token(seq_ids, VOCAB, CONTEXT, 1)
+m_hp     = Toy::AdamW.new.hp(0)
+
+loss = 0.0
+step = 0
+while step < STEPS
+  loss = recipe.step!(seq_ids, positions, m_labels, m_hp, step == 0)
+  step = step + 1
+end
+
+puts "compute-surface: engines=[llama,vit,gpt2] + FromScratch recipe trained, final_loss=" + loss.to_s
+if loss.finite?
   puts "compute-surface: ok"
 else
-  puts "compute-surface: FAIL (realize produced null session)"
+  puts "compute-surface: FAIL (non-finite loss)"
 end

--- a/lib/toy/compute.rb
+++ b/lib/toy/compute.rb
@@ -43,10 +43,19 @@ require_relative "llm/engine/gpt2_seq_engine"
 # KV-cache decode engine (inference).
 require_relative "../toy_smollm2_ffi_kv"
 
-# Recipes — the named training/init compositions (from-scratch, LoRA,
-# warm-start, ViT). Realize-path orchestration over the engines.
+# Recipes — the named training/init compositions. Realize-path orchestration
+# over the engines.
+#
+# NOTE: `recipes/lora` is deliberately NOT required here. It triggers a Spinel
+# analyzer bug (OriPekelman/spinel-dev#11): LoRA#realize! is loaded but, for a
+# consumer using a different recipe, never called — so its unconstrained `cfg`
+# param widens to poly and poisons the SHARED LlamaSeqEngine#realize_for_mmap,
+# which cascades to SmolLM2Config accessors program-wide and fails the C
+# compile for any recipe-path consumer. RBS can't seed it (its FFI-pointer
+# params are `untyped`, which drops the whole sig). Every OTHER surface here is
+# clean. A consumer that actually trains LoRA requires `toy/llm/recipes/lora`
+# itself (and calls it, which pins cfg). Re-add this require once #11 lands.
 require_relative "llm/recipes/from_scratch"
-require_relative "llm/recipes/lora"
 require_relative "llm/recipes/warm_start"
 require_relative "llm/recipes/vit_tiny"
 

--- a/lib/toy/core/cli.rb
+++ b/lib/toy/core/cli.rb
@@ -39,7 +39,8 @@ module Toy
           class: New,
           summary: "Scaffold a conventional toy project tree",
           args:  [{ name: "path", required: true, desc: "target dir" }],
-          flags: [{ name: "--force", desc: "overwrite a non-empty dir" },
+          flags: [{ name: "--lib", desc: "scaffold a library-composition project (Gemfile + experiment.rb) instead of an app" },
+                  { name: "--force", desc: "overwrite a non-empty dir" },
                   { name: "--json", desc: "machine output" }]
         },
         "list" => {

--- a/lib/toy/core/cli/new.rb
+++ b/lib/toy/core/cli/new.rb
@@ -139,10 +139,110 @@ module Toy
 
         ALGO_SUBDIRS = %w[primitives blocks archs recipes].freeze
 
+        # ---- `toy new --lib` : a library-COMPOSITION project ----
+        # Unlike the app scaffold (algos/ + toy.yml + the toy CLI), the --lib
+        # scaffold is a plain Spinel program that CONSUMES toy as a gem: a
+        # Gemfile pulls `toy` (+ `spinel_kit`), `spinel-compat vendor` builds it
+        # into vendor/, and experiment.rb requires the one-shot compute surface
+        # (toy#42). No toy.yml, no binstub — this is "compose models against
+        # toy's engines", the tao_transfer shape.
+
+        LIB_GEMFILE = <<~RUBY
+          source "https://rubygems.org"
+          ruby "3.2.3", engine: "spinel", engine_version: "0.0.0"
+
+          # toy ships its compute surface + native (ggml) build inputs; spinel_kit
+          # is toy's stdlib-surface dep (JSON/Git shims). `spinel-compat vendor`
+          # copies both into vendor/spinel/ and builds toy's archive there.
+          gem "toy"
+          gem "spinel_kit", "~> 0.1"
+        RUBY
+
+        # The starter program. Requires ONLY toy/compute (toy#42 full-API
+        # require) and trains a tiny Llama-shape model from scratch. Mirrors
+        # examples/smoke_compute_surface.rb's proven API. Spinel-clean: literal
+        # require_relative, no #{} interpolation, no kwargs.
+        LIB_EXPERIMENT = <<~'RUBY'
+          # experiment.rb — compose a model against toy's engines.
+          #
+          # ONE require pulls toy's whole compute surface (engines + recipes +
+          # loaders): vendor/spinel/toy/lib/toy/compute (toy#42). It resolves
+          # after `bundle lock && spinel-compat vendor`.
+          #
+          #   spinel experiment.rb -o experiment && ./experiment
+          require_relative "vendor/spinel/toy/lib/toy/compute"
+
+          VOCAB   = 627
+          D_MODEL = 64
+          HEADS   = 4
+          LAYERS  = 2
+          CONTEXT = 16
+          STEPS   = 20
+
+          cfg = Toy::SmolLM2Config.new(VOCAB, D_MODEL, HEADS, HEADS, 128,
+                                       LAYERS, CONTEXT, 10000.0, 1.0e-5)
+
+          # The L4 recipe drives the engine. weight_dtype=0 (f32), B=1, seed=0.
+          recipe = Toy::LLM::Recipes::FromScratch.new
+          recipe.realize!(cfg, CONTEXT, 1, 0, false, false, 0, 1.0)
+
+          seq_ids = [0]
+          seq_ids.pop
+          positions = [0]
+          positions.pop
+          i = 0
+          while i < CONTEXT
+            seq_ids.push(i % VOCAB)
+            positions.push(i)
+            i = i + 1
+          end
+
+          m_labels = Toy::Labels.next_token(seq_ids, VOCAB, CONTEXT, 1)
+          m_hp     = Toy::AdamW.new.hp(0)
+
+          step = 0
+          while step < STEPS
+            loss = recipe.step!(seq_ids, positions, m_labels, m_hp, step == 0)
+            puts "step " + (step + 1).to_s + ": loss=" + loss.to_s
+            step = step + 1
+          end
+          puts "experiment: ok"
+        RUBY
+
+        LIB_README = <<~MARKDOWN
+          # toy library-composition project
+
+          A Spinel program that composes a model against toy's engines.
+
+          ## Build & run
+          ```sh
+          bundle lock              # resolve toy + spinel_kit
+          spinel-compat vendor     # copy + build toy into vendor/spinel/
+          spinel experiment.rb -o experiment && ./experiment
+          ```
+
+          > Until `toy` is published to RubyGems, point the Gemfile at a
+          > checkout: `gem "toy", path: "../toy"` (or `git:`), then `bundle lock`.
+
+          `experiment.rb` requires `vendor/spinel/toy/lib/toy/compute` — toy's
+          one-shot compute surface (all engines + recipes + loaders). Write your
+          experiment loop against `Toy::LLM::Engine::LlamaSeqEngine` /
+          `ViTTinyEngine` / `GPT2SeqEngine` and the L4 recipes. See toy's
+          `docs/consuming-toy.md`.
+        MARKDOWN
+
+        LIB_GITIGNORE = <<~GITIGNORE
+          /vendor/
+          /experiment
+          *.o
+          *.a
+        GITIGNORE
+
         def initialize(argv)
           @argv = argv
           @json = false
           @force = false
+          @lib = false
           @path = nil
         end
 
@@ -154,14 +254,22 @@ module Toy
             return fail_out("target #{target.inspect} exists and is not empty (use --force)")
           end
 
-          created = scaffold(target)
+          created = @lib ? scaffold_lib(target) : scaffold(target)
 
           if @json
             puts JSON.pretty_generate(
               "format" => "toy/new-v1",
+              "kind" => @lib ? "lib" : "app",
               "path" => target,
               "created" => created
             )
+          elsif @lib
+            puts "Created toy library-composition project at #{target}"
+            created.each { |rel| puts "  #{rel}" }
+            puts ""
+            puts "Next: cd #{@path}"
+            puts "      bundle lock && spinel-compat vendor   # fetch + build toy into vendor/"
+            puts "      spinel experiment.rb -o experiment && ./experiment"
           else
             puts "Created toy project at #{target}"
             created.each { |rel| puts "  #{rel}" }
@@ -183,6 +291,7 @@ module Toy
             case tok
             when "--json"  then @json = true
             when "--force" then @force = true
+            when "--lib"   then @lib = true
             when /\A-/
               $stderr.puts "toy new: unknown flag #{tok.inspect}"
               return false
@@ -238,6 +347,24 @@ module Toy
           write_file(binstub, BINSTUB)
           File.chmod(0o755, binstub)
           created << "bin/toy"
+
+          created
+        end
+
+        # `toy new --lib <path>` — a library-composition project (Gemfile +
+        # starter experiment.rb against toy/compute). Returns created paths.
+        def scaffold_lib(target)
+          created = []
+          FileUtils.mkdir_p(target)
+
+          write_file(File.join(target, "Gemfile"), LIB_GEMFILE)
+          created << "Gemfile"
+          write_file(File.join(target, "experiment.rb"), LIB_EXPERIMENT)
+          created << "experiment.rb"
+          write_file(File.join(target, "README.md"), LIB_README)
+          created << "README.md"
+          write_file(File.join(target, ".gitignore"), LIB_GITIGNORE)
+          created << ".gitignore"
 
           created
         end


### PR DESCRIPTION
Two fixes on top of the merged `toy/compute` (PR #50), + the second half of #42.

## 1. Recipe-path correctness (the real validation)
PR #50's smoke drove the **engine** directly and compiled — but a **recipe-path** consumer (the common case, and what `toy new --lib` generates) did **not**: loading `recipes/lora` uncalled trips a Spinel analyzer bug — `LoRA#realize!` is compiled but never called, so its unconstrained `cfg` widens to **poly**, poisoning the shared `realize_for_mmap` and cascading to `SmolLM2Config` accessors program-wide → C compile fails.

- **`lib/toy/compute.rb`** no longer requires `recipes/lora` — the **sole** poisoner (bisected; every other surface is clean). LoRA consumers require it directly + call it (which pins `cfg`). Root cause + 31-line repro: **spinel-dev#11**; re-add tracked by **#52**.
- **`examples/smoke_compute_surface`** now trains via `Toy::LLM::Recipes::FromScratch` (`realize!` + `step!`) — the exact recipe path consumers use, so `gate-compute-surface` catches this class (the engine path didn't).
- **docs/consuming-toy.md** — notes the exclusion + links.

## 2. `toy new --lib` (#42 second half)
Scaffolds a library-composition project: `Gemfile` (`gem "toy"` + `spinel_kit`), a starter `experiment.rb` requiring `toy/compute` and training via `FromScratch`, `README`, `.gitignore`. `cli.rb` registers the `--lib` flag; `new.rb` adds `scaffold_lib` + templates. `experiment.rb` uses from_scratch → compiles via the now-recipe-clean `toy/compute`. README notes the path-dep interim until toy publishes.

## Verified
`gate-compute-surface` (recipe path) PASS; `toy new --lib` produces the 4 files; a full **consumer vendor (path-dep) + Spinel compile** reproduced the bug, then confirmed clean after the exclusion.

Closes the actionable half of #42 (full-API require + scaffold). LoRA re-integration tracked by #52 (gated on spinel-dev#11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)