### PR TITLE
feat(#52): re-add recipes/lora to toy/compute (blocked: matz/spinel#1385 merge)

### DIFF
--- a/docs/consuming-toy.md
+++ b/docs/consuming-toy.md
@@ -96,13 +96,11 @@ so `bin/toy` can require it; don't use `toy.rb` for the compute surface. If you
 build only one engine and want to compile less (Spinel has no tree-shaking),
 require that engine's file directly instead of `toy/compute`. The
 `gate-compute-surface` make target proves the one-require surface co-compiles +
-runs a from-scratch training step (`examples/smoke_compute_surface`).
-
-> One exception: `toy/compute` does **not** pull `recipes/lora` — loading it
-> uncalled trips a Spinel analyzer bug that poisons `cfg` to poly program-wide
-> ([spinel-dev#11](https://github.com/OriPekelman/spinel-dev/issues/11);
-> re-add tracked by toy#52). A consumer that trains LoRA requires
-> `toy/llm/recipes/lora` itself (and calls it, which pins the type).
+runs a from-scratch training step (`examples/smoke_compute_surface`), with
+`recipes/lora` co-loaded uncalled — historically the poisoning shape
+([spinel-dev#11](https://github.com/OriPekelman/spinel-dev/issues/11) /
+[spinel-dev#12](https://github.com/OriPekelman/spinel-dev/issues/12), fixed
+upstream; re-added by toy#52).
 
 From here you write your experiment loop against
 `Toy::LLM::Engine::LlamaSeqEngine` / `Toy::LLM::Engine::ViTTinyEngine` /

--- a/examples/smoke_compute_surface.rb
+++ b/examples/smoke_compute_surface.rb
@@ -11,6 +11,17 @@
 # combined-surface gate (every file compute.rb pulls co-compiles); the RUN
 # proves the surface is live.
 #
+# WHY LoRA IS INSTANTIATED BUT NOT TRAINED (toy#52). `recipes/lora` is the file
+# whose UNCALLED LoRA#realize! historically poisoned the shared SmolLM2/RoPE
+# constructor (cfg → poly via the constructor slot, spinel-dev#12; the regular-
+# method facet was spinel-dev#11). Keeping realize! UNCALLED here is the point:
+# the C compile of this very gate exercises exactly that shape, so a Spinel
+# regression re-breaks the BUILD loudly. Calling realize! would pin cfg
+# concretely and mask the bug — and would also drag a GGUF base model into a
+# gate that is deliberately data-free (the byte-exact LoRA *training* gate is
+# examples/smoke_recipe_lora.rb). We instantiate LoRA.new to prove the class is
+# addressable from the one require.
+#
 #   make examples/smoke_compute_surface && ./examples/smoke_compute_surface
 #
 # Expected last line: "compute-surface: ok".
@@ -28,6 +39,9 @@ cfg = Toy::SmolLM2Config.new(VOCAB, 64, 4, 4, 128, 2, CONTEXT, 10000.0, 1.0e-5)
 llama = Toy::LLM::Engine::LlamaSeqEngine.new
 vit   = Toy::LLM::Engine::ViTTinyEngine.new
 gpt2  = Toy::LLM::Engine::GPT2SeqEngine.new
+
+# LoRA recipe: instantiated, realize! left UNCALLED on purpose (see header).
+lora = Toy::LLM::Recipes::LoRA.new
 
 recipe = Toy::LLM::Recipes::FromScratch.new
 recipe.realize!(cfg, CONTEXT, 1, 0, false, false, 0, 1.0)
@@ -53,7 +67,7 @@ while step < STEPS
   step = step + 1
 end
 
-puts "compute-surface: engines=[llama,vit,gpt2] + FromScratch recipe trained, final_loss=" + loss.to_s
+puts "compute-surface: engines=[llama,vit,gpt2] recipes=[from_scratch trained, lora addressable] final_loss=" + loss.to_s
 if loss.finite?
   puts "compute-surface: ok"
 else

--- a/lib/toy/compute.rb
+++ b/lib/toy/compute.rb
@@ -46,29 +46,15 @@ require_relative "../toy_smollm2_ffi_kv"
 # Recipes — the named training/init compositions. Realize-path orchestration
 # over the engines.
 #
-# NOTE: `recipes/lora` is deliberately NOT required here — a SECOND Spinel facet,
-# distinct from spinel-dev#11 (which matz/spinel#1385 fixed + landed). Re-adding
-# the require and rebuilding against the #11-fixed Spinel STILL fails the C
-# compile (verified 2026-06-09): `@cfg.d_model.to_s` → `sp_poly_to_s`,
-# `RoPE.new(...)` arg → poly, `cache.token_ids = token_ids` → IntArray←PolyArray.
-#
-# Root cause (spinel-dev#12, isolated to a 22-line repro): #11's fix back-
-# propagates a callee's param type to an UNCALLED forwarder's param — but ONLY
-# when the shared callee is a regular instance method. It does NOT cover a
-# CONSTRUCTOR slot: `Klass.new(x)` from an uncalled method does not pin `x` from
-# `Klass#initialize`'s param type. LoRA#realize! forwards `cfg` (uncalled in the
-# compute surface) into realize_for_mmap, which builds the model via `.new`
-# (RoPE.new etc.); `cfg` never gets pinned, stays poly, and UNIONS into the
-# shared SmolLM2/RoPE constructor — which FromScratch's live realize_for_random_init
-# path also feeds concretely — poisoning it program-wide (`sp_Cfg` vs `sp_Cfg *`,
-# same shape as #11 but on the constructor argument). The untyped FFI leading
-# param on realize_for_mmap is INCIDENTAL (a no-handle, cfg-leading variant of
-# the repro fails identically); it only means an RBS sig can't independently
-# rescue it. A consumer that actually trains LoRA requires `toy/llm/recipes/lora`
-# itself (and calls realize! with a concrete cfg, which pins the type). Re-add
-# tracked by toy#52 — blocked on spinel-dev#12 (constructor-slot back-prop), not #11.
+# HISTORY: `recipes/lora` was excluded until toy#52 — loading it UNCALLED let
+# Spinel widen LoRA#realize!'s forwarded `cfg` to poly through a CONSTRUCTOR
+# slot (`Klass.new(x)` from an uncalled method didn't pin `x`), poisoning the
+# shared SmolLM2/RoPE ctor program-wide. Fixed upstream by the constructor-slot
+# back-prop (spinel-dev#12, matz/spinel#1385); spinel-dev#11 covered the
+# regular-method facet earlier.
 require_relative "llm/recipes/from_scratch"
 require_relative "llm/recipes/warm_start"
+require_relative "llm/recipes/lora"
 require_relative "llm/recipes/vit_tiny"
 
 # Inference I/O: GGUF model loading + the BPE tokenizer.


### PR DESCRIPTION
Closes #52.

## What
- `lib/toy/compute.rb`: re-adds `require_relative "llm/recipes/lora"`; the spinel-dev#12 exclusion block is replaced by a short HISTORY note.
- `examples/smoke_compute_surface.rb`: now instantiates `Toy::LLM::Recipes::LoRA` but **deliberately leaves `realize!` uncalled** — that is exactly the historically poisoning shape (uncalled forwarder → constructor slot → poly `cfg`, spinel-dev#12; the regular-method facet was spinel-dev#11). The C compile of `gate-compute-surface` therefore re-breaks loudly on any Spinel regression. Calling `realize!` would pin `cfg` concretely and mask the bug (and drag a GGUF base into a data-free gate; byte-exact LoRA *training* stays in `examples/smoke_recipe_lora`).
- `docs/consuming-toy.md`: lora caveat dropped; gate note records the uncalled co-load.

## Verification (spinel `fix/uncalled-param-overwiden` @ `96c6c48`, clean toolchain `/tmp/spinel-96c6c48-toy30`)
Toolchain sanity first: hello-world OK; spinel-dev#12 repro compiles + prints `5`; spinel-dev#11 repro prints `6`.

| Check | Result |
|---|---|
| `make gate-compute-surface` (lora co-loaded uncalled) | **GATE PASS**, `final_loss=6.14494514465332` |
| `examples/smoke_recipe_lora` STEPS=5 RANK=8 | **byte-equal** to the documented reference (`9.236274719238281 … 8.904613494873047`), VERDICT learning |
| `examples/smoke_recipe_from_scratch` SEED=0 STEPS=5 | **byte-equal** reference curve (`6.440947532653809 … 6.151132583618164`) — no train collateral |
| Warning control | `-Wincompatible-pointer-types` warnings on legacy TransformerLM paths are **identical with/without** the lora require (pre-existing on this toolchain, not introduced here) |

## Why DRAFT — do not merge yet
1. The fix this depends on (constructor-slot back-prop, spinel `96c6c48`) is **in-flight** in matz/spinel PR **1385** (which now carries both the #11 and #12 fixes) and **not yet merged by matz**. Merge this only after #1385 lands upstream **and** `~/sites/spinel` moves past it. Verification above is against the unreviewed branch rev — re-run `make gate-compute-surface` at the merged rev before merging.
2. **No Spinel pin bump here**, and serve is untouched: per **spinel-dev#14**, any environment move past `f6d5eef` currently breaks the serve gate (193 KB binary, `delete_at` on poly_array boot crash — separate `f6d5eef..cb23cc6` regression; eval facet = spinel-dev#13). **Serve-gate failures on newer Spinels are NOT #52 regressions** and must not be pinned on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)