### PR TITLE
toy#45 Phase 2+3: real-consumer proof, staged CUDA/Metal build-units (CUDA byte-exact on GB10), gem-build ready

### DIFF
--- a/docs/consuming-toy.md
+++ b/docs/consuming-toy.md
@@ -8,50 +8,19 @@ into toy's tree.
 > Not what you want? If you just want to **run** models (infer / train / eval /
 > serve a GGUF), use the `toy` **CLI** — `toy new`, `toy infer model.gguf`, … —
 > which is clean and self-contained. See [`cli.md`](cli.md). This doc is the
-> *library-composition* surface, which is a different (and, today, rougher) path.
+> *library-composition* surface.
 
-## Status: transitional — the current recipe works, but it's rougher than it should be
+## The recipe (toy#45: Gemfile + vendor — that's it)
 
-The honest state of play: the recipe below **works** and is what `tao_transfer`
-uses, but it's more brittle and contrived than consuming a normal gem — a copied
-post-vendor hook, absolute paths into toy's checkout, a manifest "canary", and
-manual `require_relative`s. All of that traces to **one root cause**: toy doesn't
-yet own its native-extension build the way [tep](https://rubygems.org/gems/tep)
-does (toy ships no `spinel-ext.json`, so the vendor step can't build/link toy's
-native archive into your tree). The cleanup is tracked across three repos —
-see [The target, and how we get there](#the-target-and-how-we-get-there).
-
-## The target (where this is going)
+Toy ships `spinel-ext.json` **build-units** (spinelgems#14): `spinel-compat
+vendor` copies toy's `lib/`, then builds ggml + the tinynn shim archive
+**inside your vendor tree**, and wires *project-relative* `-L` flags into the
+vendored Ruby. Self-contained and relocatable — no post-vendor hook, no
+absolute paths into toy's checkout, no canary. (`toy new --lib` scaffolds all
+of this for you.)
 
 ```sh
-# Gemfile:  gem "toy", "~> X"        # published to RubyGems, like tep
-bundle lock
-spinel-compat vendor                 # copies lib/ AND builds toy's native archive
-                                     #   INTO vendor/, wiring relative link paths
-# experiment.rb:
-#   require_relative "vendor/spinel/deps"   # pulls the full Toy compute surface
-spinel experiment.rb -o experiment
-./experiment
-```
-
-Three steps, no post-vendor hook, no absolute paths into toy's checkout, no
-manifest canary, no `require_relative` soup. That's the bar: as friendly as the
-CLI.
-
-## The current recipe (works today)
-
-### Prereqs (one-time)
-- A toy checkout (e.g. `~/sites/toy`) with `make tinynn/libtinynn_ggml.a` already
-  run (so the `.a` the consumer links against exists). For CUDA/Metal,
-  `make setup-ggml-cuda` / `setup-ggml-metal`.
-- Ruby ≥ 3.2 on the consumer side (`bundle lock` resolves under CRuby).
-- Bundler (`gem install --user-install bundler`).
-- A [spinelgems](https://github.com/OriPekelman/spinelgems) checkout at
-  `~/sites/spinelgems` (the vendor tool), or set `SPINEL_DIR=…`.
-
-### The five steps
-```sh
-# 1. Declare toy as a path: gem (a published gem is the target; see above).
+# 1. Gemfile (path: for a checkout today; plain `gem "toy"` once published)
 cat > Gemfile <<'EOF'
 source "https://rubygems.org"
 ruby "3.2.3", engine: "spinel", engine_version: "0.0.0"
@@ -59,23 +28,32 @@ ruby "3.2.3", engine: "spinel", engine_version: "0.0.0"
 gem "toy", path: "../toy"
 EOF
 
-# 2. Resolve.
+# 2. Resolve (CRuby + Bundler).
 bundle lock
 
-# 3. Vendor — copies toy/lib/*.rb into vendor/spinel/toy/lib/ + writes
-#    vendor/spinel/deps.rb (which requires vendor/spinel/toy/lib/toy.rb).
+# 3. Vendor — copies lib/ AND builds toy's native archives INTO vendor/
+#    (ggml via its cmake build-unit + vendor-patches, tinynn via make).
 SPINEL_DIR=~/sites/spinel ~/sites/spinelgems/exe/spinel-compat vendor
 
-# 4. (THE CONTRIVED STEP — tracked for removal, toy#42) Rewrite link paths:
-#    turns toy's relative -L flags into absolute paths anchored at TOY_SRC.
-#    Copy the hook template from toy's prep/ into your own prep/:
-# (nothing else — spinel-ext.json build-units build ggml + the tinynn
-# archive inside vendor/spinel/toy/ during `spinel-compat vendor`; toy#45)
-
-# 5. Compile.
+# 4. Compile from the project root (the -L flags are project-relative).
 spinel experiment.rb -o experiment
 ./experiment
 ```
+
+After step 3 you should see, with **zero absolute paths** into toy's checkout:
+
+```
+vendor/spinel/toy/lib/…                              # the primitives
+vendor/spinel/toy/tinynn/libtinynn_ggml.a            # the shim archive
+vendor/spinel/toy/vendor/ggml/build/src/libggml*.a   # 3 CPU archives
+```
+
+and the vendored `lib/tinynn.rb` carries
+`-Lvendor/spinel/toy/tinynn -Lvendor/spinel/toy/vendor/ggml/build/src …`.
+You can move the whole project directory and recompile; it keeps working.
+If the vendor step warns that a placeholder matched **no** vendored `.rb`,
+toy's dev `ffi_cflags` line drifted from its manifest placeholder — that
+warning is systemic (spinelgems), not a per-gem canary; report it.
 
 A typical `experiment.rb`. One require — `toy/compute` (toy#42) — pulls the
 whole composition surface (all three engines + recipes + GGUF/tokenizer
@@ -84,10 +62,10 @@ loaders), so you no longer hand-`require_relative` each primitive:
 ```ruby
 require_relative "vendor/spinel/toy/lib/toy/compute"   # the full compute API
 
-cfg    = Toy::SmolLM2Config.new(627, 64, 4, 4, 128, 2, 32, 10000.0, 1.0e-5)
-engine = Toy::LLM::Engine::LlamaSeqEngine.new
-engine.realize_for_random_init(cfg, 32, 1, 0, false, false, 0, 1.0)
-# … build_training_step, upload, compute, …
+cfg    = Toy::SmolLM2Config.mha(627, 64, 4, 128, 2, 32, 10000.0, 1.0e-5)
+recipe = Toy::LLM::Recipes::FromScratch.new
+recipe.realize!(cfg, 32, 1, 0, false, false, 0, 1.0)
+# … Toy::Labels.next_token, Toy::AdamW.new.hp(0), recipe.step!, …
 ```
 
 `toy/compute` is the **Spinel-only** entry — it pulls `tinynn` (FFI) and the
@@ -110,35 +88,27 @@ From here you write your experiment loop against
 worked example. To emit Tao-consumable telemetry, see [`events.md`](events.md)
 (and `SpinelKit::Json::Builder` / `Toy::Events.add_provenance` for building it).
 
-### Env knobs (`prep/post_vendor_toy.rb`)
-| Env | Purpose |
-| --- | --- |
-| `TOY_SRC=…` | Absolute path to toy's checkout. Default `~/sites/toy`. The `-L` rewrites anchor here. |
-| `TOY_DISABLE=cuda,metal` | Skip rewriting backend files you don't compile. CPU always rewritten. |
-| `CUDA_DIR_LIB=…` | Override the absolute CUDA libdir baked into `tinynn_cuda.rb`. Default `/usr/local/cuda/lib64`. |
-
-### What gets vendored, what doesn't
-`spinel-compat vendor` copies the gem's `lib/` verbatim into
-`vendor/spinel/toy/lib/`. It does **not** copy `vendor/ggml/build/` (6 MB),
-`data/`/weights, or `tinynn/libtinynn_ggml.a` — those are referenced by the
-absolute paths step 4 writes (pointing into toy's own tree). **This is the
-brittleness:** delete toy's checkout and your consumer breaks. Re-run the
-workflow against a fresh toy checkout to repoint. (The fix — build the archive
-*into your vendor tree* — is spinelgems#14 + toy#42.)
-
 ### Updating when toy moves
-Re-run steps 2–4:
-```sh
-bundle lock
-SPINEL_DIR=~/sites/spinel ~/sites/spinelgems/exe/spinel-compat vendor
-./prep/post_vendor_toy.rb
-spinel experiment.rb -o experiment
-```
-If toy's `lib/tinynn.rb` changes its literal `ffi_cflags`, `post_vendor_toy.rb`
-warns that no substitution matched — that means `lib/toy/ffi_manifest.rb`'s
-`CURRENT_FFI_CFLAGS` is out of sync with the source; bump both in one toy commit.
-The warning is the canary; honor it. (This canary, too, disappears once toy owns
-its ext wiring — toy#42.)
+
+Re-run `bundle lock` → `spinel-compat vendor` → recompile. The vendor step
+rebuilds the native units in your tree (a `path:` dev checkout that is already
+patched is detected; patches are not re-applied).
+
+### CUDA / Metal (opt-in; staged)
+
+The GPU backends are authored as **default-disabled** build-units in
+`spinel-ext-gpu.json` (CUDA validated on gx10; Metal structural,
+Mac-validation-pending — toy#27). They stay staged until spinelgems grows the
+opt-in + variant-build-dir mechanics —
+[spinelgems#20](https://github.com/OriPekelman/spinelgems/issues/20). Until
+then, a CUDA consumer replicates what the staged entries declare: configure
+ggml's `build-cuda/` with the entry's cmake args inside
+`vendor/spinel/toy/vendor/ggml/`, `make -C vendor/spinel/toy/tinynn cuda`, and
+substitute the `lib/tinynn_cuda.rb` placeholder with the vendored-relative
+`-L` set (see the `link` template in `spinel-ext-gpu.json`). CUDA compiles
+need `spinel --cc='cc -Wl,-u,tnn_cuda_force_link' …` — without the force-link
+symbol the linker drops the CUDA backend registration and ggml silently
+computes on CPU (verified: the loss curve flips to the CPU fixture).
 
 ## The `sp_Mat undeclared` landmine
 
@@ -153,22 +123,17 @@ deeper root of *why* vendoring has to exist — filed as **matz/spinel#1367**.
 toy's `make gate-poly-degrade` guards regressions of the related emit-0 class but
 not this root.
 
-## The target, and how we get there
+## History
 
-Everything brittle above is a workaround for one gap — **toy doesn't own its
-native-ext wiring like tep does**. The cleanup, tracked across three repos:
-
-| Repo | Issue | What it unblocks |
-| --- | --- | --- |
-| spinelgems | **#14** | a native **build-step** in `spinel-ext.json` (build + link archives *into* the vendor tree), not just per-`.c` placeholder substitution — toy's ggml CMake build needs this. **The keystone.** |
-| toy | **#42** | author `spinel-ext.json` (→ retire `post_vendor_toy.rb` + the `ffi_manifest` canary); a Spinel-only full-API `require`; **publish to RubyGems**; `toy new --lib` scaffold. Depends on #14. |
-| matz/spinel | **#1367** | stable package identity so a user class (`Mat`) types the same regardless of require path — removes the layout-sensitivity the vendored layout works around. |
-
-When #14 + #42 land, this doc collapses to the three-step
-[target](#the-target-where-this-is-going) above.
+The pre-#45 flow needed a per-consumer post-vendor hook (`post_vendor_toy.rb`)
+that rewrote vendored `-L` flags to **absolute paths into toy's checkout**,
+plus a `CURRENT_FFI_CFLAGS` canary in `lib/toy/ffi_manifest.rb`. Both are
+retired: the hook by the build-units above, the canary by the vendor step's
+zero-substitution warning. Consumers still carrying the hook: delete it and
+re-vendor (tao_transfer: see OriPekelman/tao#8).
 
 ## See also
 - [`cli.md`](cli.md) — the friendly *app* surface (run models without any of this).
 - [`events.md`](events.md) — the `toy/v1` event contract your consumer can emit.
 - [`dependencies.md`](dependencies.md) — how toy itself consumes tep (the model toy is following).
-- toy#19 (the original "no Mat landmine" work), tep#97, spinelgems#3 — the issue trail.
+- toy#19 / toy#42 / toy#45, tep#97, spinelgems#3 / #14 / #20 — the issue trail.

--- a/lib/tinynn.rb
+++ b/lib/tinynn.rb
@@ -351,7 +351,11 @@ module TinyNN
   # which this CPU bridge can't add. `make setup` on macOS now
   # builds BOTH build/ (CPU) and build-metal/ (Metal), so CPU
   # examples find what they need without a fallback.
-  ffi_cflags "-L. -Ltinynn -Lvendor/ggml/build/src -Lvendor/ggml/build/src/ggml-cpu -Wno-int-conversion"
+  # NOTE: this literal line doubles as the spinel-ext.json "tinynn"
+  # placeholder (toy#45) — change them in lockstep, or the vendor step's
+  # zero-substitution warning fires. Fresh ggml (GGML_REV 41e7949) puts
+  # all three archives at build/src/ — no ggml-cpu/ subdir -L needed.
+  ffi_cflags "-L. -Ltinynn -Lvendor/ggml/build/src -Wno-int-conversion"
 
   ffi_func :tnn_session_new,      [:int],                   :ptr
   # GH#3 — multi-GPU mode 1. tnn_session_new_on(kind, device) pins

--- a/lib/tinynn_cuda.rb
+++ b/lib/tinynn_cuda.rb
@@ -90,7 +90,11 @@ module TinyNNCuda
   ffi_lib "rt"
   ffi_lib "dl"
 
-  ffi_cflags "-L. -Ltinynn -Lvendor/ggml/build-cuda/src -Lvendor/ggml/build-cuda/src/ggml-cpu -Lvendor/ggml/build-cuda/src/ggml-cuda -L/usr/local/cuda/lib64 -Wno-int-conversion"
+  # NOTE: this literal line doubles as the spinel-ext-gpu.json "tinynn-cuda"
+  # placeholder (toy#45 Phase 3, staged) — change them in lockstep. Fresh
+  # ggml (GGML_REV 41e7949) puts the CPU archives at build-cuda/src/ — the
+  # only subdir archive is ggml-cuda/libggml-cuda.a.
+  ffi_cflags "-L. -Ltinynn -Lvendor/ggml/build-cuda/src -Lvendor/ggml/build-cuda/src/ggml-cuda -L/usr/local/cuda/lib64 -Wno-int-conversion"
 
   ffi_func :tnn_session_new,      [:int],                   :ptr
   # GH#3 — multi-GPU mode 1 device-aware session ctor.

--- a/lib/toy/ffi_manifest.rb
+++ b/lib/toy/ffi_manifest.rb
@@ -32,8 +32,7 @@ module Toy
         ld_paths: [
           ".",                                   # toy root (libtinynn_ggml.a is in tinynn/ — kept for legacy compat)
           "tinynn",                              # libtinynn_ggml.a
-          "vendor/ggml/build/src",               # libggml.a, libggml-base.a
-          "vendor/ggml/build/src/ggml-cpu",      # libggml-cpu.a
+          "vendor/ggml/build/src",               # libggml.a, libggml-base.a, libggml-cpu.a
         ],
         # Trailing flags that go after the -L paths.
         tail: "-Wno-int-conversion",
@@ -44,7 +43,6 @@ module Toy
           ".",
           "tinynn",
           "vendor/ggml/build-cuda/src",
-          "vendor/ggml/build-cuda/src/ggml-cpu",
           "vendor/ggml/build-cuda/src/ggml-cuda",
         ],
         # CUDA libdir is system-absolute, NOT relative to TOY_SRC.

--- a/lib/toy/io/gguf_kv.rb
+++ b/lib/toy/io/gguf_kv.rb
@@ -19,7 +19,10 @@ module GgufKV
   ffi_lib "pthread"
   ffi_lib "m"
 
-  ffi_cflags "-L. -Ltinynn -Lvendor/ggml/build/src -Lvendor/ggml/build/src/ggml-cpu -Wno-int-conversion"
+  # Keep BYTE-IDENTICAL to lib/tinynn.rb's line — it doubles as the
+  # spinel-ext.json "tinynn" placeholder (toy#45) and the vendor step
+  # substitutes every vendored .rb carrying it.
+  ffi_cflags "-L. -Ltinynn -Lvendor/ggml/build/src -Wno-int-conversion"
 
   ffi_func :tnn_gguf_load,     [:str],            :ptr
   ffi_func :tnn_gguf_free,     [:ptr],            :void

--- a/spinel-ext-gpu.json
+++ b/spinel-ext-gpu.json
@@ -1,0 +1,96 @@
+[
+  {
+    "_comment": [
+      "STAGED build-unit entries for the optional GPU backends (toy#45 Phase 3).",
+      "NOT read by spinel-compat (it reads spinel-ext.json only). Staged because",
+      "the current Vendorer would process these destructively: (a) optional: true",
+      "is opt-OUT only — a default `vendor` would attempt the CUDA/Metal build on",
+      "every box; (b) build-units rm_rf-recopy their `dir` per entry and hardcode",
+      "the cmake build dir to build/ — a second ggml entry would wipe and then",
+      "collide with the CPU unit's archives. Both fixes are proposed upstream as",
+      "OriPekelman/spinelgems#20 (`default: disabled` + SPINEL_EXT_ENABLE opt-in;",
+      "`build_dir` + copy-once shared source dirs). Merge these entries into",
+      "spinel-ext.json once that lands.",
+      "CUDA entries: validated end-to-end on gx10 (GB10 sm_121, CUDA 13.0) —",
+      "vendored-tree build + link + train run (see toy#45).",
+      "Metal entries: STRUCTURAL ONLY, Mac-validation-pending (toy#27). The",
+      "artifact list mirrors the root Makefile's build-metal sentinel; archive",
+      "subdir layout and the placeholder line are unverified on macOS.",
+      "CMAKE_CUDA_ARCHITECTURES=121 mirrors the dev Makefile's GGML_CUDA_ARCH",
+      "default (GB10); consumers on other GPUs override via the",
+      "SPINEL_EXT_<PLACEHOLDER> full-replacement escape hatch.",
+      "CMAKE_CUDA_COMPILER is pinned because build-units run with the",
+      "consumer's bare env — no PATH prepend like the dev Makefile's",
+      "PATH=$(CUDA_DIR)/bin:$PATH; /usr/local/cuda is the toolkit's own",
+      "default symlink."
+    ]
+  },
+  {
+    "name": "cuda",
+    "optional": true,
+    "default": "disabled",
+    "build": {
+      "tool": "cmake",
+      "dir": "vendor/ggml",
+      "build_dir": "build-cuda",
+      "patches": ["vendor-patches/*.patch"],
+      "args": ["-DBUILD_SHARED_LIBS=OFF", "-DGGML_STATIC=ON",
+               "-DGGML_CUDA=ON", "-DGGML_METAL=OFF", "-DGGML_VULKAN=OFF",
+               "-DGGML_OPENCL=OFF", "-DGGML_BLAS=OFF", "-DGGML_OPENMP=OFF",
+               "-DGGML_ACCELERATE=OFF", "-DGGML_BUILD_EXAMPLES=OFF",
+               "-DGGML_BUILD_TESTS=OFF", "-DCMAKE_BUILD_TYPE=Release",
+               "-DCMAKE_POSITION_INDEPENDENT_CODE=ON",
+               "-DCMAKE_CUDA_ARCHITECTURES=121", "-DGGML_NATIVE=OFF",
+               "-DCMAKE_CUDA_COMPILER=/usr/local/cuda/bin/nvcc"],
+      "artifacts": ["build-cuda/src/libggml.a",
+                    "build-cuda/src/libggml-base.a",
+                    "build-cuda/src/libggml-cpu.a",
+                    "build-cuda/src/ggml-cuda/libggml-cuda.a"]
+    }
+  },
+  {
+    "name": "cuda-shim",
+    "optional": true,
+    "default": "disabled",
+    "build": { "tool": "make", "dir": "tinynn", "targets": ["cuda"],
+               "artifacts": ["libtinynn_ggml_cuda.a"] },
+    "placeholder": "-L. -Ltinynn -Lvendor/ggml/build-cuda/src -Lvendor/ggml/build-cuda/src/ggml-cuda -L/usr/local/cuda/lib64 -Wno-int-conversion",
+    "link": ["-L{dir}", "-L{dir:cuda}/build-cuda/src",
+             "-L{dir:cuda}/build-cuda/src/ggml-cuda",
+             "-L/usr/local/cuda/lib64", "-Wno-int-conversion"]
+  },
+  {
+    "name": "metal",
+    "optional": true,
+    "default": "disabled",
+    "build": {
+      "tool": "cmake",
+      "dir": "vendor/ggml",
+      "build_dir": "build-metal",
+      "patches": ["vendor-patches/*.patch"],
+      "args": ["-DBUILD_SHARED_LIBS=OFF", "-DGGML_STATIC=ON",
+               "-DGGML_CUDA=OFF", "-DGGML_METAL=ON",
+               "-DGGML_METAL_EMBED_LIBRARY=ON",
+               "-DGGML_VULKAN=OFF", "-DGGML_OPENCL=OFF", "-DGGML_BLAS=OFF",
+               "-DGGML_OPENMP=OFF", "-DGGML_ACCELERATE=OFF",
+               "-DGGML_BUILD_EXAMPLES=OFF", "-DGGML_BUILD_TESTS=OFF",
+               "-DCMAKE_BUILD_TYPE=Release",
+               "-DCMAKE_POSITION_INDEPENDENT_CODE=ON"],
+      "artifacts": ["build-metal/src/libggml.a",
+                    "build-metal/src/libggml-base.a"]
+    }
+  },
+  {
+    "name": "metal-shim",
+    "optional": true,
+    "default": "disabled",
+    "build": { "tool": "make", "dir": "tinynn", "targets": ["metal"],
+               "artifacts": ["libtinynn_ggml_metal.a"] },
+    "placeholder": "-L. -Ltinynn -Lvendor/ggml/build-metal/src -Lvendor/ggml/build-metal/src/ggml-cpu -Lvendor/ggml/build-metal/src/ggml-metal -Wno-int-conversion -framework Foundation -framework Metal -framework MetalKit",
+    "link": ["-L{dir}", "-L{dir:metal}/build-metal/src",
+             "-L{dir:metal}/build-metal/src/ggml-metal",
+             "-Wno-int-conversion",
+             "-framework", "Foundation", "-framework", "Metal",
+             "-framework", "MetalKit"]
+  }
+]

--- a/spinel-ext.json
+++ b/spinel-ext.json
@@ -19,7 +19,7 @@
   {
     "name": "tinynn",
     "build": { "tool": "make", "dir": "tinynn", "artifacts": ["libtinynn_ggml.a"] },
-    "placeholder": "-L. -Ltinynn -Lvendor/ggml/build/src -Lvendor/ggml/build/src/ggml-cpu -Wno-int-conversion",
+    "placeholder": "-L. -Ltinynn -Lvendor/ggml/build/src -Wno-int-conversion",
     "link": ["-L{dir}", "-L{dir:ggml}/build/src", "-Wno-int-conversion"]
   }
 ]

--- a/tinynn/Makefile
+++ b/tinynn/Makefile
@@ -2,14 +2,39 @@
 # "tinynn" build-unit (toy#45): `make -C tinynn` inside a consumer's vendor
 # tree, where ../vendor/ggml is the vendored (patched) ggml. The root Makefile
 # keeps its own copies of these rules for the dev flow; keep both in sync.
-CC      ?= cc
-CFLAGS  ?= -O2 -fPIC -Wall -Wextra
+CC       ?= cc
+CFLAGS   ?= -O2 -fPIC -Wall -Wextra
 GGML_INC := -I../vendor/ggml/include -I../vendor/ggml/src
+CUDA_DIR ?= /usr/local/cuda
 
 OBJS := tinynn_ggml.o tinynn_gguf.o tinynn_trace.o tinynn_events.o
 
 libtinynn_ggml.a: $(OBJS)
 	ar rcs $@ $(OBJS)
+
+# Optional backend shims (toy#45 Phase 3). NOT in the default target —
+# they are separate build-unit targets ("targets": ["cuda"] / ["metal"]
+# in the staged spinel-ext-gpu.json entries), opt-in per spinelgems#20.
+cuda: libtinynn_ggml_cuda.a
+.PHONY: cuda
+
+libtinynn_ggml_cuda.a: tinynn_backend_cuda.o
+	ar rcs $@ $<
+
+tinynn_backend_cuda.o: tinynn_backend_cuda.c
+	$(CC) $(CFLAGS) $(GGML_INC) -I$(CUDA_DIR)/include -c $< -o $@
+
+# Metal (macOS-only; Mac-validation-pending — toy#27). Mirrors the root
+# Makefile's rule: ObjC compile, no ARC objects, frameworks come in at
+# the consumer's link line.
+metal: libtinynn_ggml_metal.a
+.PHONY: metal
+
+libtinynn_ggml_metal.a: tinynn_backend_metal.o
+	ar rcs $@ $<
+
+tinynn_backend_metal.o: tinynn_backend_metal.m
+	$(CC) $(CFLAGS) -x objective-c $(GGML_INC) -c $< -o $@
 
 tinynn_ggml.o: tinynn_ggml.c tinynn_ggml.h tinynn_trace.h
 	$(CC) $(CFLAGS) $(GGML_INC) -c $< -o $@
@@ -24,5 +49,7 @@ tinynn_events.o: tinynn_events.c tinynn_events.h
 	$(CC) $(CFLAGS) -c $< -o $@
 
 clean:
-	rm -f $(OBJS) libtinynn_ggml.a
+	rm -f $(OBJS) libtinynn_ggml.a \
+	      tinynn_backend_cuda.o libtinynn_ggml_cuda.a \
+	      tinynn_backend_metal.o libtinynn_ggml_metal.a
 .PHONY: clean

--- a/tinynn/smoke.rb
+++ b/tinynn/smoke.rb
@@ -20,7 +20,7 @@ module TinyNN
 
   # Library search paths injected by Makefile via SPINEL_FFI_CFLAGS.
   # Default fallback works for the in-tree build.
-  ffi_cflags "-L. -Ltinynn -Lvendor/ggml/build/src -Lvendor/ggml/build/src/ggml-cpu"
+  ffi_cflags "-L. -Ltinynn -Lvendor/ggml/build/src"
 
   ffi_func :tnn_session_new,      [:int],                   :ptr
   ffi_func :tnn_session_free,     [:ptr],                   :void

--- a/tinynn/tinynn_ggml.c
+++ b/tinynn/tinynn_ggml.c
@@ -147,6 +147,18 @@ static tnn_engine *tnn_engine_get_on(int backend_kind, int device)
         if (e->backend) e->backend_name = "metal";
     }
     if (!e->backend) {
+        /* Fail loud on the GPU→CPU fallback: a consumer that asked for
+         * CUDA/Metal but didn't link the backend archive (e.g. missing
+         * -Wl,-u,tnn_cuda_force_link) would otherwise silently compute
+         * on CPU — the loss curve flips with no other symptom. */
+        if (backend_kind == 1 || backend_kind == 2) {
+            fprintf(stderr,
+                    "[tnn] WARNING: %s backend requested but not linked into "
+                    "this binary (init returned NULL) — falling back to CPU. "
+                    "CUDA consumers must link with "
+                    "-Wl,-u,tnn_cuda_force_link; see docs/consuming-toy.md.\n",
+                    backend_kind == 1 ? "CUDA" : "Metal");
+        }
         e->backend = ggml_backend_init_by_type(GGML_BACKEND_DEVICE_TYPE_CPU, NULL);
         e->backend_name = "cpu";
     }

--- a/toy.gemspec
+++ b/toy.gemspec
@@ -71,6 +71,10 @@ Gem::Specification.new do |s|
     # spinel-ext.json build-units (toy#45): consumers' `spinel-compat vendor`
     # builds ggml + the tinynn archive INSIDE their vendor tree.
     "spinel-ext.json",
+    # spinel-ext-gpu.json: STAGED default-disabled CUDA/Metal build-unit
+    # entries (inert until spinelgems#20; shipped for transparency + the
+    # manual CUDA recipe in docs/consuming-toy.md).
+    "spinel-ext-gpu.json",
     "tinynn/Makefile",
     # Pristine pinned ggml source (GGML_REV), shipped IN the gem so vendoring
     # is hermetic (nokogiri-vendoring-libxml2 precedent). It is NOT in toy's


### PR DESCRIPTION
toy#45 remaining work: Phase 2 against the **real** tao_transfer consumer + Phase 3 (CUDA/Metal optional build-units) + gem-build readiness. Toolchain for everything here: clean spinel @ **08a189c** (`/tmp/spinel-08a189c-toy45`), ggml @ pinned 41e7949.

## Phase 2 — real tao_transfer consumer (proven)

Scratch copy of `~/sites/tao_transfer` (sibling, read-only) with `gem "toy", path: <this branch>`:

- `bundle lock` → `spinel-compat vendor`: self-contained tree — `vendor/spinel/toy/vendor/ggml/build/src/libggml{,-base,-cpu}.a` + `vendor/spinel/toy/tinynn/libtinynn_ggml.a`, vendored `ffi_cflags` project-relative, **zero absolute references** into the checkout.
- Ported `experiments/train_from_scratch.rb` to toy@0.7 (`toy/compute` one-require + `Recipes::FromScratch`): compiles, trains (6.483 → 5.657 @ 10 steps).
- **Relocatable:** moved the whole project dir, recompiled, ran.
- tao_transfer's own tree needs the readapt (pre-rename requires + retiring its hook): exact patch filed as **OriPekelman/tao#8** (no sibling commits).

## Phase 3 — CUDA validated, Metal structural, opt-in upstream

- **spinelgems#20** filed: `default: "disabled"` + `SPINEL_EXT_ENABLE` opt-in, and `build_dir` + copy-once shared source dirs. Both are required before GPU entries can live in `spinel-ext.json` (today's Vendorer would rm_rf/collide the CPU unit — staged as `spinel-ext-gpu.json` with the rationale inline).
- **CUDA validated on this GB10** inside the consumer's vendored tree, replicating exactly what the staged entries declare: staged cmake args → all 4 declared artifacts; `make -C tinynn cuda` → shim archive; placeholder substituted per the `link` template; vendored `lib/toy/run/train_cuda.rb` compiled with `--cc='cc -Wl,-u,tnn_cuda_force_link'` and reproduced `prep/fixtures/train_cuda_baseline.txt` **byte-for-byte**.
- Found + pinned along the way: without the force-link symbol the CUDA backend silently drops and the curve flips to the CPU fixture — documented; and build-units run with a bare env, so the staged entry pins `-DCMAKE_CUDA_COMPILER=/usr/local/cuda/bin/nvcc` (no PATH prepend like the dev Makefile).
- **Metal entries:** structural mirror of the Makefile's build-metal configure; explicitly Mac-validation-pending (toy#27). Not claimed verified.
- Cleanup from the last issue comment: the vestigial `build*/src/ggml-cpu` `-L`s removed from all dev lines (`tinynn.rb`, `tinynn_cuda.rb`, `smoke.rb`, `gguf_kv.rb` — the last one substitutes off the SAME placeholder, now noted inline) + `ffi_manifest` tables synced.

## Gates (all with SPINEL_DIR=/tmp/spinel-08a189c-toy45)

- `gate-compute-surface` PASS
- `gate-gpt2` PASS (CE curve byte-identical)
- `gate-train-cuda` PASS (from-scratch + warm-start + lora, byte-identical)
- `infer_gate` PASS (cpu + cuda arms, byte-exact)
- `eval_gate` **pre-existing FAIL at base e82e5d6 with spinel 08a189c** (runner aborts in `tnn_upload_from_int_array`); same source compiles green with f6d5eef. Spinel regression in f6d5eef..08a189c — bisect running, being filed on spinel-dev. Unrelated to this branch (reproduced on pristine base).

## gem build — READY, not pushed

`make gem-prep` + `gem build toy.gemspec`: 3.4 MB, 2073 files, pristine pinned ggml 41e7949 source, no build dirs / archives / models. `gem push` awaits explicit go-ahead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
