### PR TITLE
toy#60: examples curation (7 narrated teaching files) + DevEx hardening (consumer gate, full-SHA ggml fetch, fail-loud boundary)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -208,9 +208,11 @@ toy-*.gem
 # blocklist above and prevents `git add -A` from ever sweeping a build output
 # (incl. the ~680 MB CUDA binaries) into a commit.
 examples/example_*
-examples/smoke_*
 examples/gpt2_train
 !examples/*.rb
+# Gate-smoke binaries (prep/smokes/): .rb sources tracked, Spinel builds ignored.
+prep/smokes/smoke_*
+!prep/smokes/*.rb
 tinynn/ab_smoke_*
 tinynn/probe_*
 !tinynn/*.rb
@@ -262,5 +264,5 @@ lib/gpt2_ffi_kv_cuda.rb
 lib/gpt2_ffi_kv_metal.rb
 examples/06_train_from_scratch_cuda.rb
 examples/06_train_from_scratch_metal.rb
-examples/smoke_projection_lens_cuda.rb
-examples/smoke_projection_lens_metal.rb
+prep/smokes/smoke_projection_lens_cuda.rb
+prep/smokes/smoke_projection_lens_metal.rb

--- a/.gitignore
+++ b/.gitignore
@@ -262,7 +262,7 @@ lib/gpt2_ffi_cuda.rb
 lib/gpt2_ffi_metal.rb
 lib/gpt2_ffi_kv_cuda.rb
 lib/gpt2_ffi_kv_metal.rb
-examples/06_train_from_scratch_cuda.rb
-examples/06_train_from_scratch_metal.rb
+examples/legacy/06_train_from_scratch_cuda.rb
+examples/legacy/06_train_from_scratch_metal.rb
 prep/smokes/smoke_projection_lens_cuda.rb
 prep/smokes/smoke_projection_lens_metal.rb

--- a/Makefile
+++ b/Makefile
@@ -214,12 +214,15 @@ help:
 	    echo "    make example_inference_metal       same, Metal-accelerated (macOS) — use this on Mac"; \
 	fi
 	@echo "    Most tasks are the CLI now: toy train|infer|eval|serve (see 'toy --help')."
-	@echo "    Curated library/instrumentation examples:"
-	@echo "    make example_train                 tiny GPT from scratch on TinyStories (pure-Ruby teaching path)"
-	@echo "    make example_train_from_scratch    modern Llama-shape from-scratch trainer (instrumentation ref)"
-	@echo "    make example_train_vit_tiny        ViT-Tiny image-classifier + warm-start from timm"
-	@echo "    toy train from-scratch --arch gpt2 GPT-2 from-scratch (CPU/CUDA) — see examples/gpt2_train.rb"
-	@echo "    (CLI-superseded demos moved to examples/legacy/: lora, warm-start, lmc, metal-infer.)"
+	@echo "    Curated examples (narrated; examples/README.md is the tour):"
+	@echo "    make example_01                    train a tiny Llama from scratch (start here; ~2 s)"
+	@echo "    make example_02                    warm-start fine-tune from a real GGUF's embeddings"
+	@echo "    make example_03                    LoRA adapters over a frozen mmap'd base"
+	@echo "    make example_04                    load a GGUF, KV decode, print text"
+	@echo "    make example_05                    per-token logprobs (the eval building block)"
+	@echo "    make example_06                    compare your runs/ (CRuby, no build)"
+	@echo "    make example_07                    ViT-Tiny image classifier (same recipe shape)"
+	@echo "    (Superseded tutorials live on in examples/legacy/ — they still build.)"
 	@echo ""
 	@echo "  HTTP SERVING — tep_demo/"
 	@echo "    make tep_demo/hello                minimal Tep HTTP smoke"
@@ -748,9 +751,60 @@ prep/smokes/smoke_recipe_from_scratch: prep/smokes/smoke_recipe_from_scratch.rb 
 # BLESSED from-scratch path — the short tutorial. Same gate-fixture
 # config as smoke_recipe_from_scratch, but the clean tutorial read using
 # the value objects (Toy::SmolLM2Config.mha + Toy::Labels + Toy::AdamW).
-examples/example_train_from_scratch_blessed: examples/train_from_scratch.rb lib/toy.rb lib/toy/llm/engine/llama_seq_engine.rb lib/toy/models/toy_smollm2.rb lib/toy/models/transformer.rb lib/toy/ffi/tinynn.rb lib/toy/llm/adamw.rb lib/toy/llm/labels.rb lib/toy/llm/recipe_options.rb lib/toy/llm/recipes/from_scratch.rb tinynn/libtinynn_ggml.a $(SPINEL_DEPS)
+examples/example_train_from_scratch_blessed: examples/legacy/train_from_scratch.rb lib/toy.rb lib/toy/llm/engine/llama_seq_engine.rb lib/toy/models/toy_smollm2.rb lib/toy/models/transformer.rb lib/toy/ffi/tinynn.rb lib/toy/llm/adamw.rb lib/toy/llm/labels.rb lib/toy/llm/recipe_options.rb lib/toy/llm/recipes/from_scratch.rb tinynn/libtinynn_ggml.a $(SPINEL_DEPS)
 	$(SPINEL) $< -o $@
 example_train_from_scratch_blessed: examples/example_train_from_scratch_blessed
+
+# ── Curated examples (toy#60) — the narrated teaching set. One file,
+# one make target, one binary each; see examples/README.md for the tour.
+# 01 — from-scratch on the bundled tiny corpus via the one-require
+# compute surface + the named value objects. THE showcase; the example
+# in docs/framework.md must stay truthful to this file.
+examples/example_01_train_tiny: examples/01_train_tiny.rb lib/toy/compute.rb lib/toy/io/toy_corpus_loader.rb lib/toy/llm/training_batch.rb lib/toy/llm/recipe_options.rb tinynn/libtinynn_ggml.a $(SPINEL_DEPS)
+	$(SPINEL) $< -o $@
+example_01: examples/example_01_train_tiny
+.PHONY: example_01
+
+# 02 — warm-start fine-tune: donor token_embd from a real GGUF through
+# Toy::LLM::Recipes::WarmStart (realize_scratch! → realize_warm! → build!).
+examples/example_02_finetune_warm_start: examples/02_finetune_warm_start.rb lib/toy.rb lib/toy/models/toy_smollm2.rb lib/toy/llm/engine/llama_seq_engine.rb lib/toy/io/toy_corpus_loader.rb lib/toy/train/toy_lr_schedule.rb lib/toy/llm/adamw.rb lib/toy/llm/labels.rb lib/toy/llm/training_batch.rb lib/toy/llm/recipe_options.rb lib/toy/llm/recipes/warm_start.rb lib/toy/ffi/tinynn.rb lib/toy/models/transformer.rb tinynn/libtinynn_ggml.a $(SPINEL_DEPS)
+	$(SPINEL) $< -o $@
+example_02: examples/example_02_finetune_warm_start
+.PHONY: example_02
+
+# 03 — LoRA adapters over a frozen mmap'd base GGUF. Requires the lora
+# recipe DIRECTLY (not via toy/compute — spinel-dev#12 / toy#52).
+examples/example_03_lora: examples/03_lora.rb lib/toy.rb lib/toy/models/toy_smollm2.rb lib/toy/io/loaders/toy_smollm2_loader.rb lib/toy/llm/engine/llama_seq_engine.rb lib/toy/models/transformer.rb lib/toy/models/gpt2.rb lib/toy/io/gguf_load.rb lib/toy/ffi/tinynn.rb lib/toy/llm/adamw.rb lib/toy/llm/recipe_options.rb lib/toy/llm/recipes/lora.rb tinynn/libtinynn_ggml.a $(SPINEL_DEPS)
+	$(SPINEL) $< -o $@
+example_03: examples/example_03_lora
+.PHONY: example_03
+
+# 04 — load a GGUF, KV-cache decode, print text (the llama_kv_engine
+# path the `toy infer` runner drives).
+examples/example_04_generate: examples/04_generate.rb lib/toy/models/arch.rb lib/toy/models/transformer_lm.rb lib/toy/llm/engine/llama_kv_engine.rb lib/toy/io/loaders/toy_smollm2_loader.rb lib/toy/models/transformer.rb lib/toy/models/gpt2.rb lib/toy/io/gguf_load.rb lib/toy/ffi/tinynn.rb lib/toy/io/tokenizer.rb tinynn/libtinynn_ggml.a $(SPINEL_DEPS)
+	$(SPINEL) $< -o $@
+example_04: examples/example_04_generate
+.PHONY: example_04
+
+# 05 — per-token logprobs at a decode position (the `toy eval` compute).
+examples/example_05_eval_logprobs: examples/05_eval_logprobs.rb lib/toy/models/arch.rb lib/toy/models/transformer_lm.rb lib/toy/llm/engine/llama_kv_engine.rb lib/toy/io/loaders/toy_smollm2_loader.rb lib/toy/models/transformer.rb lib/toy/models/gpt2.rb lib/toy/io/gguf_load.rb lib/toy/ffi/tinynn.rb lib/toy/io/tokenizer.rb lib/toy/dev/toy_logprobs.rb tinynn/libtinynn_ggml.a $(SPINEL_DEPS)
+	$(SPINEL) $< -o $@
+example_05: examples/example_05_eval_logprobs
+.PHONY: example_05
+
+# 06 — CRuby, NOT compiled: Toy::RunLog comparison table over runs/.
+example_06:
+	ruby examples/06_runlog_compare.rb
+.PHONY: example_06
+
+# 07 — ViT-Tiny on the committed data/vit_smoke corpus via Recipes::VitTiny.
+examples/example_07_vit_tiny: examples/07_vit_tiny.rb lib/toy/llm/engine/vit_tiny_engine.rb lib/toy/llm/recipes/vit_tiny.rb lib/toy/models/toy_vit.rb lib/toy/models/toy_smollm2.rb lib/toy/io/toy_image_loader.rb lib/toy/train/toy_lr_schedule.rb lib/toy/llm/adamw.rb lib/toy/llm/recipe_options.rb lib/toy/models/transformer.rb lib/toy/ffi/tinynn.rb tinynn/libtinynn_ggml.a $(SPINEL_DEPS)
+	$(SPINEL) $< -o $@
+example_07: examples/example_07_vit_tiny
+.PHONY: example_07
+
+examples-curated: example_01 example_02 example_03 example_04 example_05 example_07
+.PHONY: examples-curated
 
 # L4 LoRA recipe gate. Drives the same LoRA fine-tune config as the
 # frozen reference 03_finetune_lora THROUGH Toy::LLM::Recipes::LoRA; its
@@ -826,7 +880,7 @@ coverage-check:
 	ruby prep/gen_coverage.rb --check
 .PHONY: coverage coverage-check
 
-examples/example_train: examples/02_train_custom_gpt.rb lib/toy/models/transformer.rb lib/toy/train/training.rb lib/toy/train/toy_trainer.rb lib/toy/ffi/tinynn.rb tinynn/libtinynn_ggml.a
+examples/example_train: examples/legacy/02_train_custom_gpt.rb lib/toy/models/transformer.rb lib/toy/train/training.rb lib/toy/train/toy_trainer.rb lib/toy/ffi/tinynn.rb tinynn/libtinynn_ggml.a
 	$(SPINEL) $< -o $@
 example_train: examples/example_train
 
@@ -866,12 +920,12 @@ example_inference_metal: examples/example_inference_metal
 # toy#train-device-select-cuda follow-up. The dispatcher errors
 # cleanly on DEVICE=cuda so Tao's `run_start.backend.kind=="cuda"`
 # acceptance fails honestly rather than silently emitting cpu data.
-examples/example_train_from_scratch_cpu: examples/06_train_from_scratch.rb vendor/spinel/spinel_kit/lib/spinel_kit/json_builder.rb lib/toy/io/toy_events.rb vendor/spinel/spinel_kit/lib/spinel_kit/git.rb lib/toy/llm/engine/llama_seq_engine.rb lib/toy/models/toy_smollm2.rb lib/toy/models/transformer.rb lib/toy/ffi/tinynn.rb lib/toy/dev/toy_describe_flow.rb lib/toy/train/toy_drift_grad.rb lib/toy/train/toy_gguf_writer.rb lib/toy/dev/toy_tap.rb tinynn/libtinynn_ggml.a $(SPINEL_DEPS)
+examples/example_train_from_scratch_cpu: examples/legacy/06_train_from_scratch.rb vendor/spinel/spinel_kit/lib/spinel_kit/json_builder.rb lib/toy/io/toy_events.rb vendor/spinel/spinel_kit/lib/spinel_kit/git.rb lib/toy/llm/engine/llama_seq_engine.rb lib/toy/models/toy_smollm2.rb lib/toy/models/transformer.rb lib/toy/ffi/tinynn.rb lib/toy/dev/toy_describe_flow.rb lib/toy/train/toy_drift_grad.rb lib/toy/train/toy_gguf_writer.rb lib/toy/dev/toy_tap.rb tinynn/libtinynn_ggml.a $(SPINEL_DEPS)
 	$(SPINEL) $< -o $@
-examples/example_train_from_scratch_cuda: examples/06_train_from_scratch_cuda.rb vendor/spinel/spinel_kit/lib/spinel_kit/json_builder.rb lib/toy/io/toy_events.rb vendor/spinel/spinel_kit/lib/spinel_kit/git.rb lib/toy/llm/engine/llama_seq_engine_cuda.rb lib/toy/models/toy_smollm2.rb lib/toy/models/transformer.rb lib/toy/ffi/tinynn_cuda.rb lib/toy/dev/toy_describe_flow.rb lib/toy/train/toy_drift_grad.rb lib/toy/train/toy_gguf_writer.rb lib/toy/dev/toy_tap.rb tinynn/libtinynn_ggml.a tinynn/libtinynn_ggml_cuda.a $(SPINEL_DEPS)
+examples/example_train_from_scratch_cuda: examples/legacy/06_train_from_scratch_cuda.rb vendor/spinel/spinel_kit/lib/spinel_kit/json_builder.rb lib/toy/io/toy_events.rb vendor/spinel/spinel_kit/lib/spinel_kit/git.rb lib/toy/llm/engine/llama_seq_engine_cuda.rb lib/toy/models/toy_smollm2.rb lib/toy/models/transformer.rb lib/toy/ffi/tinynn_cuda.rb lib/toy/dev/toy_describe_flow.rb lib/toy/train/toy_drift_grad.rb lib/toy/train/toy_gguf_writer.rb lib/toy/dev/toy_tap.rb tinynn/libtinynn_ggml.a tinynn/libtinynn_ggml_cuda.a $(SPINEL_DEPS)
 	$(SPINEL) --cc='cc -Wl,-u,tnn_cuda_force_link' $< -o $@
 examples/example_train_from_scratch: examples/example_train_from_scratch_cpu
-	@printf '#!/bin/sh\n# Auto-generated by Makefile. DEVICE selects the backend binary.\n# Edit examples/06_train_from_scratch.rb (cpu) for behaviour; CUDA mirror is auto-generated by prep/gen_cuda_mirror.rb.\ncase "$${DEVICE:-cpu}" in\n  cpu|"") exec "$$(dirname "$$0")/example_train_from_scratch_cpu" "$$@" ;;\n  cuda)   exec "$$(dirname "$$0")/example_train_from_scratch_cuda" "$$@" ;;\n  metal)  echo "DEVICE=metal not yet supported for training (inference only)" >&2; exit 2 ;;\n  *)      echo "DEVICE=$${DEVICE} not recognised (want cpu|cuda)" >&2; exit 2 ;;\nesac\n' > $@
+	@printf '#!/bin/sh\n# Auto-generated by Makefile. DEVICE selects the backend binary.\n# Edit examples/legacy/06_train_from_scratch.rb (cpu) for behaviour; CUDA mirror is auto-generated by prep/gen_cuda_mirror.rb.\ncase "$${DEVICE:-cpu}" in\n  cpu|"") exec "$$(dirname "$$0")/example_train_from_scratch_cpu" "$$@" ;;\n  cuda)   exec "$$(dirname "$$0")/example_train_from_scratch_cuda" "$$@" ;;\n  metal)  echo "DEVICE=metal not yet supported for training (inference only)" >&2; exit 2 ;;\n  *)      echo "DEVICE=$${DEVICE} not recognised (want cpu|cuda)" >&2; exit 2 ;;\nesac\n' > $@
 	@chmod +x $@
 example_train_from_scratch: examples/example_train_from_scratch
 example_train_from_scratch_cuda: examples/example_train_from_scratch_cuda
@@ -879,7 +933,7 @@ example_train_from_scratch_cuda: examples/example_train_from_scratch_cuda
 # GPT-2 from-scratch via the GPT2SeqEngine library API (the curated GPT-2 demo;
 # CLI surface is `toy train from-scratch --arch gpt2`). Memorizes a synthetic
 # sequence so CE visibly collapses; exercises the vendored LayerNorm/GELU kernels.
-examples/gpt2_train: examples/gpt2_train.rb lib/toy.rb \
+examples/gpt2_train: examples/legacy/gpt2_train.rb lib/toy.rb \
 		lib/toy/llm/engine/gpt2_seq_engine.rb lib/toy/models/transformer.rb \
 		lib/toy/ffi/tinynn.rb tinynn/libtinynn_ggml.a $(SPINEL_DEPS) | libexec
 	$(SPINEL) $< -o $@
@@ -920,7 +974,7 @@ MIRROR_CUDA := \
   lib/toy/llm/recipes/warm_start_cuda.rb \
   lib/toy/llm/engine/llama_kv_engine_cuda.rb \
   lib/gpt2_ffi_cuda.rb lib/gpt2_ffi_kv_cuda.rb \
-  examples/06_train_from_scratch_cuda.rb prep/smokes/smoke_projection_lens_cuda.rb
+  examples/legacy/06_train_from_scratch_cuda.rb prep/smokes/smoke_projection_lens_cuda.rb
 MIRROR_METAL := $(MIRROR_CUDA:_cuda.rb=_metal.rb)
 
 $(MIRROR_CUDA): %_cuda.rb: %.rb prep/gen_cuda_mirror.rb
@@ -1184,7 +1238,7 @@ prep/smokes/smoke_image_loader: prep/smokes/smoke_image_loader.rb lib/toy/io/toy
 	$(SPINEL) $< -o $@
 
 # E1.6 / GH#13 — ViT-Tiny training driver.
-examples/example_train_vit_tiny: examples/07_train_vit_tiny.rb lib/toy/llm/engine/vit_tiny_engine.rb lib/toy/models/toy_vit.rb lib/toy/models/toy_smollm2.rb lib/toy/io/toy_image_loader.rb lib/toy/train/toy_lr_schedule.rb lib/toy/train/toy_drift_grad.rb lib/toy/models/transformer.rb lib/toy/ffi/tinynn.rb tinynn/libtinynn_ggml.a $(SPINEL_DEPS)
+examples/example_train_vit_tiny: examples/legacy/07_train_vit_tiny.rb lib/toy/llm/engine/vit_tiny_engine.rb lib/toy/models/toy_vit.rb lib/toy/models/toy_smollm2.rb lib/toy/io/toy_image_loader.rb lib/toy/train/toy_lr_schedule.rb lib/toy/train/toy_drift_grad.rb lib/toy/models/transformer.rb lib/toy/ffi/tinynn.rb tinynn/libtinynn_ggml.a $(SPINEL_DEPS)
 	$(SPINEL) $< -o $@
 example_train_vit_tiny: examples/example_train_vit_tiny
 

--- a/Makefile
+++ b/Makefile
@@ -406,13 +406,13 @@ gate-mixed-precision:
 gate-run-log:
 	ruby prep/run_log_gate.rb
 
-# toy#42 full-API require gate. Builds examples/smoke_compute_surface (which
+# toy#42 full-API require gate. Builds prep/smokes/smoke_compute_surface (which
 # requires ONLY lib/toy/compute.rb) and asserts it realizes a live engine —
 # proving the one-require compute surface co-compiles + works for a library
 # consumer. Builds the smoke itself.
 .PHONY: gate-compute-surface
-gate-compute-surface: examples/smoke_compute_surface
-	@out="$$(./examples/smoke_compute_surface 2>&1)"; \
+gate-compute-surface: prep/smokes/smoke_compute_surface
+	@out="$$(./prep/smokes/smoke_compute_surface 2>&1)"; \
 	echo "$$out" | tail -2; \
 	echo "$$out" | grep -q "compute-surface: ok" \
 	  && echo "GATE PASS [compute-surface]: lib/toy/compute.rb one-require surface is live" \
@@ -421,8 +421,8 @@ gate-compute-surface: examples/smoke_compute_surface
 # toy#64 item 8 — CUDA twin of gate-compute-surface: build + run the
 # consumer-ish CUDA entry smoke on the GPU (GB10 sm_121).
 .PHONY: gate-compute-surface-cuda
-gate-compute-surface-cuda: examples/smoke_compute_surface_cuda
-	@out="$$(./examples/smoke_compute_surface_cuda 2>&1)"; \
+gate-compute-surface-cuda: prep/smokes/smoke_compute_surface_cuda
+	@out="$$(./prep/smokes/smoke_compute_surface_cuda 2>&1)"; \
 	echo "$$out" | tail -2; \
 	echo "$$out" | grep -q "compute-surface-cuda: ok" \
 	  && echo "GATE PASS [compute-surface-cuda]: lib/toy/compute_cuda.rb device entry is live" \
@@ -664,21 +664,21 @@ toy-serve: libexec/toy-serve
 
 # toy#gguf-checkpoint-reload (#153) — smoke binary that loads a
 # from-scratch toy GGUF and runs a tiny generation. No tokenizer.
-examples/smoke_toy_ckpt_reload: examples/smoke_toy_ckpt_reload.rb lib/toy/models/arch.rb lib/toy/models/transformer_lm.rb lib/toy/llm/engine/llama_kv_engine.rb lib/toy/io/loaders/toy_smollm2_loader.rb lib/toy/models/transformer.rb lib/toy/models/gpt2.rb lib/toy/io/gguf_load.rb lib/toy/ffi/tinynn.rb lib/toy/io/tokenizer.rb tinynn/libtinynn_ggml.a
+prep/smokes/smoke_toy_ckpt_reload: prep/smokes/smoke_toy_ckpt_reload.rb lib/toy/models/arch.rb lib/toy/models/transformer_lm.rb lib/toy/llm/engine/llama_kv_engine.rb lib/toy/io/loaders/toy_smollm2_loader.rb lib/toy/models/transformer.rb lib/toy/models/gpt2.rb lib/toy/io/gguf_load.rb lib/toy/ffi/tinynn.rb lib/toy/io/tokenizer.rb tinynn/libtinynn_ggml.a
 	$(SPINEL) $< -o $@
 
 # toy#embed-api (#145) — smoke for ToyLM#embed_lookup.
-examples/smoke_embed_api: examples/smoke_embed_api.rb lib/toy/models/arch.rb lib/toy/models/transformer_lm.rb lib/toy/llm/engine/llama_kv_engine.rb lib/toy/io/loaders/toy_smollm2_loader.rb lib/toy/models/transformer.rb lib/toy/models/gpt2.rb lib/toy/io/gguf_load.rb lib/toy/ffi/tinynn.rb lib/toy/io/tokenizer.rb lib/toy/dev/toy_logprobs.rb tinynn/libtinynn_ggml.a
+prep/smokes/smoke_embed_api: prep/smokes/smoke_embed_api.rb lib/toy/models/arch.rb lib/toy/models/transformer_lm.rb lib/toy/llm/engine/llama_kv_engine.rb lib/toy/io/loaders/toy_smollm2_loader.rb lib/toy/models/transformer.rb lib/toy/models/gpt2.rb lib/toy/io/gguf_load.rb lib/toy/ffi/tinynn.rb lib/toy/io/tokenizer.rb lib/toy/dev/toy_logprobs.rb tinynn/libtinynn_ggml.a
 	$(SPINEL) $< -o $@
 
 # P1 framework refactor — runtime Card derivation smoke. Loads a
 # llama-family GGUF, realizes the seq-mode cache, derives a
 # structural Toy::Card via ToyDescribeFlow.card, prints + gates.
-examples/smoke_card_derive: examples/smoke_card_derive.rb lib/toy.rb lib/toy/models/toy_smollm2.rb lib/toy/llm/engine/llama_seq_engine.rb lib/toy/dev/toy_describe_flow.rb lib/toy/train/toy_drift_grad.rb lib/toy/io/loaders/toy_smollm2_loader.rb lib/toy/models/transformer.rb lib/toy/models/gpt2.rb lib/toy/io/gguf_load.rb lib/toy/ffi/tinynn.rb lib/toy/dev/toy_card.rb tinynn/libtinynn_ggml.a
+prep/smokes/smoke_card_derive: prep/smokes/smoke_card_derive.rb lib/toy.rb lib/toy/models/toy_smollm2.rb lib/toy/llm/engine/llama_seq_engine.rb lib/toy/dev/toy_describe_flow.rb lib/toy/train/toy_drift_grad.rb lib/toy/io/loaders/toy_smollm2_loader.rb lib/toy/models/transformer.rb lib/toy/models/gpt2.rb lib/toy/io/gguf_load.rb lib/toy/ffi/tinynn.rb lib/toy/dev/toy_card.rb tinynn/libtinynn_ggml.a
 	$(SPINEL) $< -o $@
 
 # toy#decode-logprobs (#151) — smoke for ToyLM#decode_step_with_logprobs.
-examples/smoke_decode_logprobs: examples/smoke_decode_logprobs.rb lib/toy/models/arch.rb lib/toy/models/transformer_lm.rb lib/toy/llm/engine/llama_kv_engine.rb lib/toy/io/loaders/toy_smollm2_loader.rb lib/toy/models/transformer.rb lib/toy/models/gpt2.rb lib/toy/io/gguf_load.rb lib/toy/ffi/tinynn.rb lib/toy/io/tokenizer.rb lib/toy/dev/toy_logprobs.rb tinynn/libtinynn_ggml.a
+prep/smokes/smoke_decode_logprobs: prep/smokes/smoke_decode_logprobs.rb lib/toy/models/arch.rb lib/toy/models/transformer_lm.rb lib/toy/llm/engine/llama_kv_engine.rb lib/toy/io/loaders/toy_smollm2_loader.rb lib/toy/models/transformer.rb lib/toy/models/gpt2.rb lib/toy/io/gguf_load.rb lib/toy/ffi/tinynn.rb lib/toy/io/tokenizer.rb lib/toy/dev/toy_logprobs.rb tinynn/libtinynn_ggml.a
 	$(SPINEL) $< -o $@
 
 # GH#18 — LMC interpolate-and-eval runner.
@@ -687,7 +687,7 @@ examples/example_lmc: examples/legacy/08_lmc.rb lib/toy/llm/engine/llama_seq_eng
 example_lmc: examples/example_lmc
 
 # E2.3 (towards GH#14) — projection-lens smoke.
-examples/smoke_projection_lens: examples/smoke_projection_lens.rb lib/toy/llm/engine/llama_seq_engine.rb lib/toy/models/toy_smollm2.rb lib/toy/models/transformer.rb lib/toy/ffi/tinynn.rb lib/toy/train/toy_drift_grad.rb tinynn/libtinynn_ggml.a $(SPINEL_DEPS)
+prep/smokes/smoke_projection_lens: prep/smokes/smoke_projection_lens.rb lib/toy/llm/engine/llama_seq_engine.rb lib/toy/models/toy_smollm2.rb lib/toy/models/transformer.rb lib/toy/ffi/tinynn.rb lib/toy/train/toy_drift_grad.rb tinynn/libtinynn_ggml.a $(SPINEL_DEPS)
 	$(SPINEL) $< -o $@
 
 # toy#42 full-API require gate. Compiling this proves lib/toy/compute.rb's whole
@@ -695,7 +695,7 @@ examples/smoke_projection_lens: examples/smoke_projection_lens.rb lib/toy/llm/en
 # running it realizes a LlamaSeqEngine to prove the surface is live. The prereq
 # is just lib/toy/compute.rb — it pulls everything else transitively, and
 # $(SPINEL) follows the require graph.
-examples/smoke_compute_surface: examples/smoke_compute_surface.rb lib/toy/compute.rb lib/toy/llm/training_batch.rb lib/toy/llm/recipe_options.rb tinynn/libtinynn_ggml.a $(SPINEL_DEPS)
+prep/smokes/smoke_compute_surface: prep/smokes/smoke_compute_surface.rb lib/toy/compute.rb lib/toy/llm/training_batch.rb lib/toy/llm/recipe_options.rb tinynn/libtinynn_ggml.a $(SPINEL_DEPS)
 	$(SPINEL) $< -o $@
 
 # toy#64 item 8 — the CUDA compute entry (lib/toy/compute_cuda.rb), the
@@ -703,7 +703,7 @@ examples/smoke_compute_surface: examples/smoke_compute_surface.rb lib/toy/comput
 # compute-surface gate but requires compute_cuda + links the CUDA
 # archives with the force-link flag. The generated CUDA mirrors in the
 # dep list are kept fresh by the $(MIRROR_CUDA) pattern rules.
-examples/smoke_compute_surface_cuda: examples/smoke_compute_surface_cuda.rb lib/toy/compute_cuda.rb \
+prep/smokes/smoke_compute_surface_cuda: prep/smokes/smoke_compute_surface_cuda.rb lib/toy/compute_cuda.rb \
 		lib/toy/llm/training_batch.rb lib/toy/llm/recipe_options.rb \
 		lib/toy/llm/engine/llama_seq_engine_cuda.rb lib/toy/llm/engine/gpt2_seq_engine_cuda.rb \
 		lib/toy/llm/engine/llama_kv_engine_cuda.rb \
@@ -717,7 +717,7 @@ examples/smoke_compute_surface_cuda: examples/smoke_compute_surface_cuda.rb lib/
 # P2.6 — GQA-divergent (w_o) gate. Realizes a config with head_dim=24 so
 # n_heads*head_dim (96) != d_model (64), proving the divergent w_o shape
 # [d_model, n_heads*head_dim] allocates and runs forward+backward.
-examples/smoke_gate_gqa_divergent: examples/smoke_gate_gqa_divergent.rb lib/toy/llm/engine/llama_seq_engine.rb lib/toy/models/toy_smollm2.rb lib/toy/models/transformer.rb lib/toy/ffi/tinynn.rb lib/toy/train/toy_drift_grad.rb tinynn/libtinynn_ggml.a $(SPINEL_DEPS)
+prep/smokes/smoke_gate_gqa_divergent: prep/smokes/smoke_gate_gqa_divergent.rb lib/toy/llm/engine/llama_seq_engine.rb lib/toy/models/toy_smollm2.rb lib/toy/models/transformer.rb lib/toy/ffi/tinynn.rb lib/toy/train/toy_drift_grad.rb tinynn/libtinynn_ggml.a $(SPINEL_DEPS)
 	$(SPINEL) $< -o $@
 
 # P2.6 — llama3 RoPE post-rope TENSOR parity gate. Builds a standalone
@@ -728,7 +728,7 @@ examples/smoke_gate_gqa_divergent: examples/smoke_gate_gqa_divergent.rb lib/toy/
 # asserts (a) freq_factors non-uniform / kind==:llama3, (b) post-rope output
 # byte-identical run-to-run, plus a contrast guard vs :none (NULL factors).
 # No model file, no lib/ change, no mirror regen. Run from repo root.
-examples/smoke_gate_llama3_tensor: examples/smoke_gate_llama3_tensor.rb lib/toy/llm/engine/llama_seq_engine.rb lib/toy/models/toy_smollm2.rb lib/toy/models/transformer.rb lib/toy/ffi/tinynn.rb tinynn/libtinynn_ggml.a $(SPINEL_DEPS)
+prep/smokes/smoke_gate_llama3_tensor: prep/smokes/smoke_gate_llama3_tensor.rb lib/toy/llm/engine/llama_seq_engine.rb lib/toy/models/toy_smollm2.rb lib/toy/models/transformer.rb lib/toy/ffi/tinynn.rb tinynn/libtinynn_ggml.a $(SPINEL_DEPS)
 	$(SPINEL) $< -o $@
 
 # P2.6 — B>1 (micro-batch) gate. Realizes with t_batch=2 so @seq_b=2,
@@ -736,13 +736,13 @@ examples/smoke_gate_llama3_tensor: examples/smoke_gate_llama3_tensor.rb lib/toy/
 # soft_max_ext attention path (gqa.rb:50). Proves the batched graph
 # allocates the [T*B,T*B] mask and runs forward+backward; records a
 # reproducible loss baseline. MUST run from repo root (data/ts_seqs.txt).
-examples/smoke_gate_b_gt_1: examples/smoke_gate_b_gt_1.rb lib/toy/llm/engine/llama_seq_engine.rb lib/toy/models/toy_smollm2.rb lib/toy/models/transformer.rb lib/toy/ffi/tinynn.rb lib/toy/train/toy_drift_grad.rb tinynn/libtinynn_ggml.a $(SPINEL_DEPS)
+prep/smokes/smoke_gate_b_gt_1: prep/smokes/smoke_gate_b_gt_1.rb lib/toy/llm/engine/llama_seq_engine.rb lib/toy/models/toy_smollm2.rb lib/toy/models/transformer.rb lib/toy/ffi/tinynn.rb lib/toy/train/toy_drift_grad.rb tinynn/libtinynn_ggml.a $(SPINEL_DEPS)
 	$(SPINEL) $< -o $@
 
 # P2.6 — L4 FromScratch recipe gate. Drives the same random-init config
 # as smoke_projection_lens THROUGH Toy::LLM::Recipes::FromScratch; its
 # loss curve must byte-equal the projection-lens reference.
-examples/smoke_recipe_from_scratch: examples/smoke_recipe_from_scratch.rb lib/toy/llm/engine/llama_seq_engine.rb lib/toy/models/toy_smollm2.rb lib/toy/models/transformer.rb lib/toy/ffi/tinynn.rb lib/toy/train/toy_drift_grad.rb lib/toy/llm/adamw.rb lib/toy/llm/labels.rb lib/toy/llm/recipe_options.rb lib/toy/llm/recipes/from_scratch.rb tinynn/libtinynn_ggml.a $(SPINEL_DEPS)
+prep/smokes/smoke_recipe_from_scratch: prep/smokes/smoke_recipe_from_scratch.rb lib/toy/llm/engine/llama_seq_engine.rb lib/toy/models/toy_smollm2.rb lib/toy/models/transformer.rb lib/toy/ffi/tinynn.rb lib/toy/train/toy_drift_grad.rb lib/toy/llm/adamw.rb lib/toy/llm/labels.rb lib/toy/llm/recipe_options.rb lib/toy/llm/recipes/from_scratch.rb tinynn/libtinynn_ggml.a $(SPINEL_DEPS)
 	$(SPINEL) $< -o $@
 
 # BLESSED from-scratch path — the short tutorial. Same gate-fixture
@@ -755,7 +755,7 @@ example_train_from_scratch_blessed: examples/example_train_from_scratch_blessed
 # L4 LoRA recipe gate. Drives the same LoRA fine-tune config as the
 # frozen reference 03_finetune_lora THROUGH Toy::LLM::Recipes::LoRA; its
 # loss curve must byte-equal the reference at the fixed config.
-examples/smoke_recipe_lora: examples/smoke_recipe_lora.rb lib/toy/llm/engine/llama_seq_engine.rb lib/toy/models/toy_smollm2.rb lib/toy/io/loaders/toy_smollm2_loader.rb lib/toy/models/transformer.rb lib/toy/models/gpt2.rb lib/toy/io/gguf_load.rb lib/toy/ffi/tinynn.rb lib/toy/llm/adamw.rb lib/toy/llm/recipe_options.rb lib/toy/llm/recipes/lora.rb tinynn/libtinynn_ggml.a $(SPINEL_DEPS)
+prep/smokes/smoke_recipe_lora: prep/smokes/smoke_recipe_lora.rb lib/toy/llm/engine/llama_seq_engine.rb lib/toy/models/toy_smollm2.rb lib/toy/io/loaders/toy_smollm2_loader.rb lib/toy/models/transformer.rb lib/toy/models/gpt2.rb lib/toy/io/gguf_load.rb lib/toy/ffi/tinynn.rb lib/toy/llm/adamw.rb lib/toy/llm/recipe_options.rb lib/toy/llm/recipes/lora.rb tinynn/libtinynn_ggml.a $(SPINEL_DEPS)
 	$(SPINEL) $< -o $@
 
 # L4 WarmStart recipe gate. Drives the same warm-start config as the
@@ -763,7 +763,7 @@ examples/smoke_recipe_lora: examples/smoke_recipe_lora.rb lib/toy/llm/engine/lla
 # Toy::LLM::Recipes::WarmStart; its loss curve must byte-equal 09's at
 # the fixed config (SEED=0 STEPS=5). The fixture drives the cosine LR
 # schedule + streaming corpus loader (deps below); the recipe stays thin.
-examples/smoke_recipe_warm_start: examples/smoke_recipe_warm_start.rb lib/toy/llm/engine/llama_seq_engine.rb lib/toy/models/toy_smollm2.rb lib/toy/models/transformer.rb lib/toy/ffi/tinynn.rb lib/toy/train/toy_drift_grad.rb lib/toy/io/toy_corpus_loader.rb lib/toy/train/toy_lr_schedule.rb lib/toy/llm/adamw.rb lib/toy/llm/labels.rb lib/toy/llm/recipe_options.rb lib/toy/llm/recipes/warm_start.rb tinynn/libtinynn_ggml.a $(SPINEL_DEPS)
+prep/smokes/smoke_recipe_warm_start: prep/smokes/smoke_recipe_warm_start.rb lib/toy/llm/engine/llama_seq_engine.rb lib/toy/models/toy_smollm2.rb lib/toy/models/transformer.rb lib/toy/ffi/tinynn.rb lib/toy/train/toy_drift_grad.rb lib/toy/io/toy_corpus_loader.rb lib/toy/train/toy_lr_schedule.rb lib/toy/llm/adamw.rb lib/toy/llm/labels.rb lib/toy/llm/recipe_options.rb lib/toy/llm/recipes/warm_start.rb tinynn/libtinynn_ggml.a $(SPINEL_DEPS)
 	$(SPINEL) $< -o $@
 
 # P2.6 gate — GGUF F32 mmap round-trip parity. Head-fuses a random_init
@@ -773,10 +773,10 @@ examples/smoke_recipe_warm_start: examples/smoke_recipe_warm_start.rb lib/toy/ll
 # (previously only realize_for_random_init was gated). CPU-only: the GGUF
 # WRITE half reads host data ptrs (tnn_gguf_w_add_tensor), which the CUDA
 # writer doesn't implement — do NOT auto-mirror this to CUDA.
-examples/smoke_gguf_roundtrip: examples/smoke_gguf_roundtrip.rb lib/toy/llm/engine/llama_seq_engine.rb lib/toy/models/toy_smollm2.rb lib/toy/models/transformer.rb lib/toy/ffi/tinynn.rb lib/toy/train/toy_gguf_fuse.rb lib/toy/train/toy_gguf_writer.rb tinynn/libtinynn_ggml.a $(SPINEL_DEPS)
+prep/smokes/smoke_gguf_roundtrip: prep/smokes/smoke_gguf_roundtrip.rb lib/toy/llm/engine/llama_seq_engine.rb lib/toy/models/toy_smollm2.rb lib/toy/models/transformer.rb lib/toy/ffi/tinynn.rb lib/toy/train/toy_gguf_fuse.rb lib/toy/train/toy_gguf_writer.rb tinynn/libtinynn_ggml.a $(SPINEL_DEPS)
 	$(SPINEL) $< -o $@
 
-examples/smoke_full_finetune: examples/smoke_full_finetune.rb lib/toy/llm/adamw.rb lib/toy/llm/engine/llama_seq_engine.rb lib/toy/models/toy_smollm2.rb lib/toy/io/loaders/toy_smollm2_loader.rb lib/toy/models/transformer.rb lib/toy/ffi/tinynn.rb tinynn/libtinynn_ggml.a $(SPINEL_DEPS)
+prep/smokes/smoke_full_finetune: prep/smokes/smoke_full_finetune.rb lib/toy/llm/adamw.rb lib/toy/llm/engine/llama_seq_engine.rb lib/toy/models/toy_smollm2.rb lib/toy/io/loaders/toy_smollm2_loader.rb lib/toy/models/transformer.rb lib/toy/ffi/tinynn.rb tinynn/libtinynn_ggml.a $(SPINEL_DEPS)
 	$(SPINEL) $< -o $@
 
 # P2.6 gate — qkv_bias mmap branch. Loads the real Qwen2.5-0.5B native GGUF
@@ -787,14 +787,14 @@ examples/smoke_full_finetune: examples/smoke_full_finetune.rb lib/toy/llm/adamw.
 # (qkv_bias=FALSE). Records a deterministic finite-logit baseline. CPU-only;
 # DATA DEPENDENCY: data/qwen25-0.5b-native.gguf (not self-contained). MUST run
 # from repo root. Do NOT auto-mirror to CUDA.
-examples/smoke_gate_qkv_bias: examples/smoke_gate_qkv_bias.rb lib/toy/llm/engine/llama_seq_engine.rb lib/toy/models/toy_smollm2.rb lib/toy/models/transformer.rb lib/toy/ffi/tinynn.rb tinynn/libtinynn_ggml.a $(SPINEL_DEPS)
+prep/smokes/smoke_gate_qkv_bias: prep/smokes/smoke_gate_qkv_bias.rb lib/toy/llm/engine/llama_seq_engine.rb lib/toy/models/toy_smollm2.rb lib/toy/models/transformer.rb lib/toy/ffi/tinynn.rb tinynn/libtinynn_ggml.a $(SPINEL_DEPS)
 	$(SPINEL) $< -o $@
 
 # P2.6 gate — Q8-stays-Q8 realize_for_q8_copy branch. Loads the existing
 # Q8 GGUF, asserts blk.0 attn_q weight stays Q8_0 in memory (NOT dequant
 # to F32), deterministic forward x2 byte-identical baseline. Pure-Ruby
 # fixture (no toy_drift_grad dep; seq_blocks_ffi directly).
-examples/smoke_gate_q8_preserve: examples/smoke_gate_q8_preserve.rb lib/toy/llm/engine/llama_seq_engine.rb lib/toy/models/toy_smollm2.rb lib/toy/models/transformer.rb lib/toy/ffi/tinynn.rb tinynn/libtinynn_ggml.a $(SPINEL_DEPS)
+prep/smokes/smoke_gate_q8_preserve: prep/smokes/smoke_gate_q8_preserve.rb lib/toy/llm/engine/llama_seq_engine.rb lib/toy/models/toy_smollm2.rb lib/toy/models/transformer.rb lib/toy/ffi/tinynn.rb tinynn/libtinynn_ggml.a $(SPINEL_DEPS)
 	$(SPINEL) $< -o $@
 
 # P2.6 CUDA gate — GPU mirror of the projection-lens smoke. Exercises
@@ -802,11 +802,11 @@ examples/smoke_gate_q8_preserve: examples/smoke_gate_q8_preserve.rb lib/toy/llm/
 # realize-path refactor can be parity-gated on GPU (CUDA self-consistency
 # before/after; CUDA floats don't bit-equal CPU). Mirror auto-generated
 # by prep/gen_cuda_mirror.rb. Same force-link recipe as the 06 CUDA entry.
-examples/smoke_projection_lens_cuda: examples/smoke_projection_lens_cuda.rb lib/toy/llm/engine/llama_seq_engine_cuda.rb lib/toy/models/toy_smollm2.rb lib/toy/models/transformer.rb lib/toy/ffi/tinynn_cuda.rb lib/toy/train/toy_drift_grad.rb tinynn/libtinynn_ggml.a tinynn/libtinynn_ggml_cuda.a $(SPINEL_DEPS)
+prep/smokes/smoke_projection_lens_cuda: prep/smokes/smoke_projection_lens_cuda.rb lib/toy/llm/engine/llama_seq_engine_cuda.rb lib/toy/models/toy_smollm2.rb lib/toy/models/transformer.rb lib/toy/ffi/tinynn_cuda.rb lib/toy/train/toy_drift_grad.rb tinynn/libtinynn_ggml.a tinynn/libtinynn_ggml_cuda.a $(SPINEL_DEPS)
 	$(SPINEL) --cc='cc -Wl,-u,tnn_cuda_force_link' $< -o $@
 
 # E2.4 (towards GH#14) — streaming corpus loader + cosine LR smoke.
-examples/smoke_corpus_loader: examples/smoke_corpus_loader.rb lib/toy/models/transformer.rb lib/toy/ffi/tinynn.rb lib/toy/io/toy_corpus_loader.rb lib/toy/train/toy_lr_schedule.rb tinynn/libtinynn_ggml.a
+prep/smokes/smoke_corpus_loader: prep/smokes/smoke_corpus_loader.rb lib/toy/models/transformer.rb lib/toy/ffi/tinynn.rb lib/toy/io/toy_corpus_loader.rb lib/toy/train/toy_lr_schedule.rb tinynn/libtinynn_ggml.a
 	$(SPINEL) $< -o $@
 
 # E2.5 (towards GH#14) — warm-start training driver.
@@ -920,7 +920,7 @@ MIRROR_CUDA := \
   lib/toy/llm/recipes/warm_start_cuda.rb \
   lib/toy/llm/engine/llama_kv_engine_cuda.rb \
   lib/gpt2_ffi_cuda.rb lib/gpt2_ffi_kv_cuda.rb \
-  examples/06_train_from_scratch_cuda.rb examples/smoke_projection_lens_cuda.rb
+  examples/06_train_from_scratch_cuda.rb prep/smokes/smoke_projection_lens_cuda.rb
 MIRROR_METAL := $(MIRROR_CUDA:_cuda.rb=_metal.rb)
 
 $(MIRROR_CUDA): %_cuda.rb: %.rb prep/gen_cuda_mirror.rb
@@ -1176,11 +1176,11 @@ tinynn/ab_smoke_patch_embed: tinynn/ab_smoke_patch_embed.rb lib/toy/models/trans
 	$(SPINEL) tinynn/ab_smoke_patch_embed.rb -o tinynn/ab_smoke_patch_embed
 
 # E1.3 / GH#13 — ViT-Tiny forward + training smoke.
-examples/smoke_vit_tiny: examples/smoke_vit_tiny.rb lib/toy/llm/engine/vit_tiny_engine.rb lib/toy/models/toy_vit.rb lib/toy/models/toy_smollm2.rb lib/toy/models/transformer.rb lib/toy/ffi/tinynn.rb tinynn/libtinynn_ggml.a $(SPINEL_DEPS)
+prep/smokes/smoke_vit_tiny: prep/smokes/smoke_vit_tiny.rb lib/toy/llm/engine/vit_tiny_engine.rb lib/toy/models/toy_vit.rb lib/toy/models/toy_smollm2.rb lib/toy/models/transformer.rb lib/toy/ffi/tinynn.rb tinynn/libtinynn_ggml.a $(SPINEL_DEPS)
 	$(SPINEL) $< -o $@
 
 # E1.5 / GH#13 — image-loader smoke.
-examples/smoke_image_loader: examples/smoke_image_loader.rb lib/toy/io/toy_image_loader.rb lib/toy/models/transformer.rb lib/toy/ffi/tinynn.rb tinynn/libtinynn_ggml.a
+prep/smokes/smoke_image_loader: prep/smokes/smoke_image_loader.rb lib/toy/io/toy_image_loader.rb lib/toy/models/transformer.rb lib/toy/ffi/tinynn.rb tinynn/libtinynn_ggml.a
 	$(SPINEL) $< -o $@
 
 # E1.6 / GH#13 — ViT-Tiny training driver.

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,14 @@ GGML_DIR    := vendor/ggml
 GGML_REPO   := https://github.com/ggml-org/ggml.git
 # Pinned upstream rev: what the vendor-patches/ set is proven against, and
 # what ships inside the gem (toy#45). Bump deliberately, re-proving patches.
-GGML_REV    := 41e7949
+#
+# MUST be the FULL 40-char SHA (toy#60 item 5): the clone rule does a
+# shallow `git fetch origin $(GGML_REV)`, and GitHub only serves
+# fetch-by-SHA for FULL SHAs (allowReachableSHA1InWant — a short SHA
+# gets "fatal: couldn't find remote ref", which broke every pristine
+# clone during #45). Full-SHA shallow fetch verified cold against
+# github.com/ggml-org/ggml on 2026-06-11.
+GGML_REV    := 41e7949d705fd5dfeac33f3804e1af2a136cebd9
 GGML_CUDA_ARCH ?= 121
 CUDA_DIR    ?= /usr/local/cuda
 
@@ -408,6 +415,17 @@ gate-mixed-precision:
 .PHONY: gate-run-log
 gate-run-log:
 	ruby prep/run_log_gate.rb
+
+# toy#60 item 4 — the COLD-START consumer gate: `toy new` scaffold →
+# hello.rb compiles + runs (default ENV, then D_MODEL override without
+# recompiling) → `toy train` prints losses + writes runs/<id>/ → the
+# missing-corpus guard fails loud; PLUS the `toy new --lib` leg
+# (bundle lock → spinel-compat vendor → ./build.sh cpu → run; skips
+# loudly when bundler/spinel-compat are absent). Structural, not
+# byte-exact. ~4 min (the lib leg builds ggml inside the tmp project).
+.PHONY: gate-consumer
+gate-consumer:
+	ruby prep/consumer_gate.rb
 
 # toy#42 full-API require gate. Builds prep/smokes/smoke_compute_surface (which
 # requires ONLY lib/toy/compute.rb) and asserts it realizes a live engine —

--- a/README.md
+++ b/README.md
@@ -141,8 +141,9 @@ what's validated vs. expected-to-work vs. not wired) lives in
 - [`docs/events.md`](docs/events.md) — the `toy/v1` event schema.
 - [`docs/roadmap.md`](docs/roadmap.md) — deferred work and live
   research directions.
-- [`examples/`](examples/README.md) — focused, single-file entry
-  points compiled to native binaries.
+- [`examples/`](examples/README.md) — the narrated teaching set: seven
+  single-file examples (train, warm-start, LoRA, generate, logprobs,
+  run-log compare, ViT), each one `make` target away.
 
 ## Acknowledgments
 

--- a/docs/authoring.md
+++ b/docs/authoring.md
@@ -266,13 +266,13 @@ harness. The current fixtures live in `examples/`:
 
 | Layer | Fixture |
 | --- | --- |
-| L1-L3 realize (random-init forward) | `examples/smoke_projection_lens.rb` (+ `_cuda`, `_metal`) |
-| L5 FromScratch | `examples/smoke_recipe_from_scratch.rb` |
-| L5 LoRA | `examples/smoke_recipe_lora.rb` |
-| L5 WarmStart | `examples/smoke_recipe_warm_start.rb` |
+| L1-L3 realize (random-init forward) | `prep/smokes/smoke_projection_lens.rb` (+ `_cuda`, `_metal`) |
+| L5 FromScratch | `prep/smokes/smoke_recipe_from_scratch.rb` |
+| L5 LoRA | `prep/smokes/smoke_recipe_lora.rb` |
+| L5 WarmStart | `prep/smokes/smoke_recipe_warm_start.rb` |
 
-Each fixture is built and run as a gate (the `examples/smoke_recipe_*`
-and `examples/smoke_projection_lens*` Make targets). The shape contract
+Each fixture is built and run as a gate (the `prep/smokes/smoke_recipe_*`
+and `prep/smokes/smoke_projection_lens*` Make targets). The shape contract
 is **bit-identical output**: an extracted layer must reproduce the prior
 op order exactly, and a generated mirror must match its CPU source.
 Compute-runner behavior (infer/train/eval/serve) is gated separately via

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -168,7 +168,7 @@ gate fixtures.
 | `examples/07_train_vit_tiny.rb` | ViT-Tiny image classifier with timm AugReg donor warm-start. |
 | `examples/legacy/08_lmc.rb` (or `toy eval lmc`) | Linear Mode Connectivity blend of two from-scratch checkpoints over an α grid. |
 | `examples/legacy/09_warm_start_train.rb` (or `toy train warm-start`) | Warm-start trainer with donor `token_embd` + optional PCA-init projection lens. |
-| `examples/smoke_*.rb` | Single-purpose wire smokes — also the gate fixtures (see [gating.md](gating.md)). |
+| `prep/smokes/smoke_*.rb` | Single-purpose wire smokes — the gate fixtures, not tutorials (see [gating.md](gating.md)). |
 
 CUDA / Metal mirrors exist for several (`*_cuda.rb`, `*_metal.rb`).
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -155,24 +155,46 @@ backend module per binary), built on demand the same way. `serve` is CPU-only.
 
 ## Examples
 
-The CLI is the supported entry point; `examples/*.rb` are focused, single-file
-programs Spinel compiles to native binaries (no Python, no runtime). They cover
-paths the CLI does not yet expose (GPU, ViT, LMC, warm-start) and serve as the
-gate fixtures.
+The CLI is the supported entry point; the curated `examples/` set (toy#60)
+is the narrated library-API tour — seven single-file programs Spinel
+compiles to native binaries (06 is plain CRuby). Headers carry the
+what/how-long/what-to-tweak narration; every knob is ENV (compile once,
+run many).
 
 | Example | What it does |
 |---|---|
-| `examples/02_train_custom_gpt.rb` | Train a tiny GPT from scratch on TinyStories. |
-| `examples/legacy/03_finetune_lora.rb` (or `toy train lora`) | LoRA / QLoRA fine-tune via the sequence-mode forward graph (CPU). |
-| `examples/06_train_from_scratch.rb` | Modern Llama-shape from-scratch trainer (RMSNorm + GQA + RoPE + SwiGLU); CPU + CUDA. Emits `toy/v1` events. |
-| `examples/07_train_vit_tiny.rb` | ViT-Tiny image classifier with timm AugReg donor warm-start. |
-| `examples/legacy/08_lmc.rb` (or `toy eval lmc`) | Linear Mode Connectivity blend of two from-scratch checkpoints over an α grid. |
-| `examples/legacy/09_warm_start_train.rb` (or `toy train warm-start`) | Warm-start trainer with donor `token_embd` + optional PCA-init projection lens. |
+| `examples/01_train_tiny.rb` | From-scratch tiny Llama on the bundled corpus; recipe + value objects; writes a `runs/` bundle. |
+| `examples/02_finetune_warm_start.rb` (or `toy train warm-start`) | Warm-start: donor embeddings from a real GGUF, then fine-tune. |
+| `examples/03_lora.rb` (or `toy train lora`) | LoRA / QLoRA adapters over a frozen mmap'd base. |
+| `examples/04_generate.rb` (or `toy infer`) | GGUF → KV-cache decode → text. |
+| `examples/05_eval_logprobs.rb` (or `toy eval`) | Per-token top-K logprobs at a decode position. |
+| `examples/06_runlog_compare.rb` | CRuby: `Toy::RunLog.scan` comparison table over `runs/`. |
+| `examples/07_vit_tiny.rb` | ViT-Tiny classifier on the committed smoke corpus (no CLI surface yet). |
+| `examples/legacy/*` | Superseded tutorials (instrumented trainer, pure-Ruby GPT, …) — still build; see [examples/legacy/README.md](../examples/legacy/README.md). |
 | `prep/smokes/smoke_*.rb` | Single-purpose wire smokes — the gate fixtures, not tutorials (see [gating.md](gating.md)). |
 
-CUDA / Metal mirrors exist for several (`*_cuda.rb`, `*_metal.rb`).
-
 ### Example env knobs
+
+These are read by the example binaries (not the CLI; the CLI passes its own
+controlled env). Each example's header lists its own; the instrumented legacy
+trainer (`examples/legacy/06_train_from_scratch.rb`, built by
+`make example_train_from_scratch`) carries the full set:
+
+| Env | Purpose |
+|---|---|
+| `D_MODEL` `D_FF` `N_HEADS` `N_LAYERS` `CONTEXT` | Model shape |
+| `STEPS` `LR` `SEED` | Training schedule |
+| `DEVICE=cuda` | Use the CUDA mirror path |
+| `TAO_RUN_DIR=<dir>` | Emit the `events.jsonl` stream (and a final checkpoint) here |
+| `TOY_EVENTS=<path>` | Raw alternative to `TAO_RUN_DIR`: full path to the events file |
+| `CHECKPOINT_EVERY=N` | Write `weights/step_<N>.gguf` every N steps (+ `latest` symlink) |
+| `TOY_DESCRIBE=json\|mermaid\|text` | Dump the compute graph and exit (no training) |
+| `TOY_GRAD_SENTINELS=1` `TOY_DRIFT_EVERY=N` `TOY_CKA=N` | Instrumentation events |
+
+See [examples/README.md](../examples/README.md) for the full roster and
+invocations.
+
+## Example env knobs
 
 These are read by the example binaries (not the CLI; the CLI passes its own
 controlled env). Most relevant to `06_train_from_scratch.rb`:

--- a/docs/consuming-toy.md
+++ b/docs/consuming-toy.md
@@ -74,7 +74,7 @@ so `bin/toy` can require it; don't use `toy.rb` for the compute surface. If you
 build only one engine and want to compile less (Spinel has no tree-shaking),
 require that engine's file directly instead of `toy/compute`. The
 `gate-compute-surface` make target proves the one-require surface co-compiles +
-runs a from-scratch training step (`examples/smoke_compute_surface`).
+runs a from-scratch training step (`prep/smokes/smoke_compute_surface`).
 
 > One exception: `toy/compute` does **not** pull `recipes/lora` — loading it
 > uncalled trips a Spinel analyzer bug that poisons `cfg` to poly program-wide

--- a/docs/framework.md
+++ b/docs/framework.md
@@ -74,7 +74,8 @@ end
 ```
 
 That is the *entire* contract — the same one toy's own gates train
-through (`prep/smokes/smoke_compute_surface.rb` is the living version).
+through (`prep/smokes/smoke_compute_surface.rb` is the gate fixture;
+`examples/01_train_tiny.rb` is the narrated, runnable version).
 `WarmStart` resumes from a GGUF instead of random init; `LoRA` trains
 adapters over frozen base weights (`recipe.realize!(gguf, cfg, rank,
 opts)`); `VitTiny` is the same shape for images. Writing your own

--- a/docs/framework.md
+++ b/docs/framework.md
@@ -74,7 +74,7 @@ end
 ```
 
 That is the *entire* contract — the same one toy's own gates train
-through (`examples/smoke_compute_surface.rb` is the living version).
+through (`prep/smokes/smoke_compute_surface.rb` is the living version).
 `WarmStart` resumes from a GGUF instead of random init; `LoRA` trains
 adapters over frozen base weights (`recipe.realize!(gguf, cfg, rank,
 opts)`); `VitTiny` is the same shape for images. Writing your own

--- a/docs/gating.md
+++ b/docs/gating.md
@@ -93,6 +93,21 @@ tolerance):
   within 5% of the f32 baseline (~0.2% observed). bf16 is the CUDA/GB10
   follow-up (bf16 backward needs more than f16).
 
+### Consumer cold-start gate
+
+`make gate-consumer` (`prep/consumer_gate.rb`) proves the README /
+`docs/framework.md` quickstart is TESTED: in a throwaway tmpdir it runs
+`toy new gatelab` (asserting the scaffold seeds `data/ts_seqs.{bin,txt}`),
+compiles `algos/recipes/hello.rb` with `$SPINEL_DIR`'s spinel, runs it with
+default ENV and again with `D_MODEL=128 STEPS=10` (no recompile — one
+compile, many runs), runs `toy train from-scratch` in the project (losses
+print + `runs/<id>/events.jsonl` written), and asserts the missing-corpus
+guard fails loud naming the path (the spinel-dev#17 class). The `--lib`
+leg (`toy new gatelib --lib` → `bundle lock` → `spinel-compat vendor` →
+`./build.sh cpu` → run) skips loudly when bundler / spinel-compat are
+absent. Structural assertions (files exist, losses finite, curves react
+to ENV), not byte-exact — numerics are `train_gate`'s job.
+
 ### Model-gated regression gates
 
 Some gates exercise a REAL model whose GGUF is a gitignored multi-GB dev

--- a/docs/gating.md
+++ b/docs/gating.md
@@ -23,43 +23,44 @@ Two failure modes are explicitly rejected:
 
 ## Smoke fixtures
 
-The gate fixtures live in `examples/` as Spinel-compiled smoke binaries (each
-with a `.rb` source built via its `make examples/<name>` target). They run
-pure-Ruby CPU, SEED=0, F32 weights — deterministic by construction.
+The gate fixtures live in `prep/smokes/` as Spinel-compiled smoke binaries
+(each with a `.rb` source built via its `make prep/smokes/<name>` target).
+They run pure-Ruby CPU, SEED=0, F32 weights — deterministic by construction.
+(They are gates, not tutorials — the narrated tutorials live in `examples/`.)
 
 **Layer-decomposition gates** — prove a refactored path equals the inlined
 reference loss curve:
 
-- `examples/smoke_projection_lens` (+ `_cuda`, `_metal`) — the frozen
+- `prep/smokes/smoke_projection_lens` (+ `_cuda`, `_metal`) — the frozen
   reference forward+backward loss curve; the CUDA/Metal mirrors gate the
   generated backends against it.
-- `examples/smoke_recipe_from_scratch` — drives the same random-init config
+- `prep/smokes/smoke_recipe_from_scratch` — drives the same random-init config
   through `Toy::LLM::Recipes::FromScratch`; its `step N: loss=` lines must
   byte-equal the projection-lens reference.
-- `examples/smoke_recipe_lora`, `examples/smoke_recipe_warm_start` — the
+- `prep/smokes/smoke_recipe_lora`, `prep/smokes/smoke_recipe_warm_start` — the
   same discipline for the LoRA and warm-start recipes.
 
 **Realize-divergence gates** — exercise graph slices the bulk-realize path
 must not silently unify:
 
-- `examples/smoke_gate_gqa_divergent` — the `n_heads*head_dim != d_model`
+- `prep/smokes/smoke_gate_gqa_divergent` — the `n_heads*head_dim != d_model`
   case where `w_o` is non-square.
-- `examples/smoke_gate_b_gt_1` — batch dimension > 1.
-- `examples/smoke_gate_qkv_bias` — separate Q/K/V bias tensors.
-- `examples/smoke_gate_q8_preserve` — Q8_0 weights stay Q8_0 (no silent
+- `prep/smokes/smoke_gate_b_gt_1` — batch dimension > 1.
+- `prep/smokes/smoke_gate_qkv_bias` — separate Q/K/V bias tensors.
+- `prep/smokes/smoke_gate_q8_preserve` — Q8_0 weights stay Q8_0 (no silent
   dequant-to-F32 on the realize path).
-- `examples/smoke_gate_llama3_tensor` — Llama-3 tensor layout.
+- `prep/smokes/smoke_gate_llama3_tensor` — Llama-3 tensor layout.
 
 **Runner / format gates:**
 
-- `examples/smoke_gguf_roundtrip` — GGUF write→read bit-identity.
-- `examples/smoke_decode_logprobs` — per-token logprob decode.
+- `prep/smokes/smoke_gguf_roundtrip` — GGUF write→read bit-identity.
+- `prep/smokes/smoke_decode_logprobs` — per-token logprob decode.
 
 Build and run any fixture directly, e.g.:
 
 ```
-make examples/smoke_recipe_from_scratch
-SEED=0 STEPS=5 ./examples/smoke_recipe_from_scratch | grep '^step'
+make prep/smokes/smoke_recipe_from_scratch
+SEED=0 STEPS=5 ./prep/smokes/smoke_recipe_from_scratch | grep '^step'
 ```
 
 ## Runner harnesses

--- a/docs/reference/loader-api.md
+++ b/docs/reference/loader-api.md
@@ -79,7 +79,7 @@ Verified bit-identical to the GGUF source on SmolLM2-135M's 28M-float
 
 The full-graph round-trip (write → reload → forward, asserting
 bit-identical logits) is gated separately by
-`examples/smoke_gguf_roundtrip.rb` (`make examples/smoke_gguf_roundtrip`).
+`prep/smokes/smoke_gguf_roundtrip.rb` (`make prep/smokes/smoke_gguf_roundtrip`).
 
 ## Why both, why not just one
 

--- a/examples/01_train_tiny.rb
+++ b/examples/01_train_tiny.rb
@@ -1,0 +1,150 @@
+# examples/01_train_tiny.rb — train a tiny Llama from scratch. START HERE.
+#
+# WHAT YOU'LL SEE: a 2-layer, 64-dim Llama-shape model (RMSNorm + MHA +
+# RoPE + SwiGLU) trained on the bundled TinyStories token corpus. One
+# "step N: loss=…" line per step — cross-entropy starts near ln(627)
+# ≈ 6.44 (uniform over the 627-token vocab) and falls visibly within
+# 30 steps. At the end: a run summary, and a runs/<id>/events.jsonl
+# bundle you can inspect from plain Ruby (see 06_runlog_compare.rb).
+#
+# HOW LONG: ~2 s to run (default 30 steps, CPU). Build: one make.
+#
+#   make example_01
+#   ./examples/example_01_train_tiny
+#
+# WHAT TO TWEAK (env, no recompile):
+#   STEPS=100         train longer (the curve keeps falling)
+#   LR=0.01           bigger steps — watch it converge faster, or wobble
+#   SEED=1            a different random init
+#   RUN_ID=lr-01      label the runs/<RUN_ID>/ bundle (for 06's table)
+#
+# THE API (the whole story is five named objects — docs/framework.md):
+#   Toy::SmolLM2Config.tiny      — the model shape (no 9-arg soup)
+#   Toy::LLM::RecipeOptions      — named realize-time options
+#   Toy::LLM::Recipes::FromScratch — realize!(cfg, opts) once, step! per step
+#   Toy::LLM::TrainingBatch      — validates each step's ids + labels
+#   Toy::AdamW.for_from_scratch  — the optimizer hyper-params, named
+#
+# Everything compute rides ONE require (lib/toy/compute.rb). The corpus
+# streamer is the one extra: it lives outside the compute surface.
+
+require_relative "../lib/toy/compute"
+require_relative "../lib/toy/io/toy_corpus_loader"
+
+STEPS  = (ENV["STEPS"]  || "30").to_i
+SEED   = (ENV["SEED"]   || "0").to_i
+LR     = (ENV["LR"]     || "0.001").to_f
+RUN_ID = ENV["RUN_ID"]  || "example-01-tiny"
+CORPUS = ENV["CORPUS"]  || "prep/fixtures/ts_seqs_gate.bin"
+
+# Fail LOUD on a missing corpus BEFORE compute starts: under Spinel,
+# File.read on a missing path silently returns "" (spinel-dev#17), so
+# every user-suppliable path gets an explicit existence check.
+if !File.exist?(CORPUS)
+  puts "01_train_tiny: corpus not found: " + CORPUS
+  puts "  the bundled tiny corpus is prep/fixtures/ts_seqs_gate.bin (committed);"
+  puts "  run this from the repo root, or point CORPUS= at a packed-i32 token file."
+  exit 1
+end
+
+# The model shape: vocab 627, d_model 64, 4 heads, d_ff 128, 2 layers,
+# context 32 — the canonical tiny experiment shape.
+cfg = Toy::SmolLM2Config.tiny
+puts "model: vocab=" + cfg.vocab.to_s + " d=" + cfg.d_model.to_s +
+     " heads=" + cfg.n_heads.to_s + " layers=" + cfg.n_layers.to_s +
+     " ctx=" + cfg.ctx.to_s
+
+# Named realize-time options: only t_seq is required; everything else
+# has sane defaults (t_batch=1, f32 weights, tied embeddings, seed 0).
+opts = Toy::LLM::RecipeOptions.new
+opts.t_seq = cfg.ctx
+opts.seed  = SEED
+
+# realize! builds the WHOLE graph natively — forward + CE loss +
+# backward + AdamW — once. step! drives one training step through it.
+recipe = Toy::LLM::Recipes::FromScratch.new
+recipe.realize!(cfg, opts)
+
+# The validating per-step quartet: positions are built by the ctor,
+# fill! checks every id is in-vocab and rebuilds the shift-by-one
+# one-hot labels. Garbage data fails loud here, not silently mid-graph.
+batch = Toy::LLM::TrainingBatch.new(cfg.vocab, cfg.ctx, 1)
+
+# Named optimizer hyper-params (lr, betas, eps, weight decay).
+adamw = Toy::AdamW.for_from_scratch
+adamw.lr = LR
+
+# Run bundle: runs/<RUN_ID>/events.jsonl in the toy/v1 schema, the same
+# stream `toy train` writes — Toy::RunLog reads it back (06_runlog_compare).
+# Hand-rolled JSON lines: the SpinelKit JSON builder lives in vendor/
+# (a `make vendor-tep` artifact), and a tutorial should run on a fresh
+# clone — so we emit the three event kinds by string concat.
+TinyNN.tnn_filesystem_mkdir("runs")
+RUN_DIR = "runs/" + RUN_ID
+TinyNN.tnn_filesystem_mkdir(RUN_DIR)
+# The events sink APPENDS (and the FFI surface has no truncate), so a
+# re-run with the same RUN_ID would double the bundle — warn loud.
+if File.exist?(RUN_DIR + "/events.jsonl")
+  puts "warn: " + RUN_DIR + "/events.jsonl already exists — appending."
+  puts "      rm -r " + RUN_DIR + " (or set RUN_ID=) for a fresh bundle."
+end
+events_on = TinyNN.tnn_events_open(RUN_DIR + "/events.jsonl") == 0
+if events_on
+  TinyNN.tnn_events_emit("{\"kind\":\"run_start\",\"schema\":\"toy/v1\"," +
+    "\"run_id\":\"" + RUN_ID + "\",\"phase\":\"train\"," +
+    "\"model\":{\"arch\":\"llama\",\"vocab\":" + cfg.vocab.to_s +
+    ",\"d_model\":" + cfg.d_model.to_s +
+    ",\"n_layers\":" + cfg.n_layers.to_s + "}," +
+    "\"config\":{\"context\":" + cfg.ctx.to_s +
+    ",\"steps\":" + STEPS.to_s +
+    ",\"lr\":" + LR.to_s +
+    ",\"seed\":" + SEED.to_s + "}}")
+else
+  puts "warn: could not open " + RUN_DIR + "/events.jsonl (run bundle disabled)"
+end
+
+# Train: stream context-sized windows off the corpus, one step each.
+first_loss  = 0.0
+final_loss  = 0.0
+byte_offset = 0
+step = 0
+while step < STEPS
+  seq_ids = ToyCorpusLoader.read_seq(CORPUS, byte_offset, cfg.ctx)
+  byte_offset = byte_offset + cfg.ctx * 4              # packed i32
+
+  batch.fill!(seq_ids)                                  # validate + labels
+  batch.hp = adamw.hp(step)
+
+  loss = recipe.step!(batch.seq_ids, batch.positions, batch.labels,
+                      batch.hp, step == 0)
+  if step == 0
+    first_loss = loss
+  end
+  final_loss = loss
+  puts "step " + (step + 1).to_s + ": loss=" + loss.to_s
+  if events_on
+    TinyNN.tnn_events_emit("{\"kind\":\"step\",\"step\":" + (step + 1).to_s +
+                           ",\"loss\":" + loss.to_s + "}")
+  end
+  step = step + 1
+end
+
+if events_on
+  TinyNN.tnn_events_emit("{\"kind\":\"run_end\",\"reason\":\"completed\"," +
+    "\"final_step\":" + STEPS.to_s + ",\"final_loss\":" + final_loss.to_s + "}")
+  TinyNN.tnn_events_close
+end
+
+# The run-log summary.
+puts ""
+puts "run " + RUN_ID + ": " + STEPS.to_s + " steps, loss " +
+     first_loss.to_s + " -> " + final_loss.to_s
+if events_on
+  puts "bundle: " + RUN_DIR + "/events.jsonl  (toy/v1 events)"
+  puts "inspect from plain Ruby:  ruby examples/06_runlog_compare.rb"
+end
+if final_loss < first_loss
+  puts "VERDICT: learning"
+else
+  puts "VERDICT: NOT learning (loss did not fall — try more STEPS or a lower LR)"
+end

--- a/examples/02_finetune_warm_start.rb
+++ b/examples/02_finetune_warm_start.rb
@@ -1,0 +1,151 @@
+# examples/02_finetune_warm_start.rb — warm-start a tiny model from a
+# REAL model's embeddings, then fine-tune.
+#
+# WHAT YOU'LL SEE: the same 2-layer tiny Llama as 01, but instead of a
+# fully random init, its token-embedding table is loaded from a real
+# donor GGUF (any llama-family model) and projected into the tiny
+# model's width through a learned lens. Training then proceeds with a
+# cosine LR schedule. One "step N: loss=…" line per step.
+#
+# HOW LONG: ~3 s to run (default 20 steps, CPU) once you have a donor
+# GGUF. No big downloads needed if you already have one cached —
+# `toy list` shows what's around; any llama-family GGUF works.
+#
+#   make example_02
+#   DONOR_GGUF=data/qwen25-0.5b-native.gguf ./examples/example_02_finetune_warm_start
+#
+# WHAT TO TWEAK (env, no recompile):
+#   DONOR_GGUF=…   the donor model (its d_model is read from the GGUF)
+#   STEPS=60       train longer
+#   SEED=1         a different random init for the non-donated weights
+#   INIT=scratch   SKIP the donor upload (same graph, random embeddings)
+#                  — diff the loss curves to see what the donor buys
+#
+# THE API — Toy::LLM::Recipes::WarmStart splits realize into a window:
+#   realize_scratch!(cfg, opts)   build the random-init graph, window OPEN
+#   realize_warm!(buf, n)         upload donor embeddings into the graph
+#   build!                        bake forward+loss+backward+AdamW, CLOSED
+#   step!(…)                      same per-step contract as FromScratch
+#
+# The donor read itself is plain GGUF plumbing (open, read one tensor,
+# free) — the recipe deliberately only owns the upload mechanism.
+
+require_relative "../lib/toy"
+require_relative "../lib/toy/models/toy_smollm2"
+require_relative "../lib/toy/llm/engine/llama_seq_engine"
+require_relative "../lib/toy/io/toy_corpus_loader"
+require_relative "../lib/toy/train/toy_lr_schedule"
+require_relative "../lib/toy/llm/adamw"
+require_relative "../lib/toy/llm/training_batch"
+require_relative "../lib/toy/llm/recipes/warm_start"
+
+STEPS      = (ENV["STEPS"] || "20").to_i
+SEED       = (ENV["SEED"]  || "0").to_i
+INIT       = ENV["INIT"]       || "warm"
+DONOR_GGUF = ENV["DONOR_GGUF"] || "data/qwen25-0.5b-native.gguf"
+CORPUS     = ENV["CORPUS"]     || "prep/fixtures/ts_seqs_gate.bin"
+
+# Tiny model shape (vocab matches the bundled corpus tokenization).
+VOCAB   = 627
+CONTEXT = 32
+
+# Fail LOUD on missing user-suppliable paths BEFORE compute starts
+# (spinel-dev#17: a silent File.read of a missing path returns "").
+if !File.exist?(DONOR_GGUF)
+  puts "02_finetune_warm_start: donor GGUF not found: " + DONOR_GGUF
+  puts "  point DONOR_GGUF= at any llama-family GGUF. Find one with `toy list`,"
+  puts "  or fetch one:  toy fetch bartowski/SmolLM2-135M-Instruct-GGUF SmolLM2-135M-Instruct-Q8_0.gguf"
+  exit 1
+end
+if !File.exist?(CORPUS)
+  puts "02_finetune_warm_start: corpus not found: " + CORPUS
+  puts "  run from the repo root (the bundled corpus is prep/fixtures/ts_seqs_gate.bin)."
+  exit 1
+end
+
+# Open the donor and read its embedding width — the projection lens is
+# sized donor_d_in × d_model, so the cfg must know the donor's width.
+ggh = TinyNN.tnn_gguf_load(DONOR_GGUF)
+if ggh == nil || ggh == TinyNN.tnn_null_ptr
+  puts "02_finetune_warm_start: failed to open " + DONOR_GGUF + " (not a GGUF?)"
+  exit 1
+end
+donor_d = TinyNN.tnn_gguf_get_u32(ggh, "llama.embedding_length")
+if donor_d <= 0
+  puts "02_finetune_warm_start: donor has no llama.embedding_length key — not llama-family?"
+  exit 1
+end
+
+cfg = Toy::SmolLM2Config.tiny
+cfg.donor_d_in = donor_d        # embed table becomes vocab × donor_d
+puts "model: vocab=" + cfg.vocab.to_s + " d=" + cfg.d_model.to_s +
+     " ctx=" + cfg.ctx.to_s + "  donor: " + DONOR_GGUF +
+     " (d=" + donor_d.to_s + ")"
+
+opts = Toy::LLM::RecipeOptions.new
+opts.t_seq  = CONTEXT
+opts.untied = true              # mandatory when donor_d_in > 0
+opts.seed   = SEED
+
+recipe = Toy::LLM::Recipes::WarmStart.new
+recipe.realize_scratch!(cfg, opts)
+
+# Read the first VOCAB rows of the donor's token_embd.weight and upload
+# them while the warm window is open. (The donor's vocab is much larger;
+# rows align when the corpus is tokenized with the donor's tokenizer —
+# for this tiny demo the POINT is the mechanism, not token alignment.)
+if INIT == "warm"
+  te_idx = TinyNN.tnn_gguf_find_index(ggh, "token_embd.weight")
+  if te_idx < 0
+    puts "02_finetune_warm_start: donor has no token_embd.weight tensor"
+    exit 1
+  end
+  n_floats = VOCAB * donor_d
+  te_buf = Mat.new(1, n_floats)
+  rc = TinyNN.tnn_gguf_read_f32_to_doubles(ggh, te_idx, te_buf.flat, n_floats)
+  if rc != 0
+    puts "02_finetune_warm_start: token_embd.weight read failed rc=" + rc.to_s
+    exit 1
+  end
+  recipe.realize_warm!(te_buf.flat, n_floats)
+  puts "warm: loaded " + n_floats.to_s + " donor embedding floats"
+else
+  puts "warm: SKIPPED (INIT=" + INIT + " — random embeddings, same graph)"
+end
+TinyNN.tnn_gguf_free(ggh)
+
+recipe.build!                   # bake the graph; window closed
+
+# Cosine LR schedule + the validating batch + named AdamW.
+batch = Toy::LLM::TrainingBatch.new(VOCAB, CONTEXT, 1)
+adamw = Toy::AdamW.for_from_scratch
+
+first_loss  = 0.0
+final_loss  = 0.0
+byte_offset = 0
+step = 0
+while step < STEPS
+  adamw.lr = ToyLR.cosine(step, STEPS, 0.001, 0.00001, 5)
+  seq_ids = ToyCorpusLoader.read_seq(CORPUS, byte_offset, CONTEXT)
+  byte_offset = byte_offset + CONTEXT * 4
+
+  batch.fill!(seq_ids)
+  batch.hp = adamw.hp(step)
+  loss = recipe.step!(batch.seq_ids, batch.positions, batch.labels,
+                      batch.hp, step == 0)
+  if step == 0
+    first_loss = loss
+  end
+  final_loss = loss
+  puts "step " + (step + 1).to_s + ": loss=" + loss.to_s
+  step = step + 1
+end
+
+puts ""
+puts "warm-start: " + STEPS.to_s + " steps, loss " + first_loss.to_s +
+     " -> " + final_loss.to_s
+if final_loss < first_loss
+  puts "VERDICT: learning (over donor-initialized embeddings)"
+else
+  puts "VERDICT: NOT learning (loss did not fall — try more STEPS)"
+end

--- a/examples/03_lora.rb
+++ b/examples/03_lora.rb
@@ -1,0 +1,126 @@
+# examples/03_lora.rb — LoRA adapters over a frozen, mmap'd base model.
+#
+# WHAT YOU'LL SEE: a REAL pretrained model (SmolLM2-135M by default) is
+# mmap'd read-only as the frozen base; rank-8 LoRA adapter pairs (~5 MB
+# of trainable f32) are attached to the attention projections; training
+# pushes every position of a 4-token prompt toward one target token.
+# Cross-entropy collapses from ~9.2 within 20 steps — the adapters are
+# learning while the base stays byte-untouched on disk.
+#
+# HOW LONG: ~10 s for 20 steps (CPU). The base GGUF is a dev artifact —
+# convert one with ./prep/convert_smollm2_to_gguf.py --ggml-native, or
+# point GGUF= at any *native-layout* llama-family GGUF you have
+# (`toy list`). Q8_0 bases work too: that is QLoRA (Q8 base + f32
+# adapters), same command.
+#
+#   make example_03
+#   ./examples/example_03_lora
+#   GGUF=data/qwen25-0.5b-native-q8.gguf ./examples/example_03_lora   # QLoRA
+#
+# WHAT TO TWEAK (env, no recompile):
+#   RANK=16        bigger adapters (more capacity, more params)
+#   STEPS=50 LR=0.01 TARGET_ID=42   the toy objective
+#
+# THE API — Toy::LLM::Recipes::LoRA:
+#   realize!(gguf, cfg, rank, opts)  — mmap base + attach rank-R adapters
+#   step!(ids, pos, labels, hp, is_first) — same contract as the siblings
+# NOTE: LoRA is required DIRECTLY (not part of the one-require
+# toy/compute surface yet — Spinel constructor-slot inference, toy#52).
+# The CLI form of this example is `toy train lora`.
+
+require_relative "../lib/toy"
+require_relative "../lib/toy/models/toy_smollm2"
+require_relative "../lib/toy/io/loaders/toy_smollm2_loader"
+require_relative "../lib/toy/llm/engine/llama_seq_engine"
+require_relative "../lib/toy/llm/adamw"
+require_relative "../lib/toy/llm/recipes/lora"
+
+GGUF      = ENV["GGUF"]  || "data/smollm2-135m-native.gguf"
+RANK      = (ENV["RANK"]  || "8").to_i
+STEPS     = (ENV["STEPS"] || "20").to_i
+LR        = (ENV["LR"]    || "0.001").to_f
+TARGET_ID = (ENV["TARGET_ID"] || "99").to_i
+
+# The toy objective: a fixed 4-token prompt; every position's next-token
+# target is TARGET_ID. Dumb on purpose — the visible point is the CE
+# collapse, not the task.
+TOKENS = [12092, 4845, 253, 1429]
+
+# Fail LOUD before compute (spinel-dev#17: silent File.read of a
+# missing path returns "").
+if !File.exist?(GGUF)
+  puts "03_lora: base GGUF not found: " + GGUF
+  puts "  LoRA needs a NATIVE-layout llama-family GGUF (mmap'd in place)."
+  puts "  convert one:  ./prep/convert_smollm2_to_gguf.py --ggml-native --out " + GGUF
+  puts "  or point GGUF= at one you have (see `toy list`)."
+  exit 1
+end
+
+# Shape + layout flags come from the GGUF itself.
+cfg   = SmolLM2ConfigLoader.read(GGUF)
+flags = GGUFLoad.detect_smollm2_flags(GGUF)
+puts "base: " + GGUF
+puts "model: vocab=" + cfg.vocab.to_s + " d=" + cfg.d_model.to_s +
+     " L=" + cfg.n_layers.to_s + " heads=" + cfg.n_heads.to_s +
+     "  adapters: rank=" + RANK.to_s
+
+gguf   = TinyNN.tnn_gguf_load(GGUF)
+recipe = Toy::LLM::Recipes::LoRA.new
+
+# Named realize options. The `? true : false` pins poly Bools from the
+# flags reader to concrete Bools (Spinel landmine — see
+# prep/smokes/smoke_recipe_lora.rb for the full story).
+opts = Toy::LLM::RecipeOptions.new
+opts.t_seq      = TOKENS.length
+opts.untied     = flags.untied ? true : false
+opts.qkv_bias   = flags.qkv_bias ? true : false
+opts.seed       = 42
+opts.init_scale = 0.01
+recipe.realize!(gguf, cfg, RANK, opts)
+puts "realize OK (base mmap'd, adapters attached)"
+
+# One-hot labels: every position targets TARGET_ID. (A custom objective
+# like this is hand-built — Toy::Labels/TrainingBatch model the
+# next-token objective only.)
+m_labels = Mat.new(TOKENS.length, cfg.vocab)
+i = 0
+while i < TOKENS.length * cfg.vocab
+  m_labels.flat[i] = 0.0
+  i = i + 1
+end
+ti = 0
+while ti < TOKENS.length
+  m_labels.flat[ti * cfg.vocab + TARGET_ID] = 1.0
+  ti = ti + 1
+end
+
+# LoRA's AdamW convention differs from from-scratch: beta2=0.999 and
+# PER-STEP bias correction (slots 5/6 of hp carry the correction
+# denominators, not the betas) — hence hp is rebuilt every step.
+adamw = Toy::AdamW.for_lora
+adamw.lr = LR
+
+positions = [0, 1, 2, 3]
+
+first_loss = 0.0
+final_loss = 0.0
+step = 1
+while step <= STEPS
+  m_hp = adamw.hp(step)                  # 1-indexed for bias correction
+  loss = recipe.step!(TOKENS, positions, m_labels, m_hp, step == 1)
+  if step == 1
+    first_loss = loss
+  end
+  final_loss = loss
+  puts "step " + step.to_s + ": loss=" + loss.to_s
+  step = step + 1
+end
+
+puts ""
+puts "lora: " + STEPS.to_s + " steps, loss " + first_loss.to_s +
+     " -> " + final_loss.to_s
+if final_loss < first_loss
+  puts "VERDICT: adapters learning (base weights untouched)"
+else
+  puts "VERDICT: NOT learning (loss did not fall — try more STEPS or higher LR)"
+end

--- a/examples/04_generate.rb
+++ b/examples/04_generate.rb
@@ -1,0 +1,88 @@
+# examples/04_generate.rb — load a GGUF, decode tokens, print text.
+#
+# WHAT YOU'LL SEE: a real model loaded from a GGUF file (arch + shape
+# read from its header), the prompt run through the KV-cache decode
+# engine one position at a time, and the greedy continuation printed —
+# as text when the GGUF embeds its tokenizer, as raw token ids when not.
+#
+# HOW LONG: ~5 s for 16 tokens of SmolLM2-135M (CPU). One model file
+# needed — `toy list` shows what's cached, or fetch one:
+#   toy fetch bartowski/SmolLM2-135M-Instruct-GGUF SmolLM2-135M-Instruct-Q8_0.gguf
+#
+#   make example_04
+#   GGUF=data/smollm2-135m-f32.gguf ./examples/example_04_generate
+#
+# WHAT TO TWEAK (env, no recompile):
+#   PROMPT="The capital of France is"    your prompt (tokenizer models)
+#   PROMPT_IDS="1 100 200"               raw ids (tokenizer-less models)
+#   N_NEW=64                             generate more tokens
+#
+# THE API — three objects:
+#   Arch.load_or_fail(gguf, who)  — read + validate the GGUF header
+#   ToyLM.new(arch, :cpu)         — the model wrapper; .load mmaps weights
+#   lm.generate(ids, n)           — greedy KV-cache decode (argmax; the
+#                                   deterministic path `toy infer` gates)
+# Tokenizer.from_gguf reads the embedded BPE when present. The CLI form
+# of this example is `toy infer <model.gguf>`.
+
+require_relative "../lib/toy/models/arch"
+require_relative "../lib/toy/models/transformer_lm"
+require_relative "../lib/toy/io/tokenizer"
+
+GGUF   = ENV["GGUF"]   || "data/smollm2-135m-f32.gguf"
+PROMPT = ENV["PROMPT"] || "Once upon a time"
+N_NEW  = (ENV["N_NEW"] || "16").to_i
+PROMPT_IDS = ENV["PROMPT_IDS"] || ""
+
+# Fail LOUD before compute (spinel-dev#17: silent File.read of a
+# missing path returns "").
+if !File.exist?(GGUF)
+  puts "04_generate: model GGUF not found: " + GGUF
+  puts "  point GGUF= at any llama-family GGUF. `toy list` shows local caches;"
+  puts "  toy fetch bartowski/SmolLM2-135M-Instruct-GGUF SmolLM2-135M-Instruct-Q8_0.gguf"
+  exit 1
+end
+
+arch = Arch.load_or_fail(GGUF, "04_generate")
+puts arch.summary
+
+lm = ToyLM.new(arch, :cpu)
+lm.load(GGUF)
+
+tok = Tokenizer.from_gguf(GGUF)
+
+if PROMPT_IDS.length > 0
+  # Raw-ids path (tokenizer-less GGUFs, e.g. your own 01 checkpoints).
+  parts = PROMPT_IDS.split(" ")
+  in_ids = [0]; in_ids.pop
+  j = 0
+  while j < parts.length
+    if parts[j].length > 0
+      idv = parts[j].to_i
+      if idv < 0 || idv >= arch.vocab_size
+        puts "04_generate: PROMPT_IDS token " + parts[j] +
+             " out of range [0," + arch.vocab_size.to_s + ")"
+        exit 1
+      end
+      in_ids.push(idv)
+    end
+    j = j + 1
+  end
+  out_ids = lm.generate(in_ids, N_NEW)
+  print "ids:"
+  k = 0
+  while k < out_ids.length
+    print " " + out_ids[k].to_s
+    k = k + 1
+  end
+  puts ""
+elsif tok.present
+  in_ids = tok.encode(PROMPT)
+  puts "prompt: " + PROMPT.inspect + " -> " + in_ids.length.to_s + " tokens"
+  out_ids = lm.generate(in_ids, N_NEW)   # greedy; returns prompt + new
+  puts "text: " + tok.decode(out_ids)
+else
+  puts "04_generate: " + GGUF + " has no embedded tokenizer, so a string"
+  puts "  prompt cannot be encoded. Pass raw ids: PROMPT_IDS=\"1 100 200\""
+  exit 1
+end

--- a/examples/05_eval_logprobs.rb
+++ b/examples/05_eval_logprobs.rb
@@ -1,0 +1,100 @@
+# examples/05_eval_logprobs.rb — what does the model think comes next?
+#
+# WHAT YOU'LL SEE: a prompt is prefilled through the KV-cache engine,
+# then at the next position the model's full distribution is computed
+# and the top-K candidates printed as log-probabilities:
+#
+#   logprob: 198 -2.5708273628290854
+#   logprob: 19 -2.7158488014277182
+#   ...
+#
+# (id 198 is "\n" for SmolLM2 — after "1 100 200" a newline is its best
+# guess.) Logprobs are the building block for perplexity, calibration
+# curves, and API logprobs=true responses.
+#
+# HOW LONG: ~3 s (CPU). Needs one llama-family GGUF (`toy list`).
+#
+#   make example_05
+#   GGUF=data/smollm2-135m-f32.gguf ./examples/example_05_eval_logprobs
+#
+# WHAT TO TWEAK (env, no recompile):
+#   TOP_K=10               more candidates
+#   PROMPT_IDS="1 2 3 4"   a different prefill (raw token ids)
+#
+# THE API — same ToyLM as 04, two decode calls:
+#   lm.decode_step(id, pos)                      — prefill, one position
+#   lm.decode_step_with_logprobs(id, pos, k)     — logits → log_softmax
+#                                                  → top-K (deterministic
+#                                                  CPU math; this is what
+#                                                  `toy eval` gates)
+# The CLI form of this example is `toy eval <model.gguf>`.
+
+require_relative "../lib/toy/models/arch"
+require_relative "../lib/toy/models/transformer_lm"
+
+GGUF  = ENV["GGUF"]  || "data/smollm2-135m-f32.gguf"
+TOP_K = (ENV["TOP_K"] || "5").to_i
+PROMPT_IDS = ENV["PROMPT_IDS"] || "1 100 200"
+
+# Fail LOUD before compute (spinel-dev#17: silent File.read of a
+# missing path returns "").
+if !File.exist?(GGUF)
+  puts "05_eval_logprobs: model GGUF not found: " + GGUF
+  puts "  point GGUF= at any llama-family GGUF (`toy list` shows local caches)."
+  exit 1
+end
+
+arch = Arch.load_or_fail(GGUF, "05_eval_logprobs")
+puts arch.summary
+
+lm = ToyLM.new(arch, :cpu)
+lm.load(GGUF)
+
+# Parse + validate the prefill ids.
+parts = PROMPT_IDS.split(" ")
+ids = [0]; ids.pop
+j = 0
+while j < parts.length
+  if parts[j].length > 0
+    idv = parts[j].to_i
+    if idv < 0 || idv >= arch.vocab_size
+      puts "05_eval_logprobs: PROMPT_IDS token " + parts[j] +
+           " out of range [0," + arch.vocab_size.to_s + ")"
+      exit 1
+    end
+    ids.push(idv)
+  end
+  j = j + 1
+end
+if ids.length == 0
+  puts "05_eval_logprobs: PROMPT_IDS parsed to no token ids"
+  exit 1
+end
+
+# Prefill: feed each prompt id at its position (order is load-bearing —
+# the KV cache is built up step by step).
+i = 0
+while i < ids.length
+  lm.decode_step(ids[i], i)
+  i = i + 1
+end
+print "prefill:"
+i = 0
+while i < ids.length
+  print " " + ids[i].to_s
+  i = i + 1
+end
+puts "  (" + ids.length.to_s + " positions)"
+
+# One more decode, returning the top-K (id, logprob) pairs at the next
+# position. log_softmax is max-shifted for stability; ties break
+# first-seen — fully deterministic.
+result   = lm.decode_step_with_logprobs(0, ids.length, TOP_K)
+top_ids  = result[2]
+top_vals = result[3]
+
+k = 0
+while k < top_ids.length
+  puts "logprob: " + top_ids[k].to_s + " " + top_vals[k].to_s
+  k = k + 1
+end

--- a/examples/06_runlog_compare.rb
+++ b/examples/06_runlog_compare.rb
@@ -1,0 +1,80 @@
+# examples/06_runlog_compare.rb — compare your training runs from plain Ruby.
+#
+# WHAT YOU'LL SEE: every run bundle under runs/ parsed by Toy::RunLog
+# and printed as a comparison table, best (lowest) final loss first:
+#
+#   run                    steps  first      final      config
+#   ---------------------  -----  ---------  ---------  -------------------
+#   example-01-tiny           30  6.440948   6.024838   d=64 L=2 lr=0.001
+#   lr-01                     30  6.440948   7.415019   d=64 L=2 lr=0.01
+#
+# (yes — 10x the LR DIVERGES on this tiny model; the table is how you
+# see it without re-reading 30 lines of step output.)
+#
+# HOW LONG: instant. This is PLAIN CRUBY — no Spinel, no FFI, no build:
+#
+#   ruby examples/06_runlog_compare.rb            # or: make example_06
+#
+# Make some runs to compare first (one compile, many runs — ENV only):
+#
+#   make example_01
+#   ./examples/example_01_train_tiny                       # baseline
+#   LR=0.01 RUN_ID=lr-01 ./examples/example_01_train_tiny  # 10x the LR
+#   STEPS=100 RUN_ID=long ./examples/example_01_train_tiny # train longer
+#
+# (`toy train` writes the same toy/v1 bundles, so CLI runs land in the
+# same table.)
+#
+# THE API — Toy::RunLog (lib/toy/core/run_log.rb):
+#   RunLog.scan("runs")  -> every parseable bundle, best final loss first
+#   log.config           -> the run_start event (model + config hashes)
+#   log.loss_curve       -> Array<Float>, one per step
+#   log.final_loss       -> run_end's final_loss (or last step's loss)
+# Malformed bundles raise — a corrupt stream should be seen, not
+# averaged over.
+
+require_relative "../lib/toy/core/run_log"
+
+RUNS_ROOT = ARGV[0] || "runs"
+
+unless Dir.exist?(RUNS_ROOT)
+  warn "06_runlog_compare: no #{RUNS_ROOT}/ directory here."
+  warn "  train something first (see the header of this file), or pass a"
+  warn "  runs root:  ruby examples/06_runlog_compare.rb path/to/runs"
+  exit 1
+end
+
+logs = Toy::RunLog.scan(RUNS_ROOT)
+if logs.empty?
+  warn "06_runlog_compare: #{RUNS_ROOT}/ has no parseable run bundles"
+  warn "  (a bundle is a subdir with an events.jsonl carrying a run_start)."
+  exit 1
+end
+
+# One row per run: id, steps, first/final loss, and a compact config
+# echo pulled out of the run_start event.
+fmt = "%-22s  %5s  %-9s  %-9s  %s"
+puts format(fmt, "run", "steps", "first", "final", "config")
+puts format(fmt, "-" * 22, "-" * 5, "-" * 9, "-" * 9, "-" * 19)
+logs.each do |log|
+  curve  = log.loss_curve
+  model  = log.config["model"]  || {}
+  config = log.config["config"] || {}
+  bits = []
+  bits << "d=#{model['d_model']}"  if model["d_model"]
+  bits << "L=#{model['n_layers']}" if model["n_layers"]
+  bits << "lr=#{config['lr']}"     if config["lr"]
+  bits << "seed=#{config['seed']}" if config["seed"]
+  puts format(fmt,
+              log.run_id || File.basename(log.dir),
+              curve.length,
+              curve.first ? format("%.6f", curve.first) : "-",
+              log.final_loss ? format("%.6f", log.final_loss) : "-",
+              bits.join(" "))
+end
+
+best = logs.first
+if best.final_loss
+  puts ""
+  puts "best: #{best.run_id} (final loss #{format('%.6f', best.final_loss)})"
+end

--- a/examples/07_vit_tiny.rb
+++ b/examples/07_vit_tiny.rb
@@ -1,0 +1,127 @@
+# examples/07_vit_tiny.rb — the same recipe shape, but for IMAGES.
+#
+# WHAT YOU'LL SEE: a ViT-Tiny image classifier (224x224 image, 16x16
+# patches, 12 transformer blocks, class token, 10 classes) trained on
+# the bundled smoke image. Cross-entropy starts near ln(10) ≈ 2.30 and
+# falls as the model memorizes the label — proof that the L5 recipe
+# contract (realize! once, step! per step) is arch-agnostic: this is
+# the SAME shape as 01, with an image where the token sequence was.
+#
+# HOW LONG: ~20 s for 20 steps (CPU; 12 blocks at d=192 is the largest
+# curated example). The pinned smoke corpus is COMMITTED at
+# data/vit_smoke/ — nothing to download.
+#
+#   make example_07
+#   ./examples/example_07_vit_tiny
+#
+# WHAT TO TWEAK (env, no recompile):
+#   STEPS=50      watch it actually memorize (loss -> ~0)
+#   SEED=1        a different random init
+#   IMG_DIR=…     your own corpus (prep/preprocess_images.py writes one)
+#
+# THE API — Toy::LLM::Recipes::VitTiny:
+#   realize!(cfg, opts)                — random-init ViT + training graph
+#   step!(m_image, cls_idx, m_labels, m_hp, is_first)
+# The per-step inputs are an image Mat ([patch_flat x n_patches]) and a
+# one-hot class label — where the LLM recipes take token ids and
+# shift-by-one labels. No CLI surface for ViT yet; this file is it.
+
+require_relative "../lib/toy/models/toy_vit"
+require_relative "../lib/toy/llm/engine/vit_tiny_engine"
+require_relative "../lib/toy/io/toy_image_loader"
+require_relative "../lib/toy/train/toy_lr_schedule"
+require_relative "../lib/toy/llm/recipes/vit_tiny"
+require_relative "../lib/toy/llm/adamw"
+
+STEPS   = (ENV["STEPS"] || "20").to_i
+SEED    = (ENV["SEED"]  || "0").to_i
+IMG_DIR = ENV["IMG_DIR"] || "data/vit_smoke"
+
+# The timm ViT-Tiny shape data/vit_smoke matches (224/16 -> 196 patches).
+IMAGE_SIZE  = 224
+PATCH_SIZE  = 16
+NUM_CHAN    = 3
+D_MODEL     = 192
+N_HEADS     = 3
+D_FF        = 768
+N_LAYERS    = 12
+NUM_CLASSES = 10
+
+cfg = ViTTinyConfig.new(IMAGE_SIZE, PATCH_SIZE, NUM_CHAN, D_MODEL,
+                        N_HEADS, D_FF, N_LAYERS, NUM_CLASSES, 1.0e-5)
+puts "model: image=" + IMAGE_SIZE.to_s + " patch=" + PATCH_SIZE.to_s +
+     " d=" + D_MODEL.to_s + " heads=" + N_HEADS.to_s +
+     " L=" + N_LAYERS.to_s + " classes=" + NUM_CLASSES.to_s
+
+opts = Toy::LLM::RecipeOptions.new
+opts.seed = SEED          # the ViT path consumes seed + init_scale only
+
+recipe = Toy::LLM::Recipes::VitTiny.new
+recipe.realize!(cfg, opts)
+
+# The bundled corpus: images.bin (pre-patchified f32 records) +
+# labels.bin. Fail LOUD if missing or short — the loader's zero-fill on
+# a short read would otherwise silently train on zeros (never-mask).
+images_path = IMG_DIR + "/images.bin"
+labels_path = IMG_DIR + "/labels.bin"
+n_patches   = (IMAGE_SIZE / PATCH_SIZE) * (IMAGE_SIZE / PATCH_SIZE)
+patch_flat  = NUM_CHAN * PATCH_SIZE * PATCH_SIZE
+record_f    = patch_flat * n_patches
+if !File.exist?(images_path) || !File.exist?(labels_path)
+  puts "07_vit_tiny: corpus missing under " + IMG_DIR +
+       " (need images.bin + labels.bin)."
+  puts "  the pinned smoke corpus is committed at data/vit_smoke/ — run from"
+  puts "  the repo root, or write your own: uv run prep/preprocess_images.py"
+  exit 1
+end
+probe = Array.new(record_f, 0.0)
+got = TinyNN.tnn_read_f32_file(images_path, 0, record_f, probe)
+if got != record_f
+  puts "07_vit_tiny: short read " + got.to_s + "/" + record_f.to_s +
+       " from " + images_path + " — refusing to train on zero-fill."
+  exit 1
+end
+
+m_image  = Mat.new(patch_flat, n_patches)
+m_labels = Mat.new(1, NUM_CLASSES)
+cls_idx  = [0]                       # read the class token at position 0
+adamw    = Toy::AdamW.for_from_scratch
+
+first_loss = 0.0
+final_loss = 0.0
+step = 0
+while step < STEPS
+  adamw.lr = ToyLR.cosine(step, STEPS, 0.003, 0.0001, 10)
+
+  # One image per step (the smoke corpus has a single record; a real
+  # corpus would advance the index).
+  patches = ToyImageLoader.read_image(images_path, 0, record_f)
+  label   = ToyImageLoader.read_label(labels_path, 0)
+  i = 0
+  while i < record_f
+    m_image.flat[i] = patches[i]
+    i = i + 1
+  end
+  j = 0
+  while j < NUM_CLASSES
+    m_labels.flat[j] = j == label ? 1.0 : 0.0
+    j = j + 1
+  end
+
+  loss = recipe.step!(m_image, cls_idx, m_labels, adamw.hp(step), step == 0)
+  if step == 0
+    first_loss = loss
+  end
+  final_loss = loss
+  puts "step " + (step + 1).to_s + ": loss=" + loss.to_s
+  step = step + 1
+end
+
+puts ""
+puts "vit-tiny: " + STEPS.to_s + " steps, loss " + first_loss.to_s +
+     " -> " + final_loss.to_s
+if final_loss < first_loss
+  puts "VERDICT: learning"
+else
+  puts "VERDICT: NOT learning (loss did not fall)"
+end

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,250 +1,74 @@
-# examples/
+# examples/ — the narrated teaching set
 
-## The CLI is the primary surface
+Seven single-file examples, curated (toy#60) onto the current API: the
+one-require compute surface, the L5 recipes, and the named value
+objects (`SmolLM2Config` / `RecipeOptions` / `TrainingBatch` / `AdamW`
+— the tour is [`docs/framework.md`](../docs/framework.md)). Each file
+opens with a narrated header: **what you'll see, how long it takes,
+what to tweak**. Each compiles to one native binary via one `make`
+target (06 is plain CRuby — no build).
 
-Most tasks are the `toy` CLI now — no example script needed:
+Most day-to-day tasks are the `toy` CLI (`toy train|infer|eval|serve`,
+see [`docs/cli.md`](../docs/cli.md)); these examples are the
+**library-API reads** — what the CLI does under the hood, in one page
+of Ruby each.
+
+## The set
+
+| # | File | What you'll see | Runtime | Needs |
+|---|---|---|---|---|
+| 01 | [`01_train_tiny.rb`](01_train_tiny.rb) | **Start here.** A tiny Llama trained from scratch on the bundled corpus through `Recipes::FromScratch` + the value-object quartet; writes a `runs/` bundle. | ~2 s | nothing (bundled corpus) |
+| 02 | [`02_finetune_warm_start.rb`](02_finetune_warm_start.rb) | Warm-start: donor embeddings from a real GGUF uploaded into the training graph (`realize_scratch! → realize_warm! → build!`); `INIT=scratch` to diff what the donor buys. | ~3 s | any llama-family GGUF |
+| 03 | [`03_lora.rb`](03_lora.rb) | LoRA/QLoRA: rank-8 adapters over a frozen mmap'd base; CE 9.2 → 3.6 in 20 steps while the base stays untouched. | ~10 s | a *native-layout* GGUF |
+| 04 | [`04_generate.rb`](04_generate.rb) | Load a GGUF, KV-cache decode, print text (or raw ids for tokenizer-less models). | ~5 s | any llama-family GGUF |
+| 05 | [`05_eval_logprobs.rb`](05_eval_logprobs.rb) | Per-token top-K log-probabilities at a decode position — the perplexity/calibration building block. | ~3 s | any llama-family GGUF |
+| 06 | [`06_runlog_compare.rb`](06_runlog_compare.rb) | **CRuby, no build**: `Toy::RunLog.scan` over `runs/` → a comparison table, best final loss first. | instant | runs from 01 / `toy train` |
+| 07 | [`07_vit_tiny.rb`](07_vit_tiny.rb) | The same recipe contract for IMAGES: ViT-Tiny memorizes the bundled smoke image (CE 2.30 → ~0.001). | ~20 s | nothing (committed corpus) |
+
+## Build + run
 
 ```sh
-toy train from-scratch [--arch gpt2] [--device cuda]   # train (Llama or GPT-2)
-toy train lora|warm-start                              # fine-tune / transfer
-toy infer <model.gguf> [--device cuda|metal]           # generate
-toy eval <model.gguf> | toy eval lmc --ckpt A --other B
-toy serve <model.gguf>                                 # OpenAI-compatible HTTP
-toy list | toy fetch | toy describe                    # discover / inspect
+make setup           # one-time: ggml backend (auto-detects CUDA/Metal/CPU)
+make example_01      # builds examples/example_01_train_tiny
+./examples/example_01_train_tiny
+LR=0.01 RUN_ID=lr-01 ./examples/example_01_train_tiny   # no recompile
+ruby examples/06_runlog_compare.rb                      # compare the two
 ```
 
-The scripts below are the ones worth reading as **library-API / instrumentation
-examples** — things the CLI hides or doesn't cover. Each is one runnable Ruby
-program Spinel compiles to a native binary (no Python, no runtime — `make`, run).
+Every knob is ENV (compile once, run many); each file's header lists
+its own. `make examples-curated` builds all the compiled ones.
 
-## Curated examples
+## Models for 02–05
 
-| File | What it does | Runtime |
-|---|---|---|
-| `train_from_scratch.rb` | **Start here.** Tiny Llama-shape model trained through the L4 `FromScratch` recipe + `Toy::AdamW` / `Toy::Labels` / `Toy::SmolLM2Config.mha`. The library-API read. | seconds |
-| `gpt2_train.rb` | **GPT-2 from scratch via `GPT2SeqEngine`** (wte+wpe / LayerNorm / multi-head attn / GELU FFN / tied output). CE collapses on a memorizable sequence. CLI: `toy train from-scratch --arch gpt2`. | seconds |
-| `02_train_custom_gpt.rb` | The **pure-Ruby teaching GPT** (the math in plain Ruby, no FFI engine). Bump EPOCHS → writes English. | ~3 min default |
-| `06_train_from_scratch.rb` | **Instrumentation reference**: events, checkpoints, drift sentinels, CKA taps, Tao harness — the full-knobs version of `train_from_scratch.rb`. | seconds–minutes |
-| `07_train_vit_tiny.rb` | **ViT-Tiny** image classifier (no CLI surface yet): patch embed + class token + 12 blocks + MLP head; timm AugReg donor warm-start. | ~30 s / 200 steps |
-
-## Gates (the test suite, not demos)
-
-`smoke_*.rb` are the **byte-identical gate suite** (wired into `docs/gating.md`
-+ `make verify`), not tutorials — each verifies one primitive/recipe end-to-end.
-They live here for historical reasons; treat them as tests.
-
-## Legacy
-
-CLI-superseded demos moved to [`legacy/`](legacy/README.md): `01_inference_metal`
-(`toy infer --device metal`), `03_finetune_lora` (`toy train lora`), `08_lmc`
-(`toy eval lmc`), `09_warm_start_train` (`toy train warm-start`). They still build.
-
-## First run — find or fetch a model
+02–05 want a GGUF. `toy list` shows what's already cached (HF /
+Ollama / LM Studio caches are scanned); otherwise:
 
 ```sh
-make setup-ggml                # one-time: clones ggml + applies local patches
-toy list                       # see what's already cached locally
-```
-
-If nothing's cached yet, three easy ways to populate one:
-
-```sh
-# 1. Use the toy CLI (defers to `hf` / huggingface-cli if installed, else curl).
 toy fetch bartowski/SmolLM2-135M-Instruct-GGUF SmolLM2-135M-Instruct-Q8_0.gguf
-
-# 2. huggingface-cli / hf directly (any GGUF repo).
-hf download bartowski/SmolLM2-135M-Instruct-GGUF SmolLM2-135M-Instruct-Q8_0.gguf
-
-# 3. Ollama / LM Studio also work — toy reads their caches too.
-ollama pull llama3.2:1b
 ```
 
-Re-run `toy list` and the new model appears. Set
-`TOY_MODEL_DIR=/srv/models` to add another search path.
+For 03 (LoRA) the base must be *native layout* (mmap'd in place):
+convert with `./prep/convert_smollm2_to_gguf.py --ggml-native`.
 
-If you'd rather convert from HF format yourself:
+## Where the rest went
 
-```sh
-./prep/convert_smollm2_to_gguf.py        # → data/smollm2-135m-f32.gguf  (legacy layout)
-./prep/convert_smollm2_to_gguf.py --ggml-native \
-    --out data/smollm2-135m-native.gguf  # mmap-ready layout for LoRA/serve
-```
+- **Gates** (`smoke_*.rb`) are not examples — they live in
+  [`prep/smokes/`](../prep/README.md) and are indexed by
+  [`docs/gating.md`](../docs/gating.md).
+- **Superseded tutorials** live in [`legacy/`](legacy/README.md) — the
+  pure-Ruby teaching GPT, the full-knobs instrumented trainer
+  (events/checkpoints/CKA — still built by the mixed-precision gate),
+  the GPT-2 engine demo, and the CLI-covered demos (lmc, metal
+  inference, …). They still build.
+- **HTTP serving** is `toy serve` (lib/toy/serve/) and the Tep demos in
+  [`tep_demo/`](../tep_demo/README.md).
+- **Exhaustive per-model drivers** are under `demos/`.
 
-The native build is what `03_finetune_lora.rb` and the `tep_demo/`
-serving binaries load — the LoRA / serve paths mmap base weights in
-place, which needs the HF `[out, in]` layout (`toy.ggml_native=true`).
-The legacy build is what `02_train_custom_gpt.rb` consumes.
+## After the examples
 
-## Inference
-
-Inference now lives in the lib-side runner (`lib/toy/run/infer.rb` →
-`libexec/toy-infer`), driven by the CLI. `toy infer` builds the runner on
-demand and shells to it:
-
-```sh
-toy infer data/smollm2-135m-f32.gguf              # uses the given GGUF
-toy infer data/smollm2-135m-q8_0.gguf --prompt "Once upon a time" --n 16
-# → ids: 6403 1980 253 655 28 665 436 253 1838 ...
-```
-
-One binary, model bytes loaded from disk, KV-cache decode. On macOS the
-Metal-accelerated GPU path is still `examples/01_inference_metal.rb`
-(`make example_inference_metal`) until the runner grows a `--device` flag.
-
-## Training your own
-
-### Blessed path — `train_from_scratch.rb` (start here)
-
-The short tutorial. A tiny Llama-shape model (RMSNorm + GQA + RoPE +
-SwiGLU) trained through the L4 `FromScratch` recipe, composed from the
-three pure-Ruby value objects:
-
-- `Toy::SmolLM2Config.mha` — the model shape (no 9-arg positional soup).
-- `Toy::Labels.next_token` — the shift-by-one one-hot label Mat.
-- `Toy::AdamW` — the named optimizer hyper-params (`adamw.hp(step)`).
-
-```sh
-make example_train_from_scratch_blessed
-./examples/example_train_from_scratch_blessed     # reproduces the gate curve
-```
-
-The four recipes (`from_scratch`, `lora`, `warm_start`, `vit_tiny`,
-under `lib/toy/llm/recipes/`) all share the same `realize!` / `step!`
-shape; the `smoke_recipe_*.rb` exemplars are the byte-gated reads.
-
-### From-scratch — full knobs + Tao instrumentation (`06_train_from_scratch.rb`)
-
-The instrumentation reference for the recipe path. Same Llama-shape
-model as the blessed tutorial, but with the full knob surface: events,
-checkpoints, drift sentinels, CKA taps, BATCH / GRAD_ACCUM /
-WEIGHT_DTYPE, and Tao's end-to-end experiment harness. Read
-`train_from_scratch.rb` first; reach for this when you need the
-instrumentation.
-
-```sh
-make example_train_from_scratch
-./examples/example_train_from_scratch                 # CPU, SmolLM2-shape default
-DEVICE=cuda ./examples/example_train_from_scratch     # ~10× faster on GB10
-```
-
-Knobs (env, all optional):
-
-| Env | Purpose |
-| --- | --- |
-| `D_MODEL=64 D_FF=128 N_HEADS=4 N_LAYERS=2 CONTEXT=32` | Model shape |
-| `STEPS=60 LR=0.001 SEED=42` | Training schedule |
-| `TAO_RUN_DIR=/tmp/r` | Emit toy/v1 events stream to `/tmp/r/events.jsonl` |
-| `TOY_GRAD_SENTINELS=1` | Per-PARAM `grad` event every step (drift detection) |
-| `TOY_DRIFT_EVERY=N` | Per-PARAM `drift` event every N steps |
-| `TOY_CKA=N` | Activation-Gram tap event every N steps (per block × 3 regions) |
-| `CHECKPOINT_EVERY=N` | Write `weights/step_<N>.gguf` every N steps (+ `latest` symlink) |
-| `TOY_DESCRIBE=json\|mermaid\|text` | Dump the compute graph and exit (no training) |
-
-Qwen-shape sanity (24L × 16-head × 1024) trains end-to-end via
-`D_MODEL=1024 D_FF=2816 N_HEADS=16 N_LAYERS=24 DEVICE=cuda` (~314
-ms/step on GB10). The graph node budget auto-sizes from cfg
-(`n_layers × n_heads × 1000 + 65536`).
-
-## Fine-tuning (LoRA + QLoRA)
-
-```sh
-# CPU path — fastest to iterate; QLoRA-capable.
-make example_finetune
-./examples/example_finetune
-# F32 base: SmolLM2-135M, ~9.24 → 3.60 CE over 20 steps.
-
-GGUF=data/qwen25-0.5b-native-q8.gguf ./examples/example_finetune
-# Q8 base (QLoRA): Qwen2.5-0.5B Q8 + F32 LoRA, ~15.4 → 6.4 CE.
-```
-
-```sh
-# CUDA path — same loss curve as CPU on F32 bases.
-make setup-ggml-cuda
-make example_finetune_cuda
-./examples/example_finetune_cuda
-```
-
-Both build on the same sequence-mode forward graph
-(`lib/toy/llm/engine/llama_seq_engine*.rb`): T positions per forward, masked CE
-in one compute, AdamW state in persistent memory. The LoRA-Q rank-8
-adapters add ~5 MB on top of an mmap'd base.
-
-CUDA QLoRA (Q8 base on GPU) goes through `realize_for_q8_copy` —
-weights live in the standard CUDA buffer (correct padding) instead
-of the BYO-pointer mmap region. One cudaMemcpy at load; full GPU
-training afterwards. Pass `Q8=1` to the CUDA example to switch paths.
-
-## Serving
-
-The working HTTP serving path is the toy CLI's **`toy serve`**,
-backed by `lib/toy/serve/openai/`. It serves any llama-family GGUF
-(SmolLM2, Qwen2.5, TinyLlama, Llama-3.x …) with an OpenAI-compatible
-surface (`/v1/models`, `/v1/completions`, `/v1/embeddings`).
-
-```sh
-toy serve data/SmolLM2-135M-Instruct-Q8_0.gguf --port 4567 --name smol
-
-curl -X POST http://127.0.0.1:4567/v1/completions \
-  -H 'Content-Type: application/json' \
-  -d '{"prompt":[12092,4845,253,1429],"max_tokens":16}'
-
-curl -X POST http://127.0.0.1:4567/v1/embeddings \
-  -H 'Content-Type: application/json' \
-  -d '{"input":[1,2,3]}'
-```
-
-Token-IDs in, token-IDs out — tokenizer work belongs client-side
-(`prep/qwen25_tokens.py encode "..."`).
-
-`toy serve` replaced the standalone `tep_demo/openai_api_llama`
-binary; the remaining Tep+Spinel demo servers live in
-[`tep_demo/`](../tep_demo/README.md).
-
-## Inspecting + analysing trained models
-
-Once you have one (or two) checkpoints from `06_train_from_scratch`,
-several runners read them back.
-
-```sh
-# Load a from-scratch toy GGUF and generate from it (smoke; the
-# checkpoint per-head naming is detected automatically).
-make prep/smokes/smoke_toy_ckpt_reload
-GGUF=/tmp/run_a/weights/latest ./prep/smokes/smoke_toy_ckpt_reload
-
-# Linear Mode Connectivity: blend two ckpts along α and eval CE.
-# Emits one eval(name="lmc", extra.alpha) per α — Tao's Analyze.lmc
-# consumes these to plot the α→loss curve and call same-basin /
-# disconnected.
-make example_lmc
-LMC_A=/tmp/run_a/weights/latest LMC_B=/tmp/run_b/weights/latest \
-  LMC_ALPHAS=0,0.25,0.5,0.75,1.0 TAO_RUN_DIR=/tmp/lmc \
-  ./examples/example_lmc
-
-# Embedding-table lookup (one row per token id; dequant-aware,
-# F32/Q4/Q5/Q6/Q8/F16). Building block for Tep's /v1/embeddings.
-make prep/smokes/smoke_embed_api
-GGUF=data/llama-3.2-1b-native.gguf ./prep/smokes/smoke_embed_api
-
-# Per-step logprobs + top-K (building block for Tep's
-# /v1/chat?logprobs=true).
-make prep/smokes/smoke_decode_logprobs
-GGUF=data/smollm2-135m-native.gguf TOP_K=5 ./prep/smokes/smoke_decode_logprobs
-```
-
-## Where to go after the examples
-
-- [`../README.md`](../README.md) — project overview + CLI quickstart.
-- [`../docs/architecture.md`](../docs/architecture.md) — generic `TransformerLM` + `Arch` struct.
-- `demos/` — exhaustive per-model and per-feature drivers.
-- `tinynn/` — C+CUDA shim over ggml (FFI bridge, KV cache, mmap loader).
-- `tep_demo/` — full OpenAI-compatible HTTP API (the canonical
-  serving path; the old lite `04_serve` example was removed).
-
-Roadmap + deferred design notes live in `docs/roadmap/`; issues we've
-filed upstream (ggml / Spinel / Tep) live in `docs/archive/upstream/`.
-
-## Two-line takeaway
-
-Each example is one Ruby file under ~100 lines. The build is one
-`make` target each. The output is a single binary with the model,
-the math, and (where relevant) the HTTP server linked in.
+- [`../docs/framework.md`](../docs/framework.md) — toy as a library:
+  the five layers, recipes, starting your own project (`toy new`).
+- [`../docs/authoring.md`](../docs/authoring.md) — add your own
+  primitive/block/arch/recipe, gate-before-merge.
+- [`../docs/consuming-toy.md`](../docs/consuming-toy.md) — toy as a gem
+  dependency with native vendoring.

--- a/examples/README.md
+++ b/examples/README.md
@@ -208,8 +208,8 @@ several runners read them back.
 ```sh
 # Load a from-scratch toy GGUF and generate from it (smoke; the
 # checkpoint per-head naming is detected automatically).
-make examples/smoke_toy_ckpt_reload
-GGUF=/tmp/run_a/weights/latest ./examples/smoke_toy_ckpt_reload
+make prep/smokes/smoke_toy_ckpt_reload
+GGUF=/tmp/run_a/weights/latest ./prep/smokes/smoke_toy_ckpt_reload
 
 # Linear Mode Connectivity: blend two ckpts along α and eval CE.
 # Emits one eval(name="lmc", extra.alpha) per α — Tao's Analyze.lmc
@@ -222,13 +222,13 @@ LMC_A=/tmp/run_a/weights/latest LMC_B=/tmp/run_b/weights/latest \
 
 # Embedding-table lookup (one row per token id; dequant-aware,
 # F32/Q4/Q5/Q6/Q8/F16). Building block for Tep's /v1/embeddings.
-make examples/smoke_embed_api
-GGUF=data/llama-3.2-1b-native.gguf ./examples/smoke_embed_api
+make prep/smokes/smoke_embed_api
+GGUF=data/llama-3.2-1b-native.gguf ./prep/smokes/smoke_embed_api
 
 # Per-step logprobs + top-K (building block for Tep's
 # /v1/chat?logprobs=true).
-make examples/smoke_decode_logprobs
-GGUF=data/smollm2-135m-native.gguf TOP_K=5 ./examples/smoke_decode_logprobs
+make prep/smokes/smoke_decode_logprobs
+GGUF=data/smollm2-135m-native.gguf TOP_K=5 ./prep/smokes/smoke_decode_logprobs
 ```
 
 ## Where to go after the examples

--- a/examples/legacy/01_inference_metal.rb
+++ b/examples/legacy/01_inference_metal.rb
@@ -24,10 +24,10 @@
 # have. The OS reclaims everything cleanly; see tinynn_backend_metal.m
 # for the full rationale.
 
-require_relative "../lib/toy/models/arch"
-require_relative "../lib/toy/ffi/tinynn_metal"
-require_relative "../lib/toy/models/transformer_lm_metal"
-require_relative "../lib/toy/io/tokenizer"
+require_relative "../../lib/toy/models/arch"
+require_relative "../../lib/toy/ffi/tinynn_metal"
+require_relative "../../lib/toy/models/transformer_lm_metal"
+require_relative "../../lib/toy/io/tokenizer"
 
 DEFAULT_GGUF = "data/smollm2-135m-f32.gguf"
 GGUF_ENV     = ENV["GGUF"]

--- a/examples/legacy/02_train_custom_gpt.rb
+++ b/examples/legacy/02_train_custom_gpt.rb
@@ -9,9 +9,9 @@
 # Bumping EPOCHS produces a model that writes English-shaped stories.
 # Defaults stay small so the example finishes in seconds.
 
-require_relative "../lib/toy/models/transformer"
-require_relative "../lib/toy/train/training"
-require_relative "../lib/toy/train/toy_trainer"
+require_relative "../../lib/toy/models/transformer"
+require_relative "../../lib/toy/train/training"
+require_relative "../../lib/toy/train/toy_trainer"
 
 D_MODEL  = 32
 D_FF     = 64

--- a/examples/legacy/03_finetune_lora.rb
+++ b/examples/legacy/03_finetune_lora.rb
@@ -20,10 +20,10 @@
 #   Qwen2.5-0.5B Q8 + r=8 LoRA + Adam ≈ 480 MB.
 #   Larger Q8 bases (1.5B/3B/7B) need proportionally more.
 
-require_relative "../lib/toy"
-require_relative "../lib/toy/models/toy_smollm2"
-require_relative "../lib/toy/io/loaders/toy_smollm2_loader"
-require_relative "../lib/toy/llm/engine/llama_seq_engine"
+require_relative "../../lib/toy"
+require_relative "../../lib/toy/models/toy_smollm2"
+require_relative "../../lib/toy/io/loaders/toy_smollm2_loader"
+require_relative "../../lib/toy/llm/engine/llama_seq_engine"
 
 GGUF      = ENV["GGUF"]    || "data/smollm2-135m-native.gguf"
 RANK      = (ENV["RANK"]   || "8").to_i

--- a/examples/legacy/03_finetune_lora_cuda.rb
+++ b/examples/legacy/03_finetune_lora_cuda.rb
@@ -9,10 +9,10 @@
 # path that bypasses the BYO-pointer padding issue. Slightly more
 # load time (cudaMemcpy instead of mmap) but full GPU training works.
 
-require_relative "../lib/toy"
-require_relative "../lib/toy/models/toy_smollm2"
-require_relative "../lib/toy/io/loaders/toy_smollm2_loader"
-require_relative "../lib/toy/llm/engine/llama_seq_engine_cuda"
+require_relative "../../lib/toy"
+require_relative "../../lib/toy/models/toy_smollm2"
+require_relative "../../lib/toy/io/loaders/toy_smollm2_loader"
+require_relative "../../lib/toy/llm/engine/llama_seq_engine_cuda"
 
 GGUF      = ENV["GGUF"]    || "data/smollm2-135m-native.gguf"
 RANK      = (ENV["RANK"]   || "8").to_i

--- a/examples/legacy/06_train_from_scratch.rb
+++ b/examples/legacy/06_train_from_scratch.rb
@@ -22,18 +22,18 @@
 #     Acceptance: loss decreases monotonically; we don't decode
 #     generated tokens.
 
-require_relative "../lib/toy"
-require_relative "../vendor/spinel/spinel_kit/lib/spinel_kit/json_builder"
-require_relative "../lib/toy/llm/adamw"
-require_relative "../lib/toy/io/toy_events"
-require_relative "../lib/toy/models/toy_smollm2"
-require_relative "../lib/toy/llm/engine/llama_seq_engine"
-require_relative "../lib/toy/dev/toy_describe_flow"
-require_relative "../lib/toy/train/toy_drift_grad"
-require_relative "../lib/toy/train/toy_gguf_writer"
-require_relative "../lib/toy/dev/toy_tap"
-require_relative "../lib/toy/train/toy_sample"
-require_relative "../lib/toy/dev/toy_token_drift"
+require_relative "../../lib/toy"
+require_relative "../../vendor/spinel/spinel_kit/lib/spinel_kit/json_builder"
+require_relative "../../lib/toy/llm/adamw"
+require_relative "../../lib/toy/io/toy_events"
+require_relative "../../lib/toy/models/toy_smollm2"
+require_relative "../../lib/toy/llm/engine/llama_seq_engine"
+require_relative "../../lib/toy/dev/toy_describe_flow"
+require_relative "../../lib/toy/train/toy_drift_grad"
+require_relative "../../lib/toy/train/toy_gguf_writer"
+require_relative "../../lib/toy/dev/toy_tap"
+require_relative "../../lib/toy/train/toy_sample"
+require_relative "../../lib/toy/dev/toy_token_drift"
 
 VOCAB_SIZE = 627
 D_MODEL    = (ENV["D_MODEL"]  || "64").to_i

--- a/examples/legacy/07_train_vit_tiny.rb
+++ b/examples/legacy/07_train_vit_tiny.rb
@@ -14,14 +14,14 @@
 #   make example_train_vit_tiny
 #   STEPS=200 TAO_RUN_DIR=/tmp/vit ./examples/example_train_vit_tiny
 
-require_relative "../vendor/spinel/spinel_kit/lib/spinel_kit/json_builder"
-require_relative "../lib/toy/llm/adamw"
-require_relative "../lib/toy/io/toy_events"
-require_relative "../lib/toy/models/toy_vit"
-require_relative "../lib/toy/llm/engine/vit_tiny_engine"
-require_relative "../lib/toy/io/toy_image_loader"
-require_relative "../lib/toy/train/toy_lr_schedule"
-require_relative "../lib/toy/train/toy_drift_grad"
+require_relative "../../vendor/spinel/spinel_kit/lib/spinel_kit/json_builder"
+require_relative "../../lib/toy/llm/adamw"
+require_relative "../../lib/toy/io/toy_events"
+require_relative "../../lib/toy/models/toy_vit"
+require_relative "../../lib/toy/llm/engine/vit_tiny_engine"
+require_relative "../../lib/toy/io/toy_image_loader"
+require_relative "../../lib/toy/train/toy_lr_schedule"
+require_relative "../../lib/toy/train/toy_drift_grad"
 # NB: NOT requiring toy_gguf_writer here — its `cfg.vocab` / `cfg.d_ff`
 # style calls clash with ViTTinyConfig under Spinel poly inference
 # (the writer's cfg arg goes poly when both SmolLM2Config and

--- a/examples/legacy/08_lmc.rb
+++ b/examples/legacy/08_lmc.rb
@@ -11,10 +11,10 @@
 # Two endpoints (α=0 and α=1) match their training final loss when
 # the eval sequence is the same. Midpoint bump tells the basin story.
 
-require_relative "../lib/toy"
-require_relative "../lib/toy/models/toy_smollm2"
-require_relative "../lib/toy/llm/engine/llama_seq_engine"
-require_relative "../lib/toy/train/toy_drift_grad"
+require_relative "../../lib/toy"
+require_relative "../../lib/toy/models/toy_smollm2"
+require_relative "../../lib/toy/llm/engine/llama_seq_engine"
+require_relative "../../lib/toy/train/toy_drift_grad"
 
 LMC_A    = ENV["LMC_A"]    || ""
 LMC_B    = ENV["LMC_B"]    || ""

--- a/examples/legacy/09_warm_start_train.rb
+++ b/examples/legacy/09_warm_start_train.rb
@@ -60,13 +60,13 @@
 # lens adds another ~1.5M). For the FineWeb-Edu corpus loader
 # (see issue #14 acceptance), see follow-up issue.
 
-require_relative "../lib/toy"
-require_relative "../lib/toy/models/toy_smollm2"
-require_relative "../lib/toy/llm/engine/llama_seq_engine"
-require_relative "../lib/toy/train/toy_drift_grad"
-require_relative "../lib/toy/train/toy_gguf_writer"
-require_relative "../lib/toy/io/toy_corpus_loader"
-require_relative "../lib/toy/train/toy_lr_schedule"
+require_relative "../../lib/toy"
+require_relative "../../lib/toy/models/toy_smollm2"
+require_relative "../../lib/toy/llm/engine/llama_seq_engine"
+require_relative "../../lib/toy/train/toy_drift_grad"
+require_relative "../../lib/toy/train/toy_gguf_writer"
+require_relative "../../lib/toy/io/toy_corpus_loader"
+require_relative "../../lib/toy/train/toy_lr_schedule"
 
 D_MODEL  = (ENV["D_MODEL"]  || "64").to_i
 DONOR_D  = (ENV["DONOR_D"]  || "128").to_i

--- a/examples/legacy/README.md
+++ b/examples/legacy/README.md
@@ -13,5 +13,5 @@ no longer part of the curated example set. Prefer the CLI.
 
 These were the right shape before the CLI existed; the CLI now drives the same
 compute runners with a controlled environment. The byte-exact behaviour is
-preserved by the gates (`prep/*_gate.rb`, `examples/smoke_*`), which are the
+preserved by the gates (`prep/*_gate.rb`, `prep/smokes/smoke_*`), which are the
 test suite and live at `examples/`, not here.

--- a/examples/legacy/README.md
+++ b/examples/legacy/README.md
@@ -1,17 +1,24 @@
 # examples/legacy/
 
-Demos superseded by the `toy` CLI (or by a newer example). Kept for reference
-and history — they still build (their `make` targets point here), but they're
-no longer part of the curated example set. Prefer the CLI.
+Demos superseded by the `toy` CLI or by the curated set (toy#60; see
+[`../README.md`](../README.md)). Kept for reference and history — they
+still build (their `make` targets point here), but they're no longer
+part of the teaching set. Prefer the CLI or the numbered examples one
+level up.
 
 | Legacy file | Use instead |
 |---|---|
 | `01_inference_metal.rb` | `toy infer <model.gguf> --device metal` |
-| `03_finetune_lora.rb` / `_cuda.rb` | `toy train lora` (or `examples/03_finetune_lora` → `make example_finetune` still works) |
+| `02_train_custom_gpt.rb` | the pure-Ruby teaching GPT (no FFI engine); still unique, but pre-recipe — read `../01_train_tiny.rb` first (`make example_train` still builds this) |
+| `03_finetune_lora.rb` / `_cuda.rb` | `toy train lora`, or `../03_lora.rb` for the library read (`make example_finetune` still works) |
+| `06_train_from_scratch.rb` | the full-knobs instrumented trainer (events, checkpoints, drift sentinels, CKA taps, WEIGHT_DTYPE). Still the instrumentation reference and still a GATE SUBJECT — `prep/mixed_precision_gate.rb` builds and drives it (`make example_train_from_scratch`); its `_cuda`/`_metal` mirrors are still generated (it stays in `MIRRORABLE`). |
+| `07_train_vit_tiny.rb` | `../07_vit_tiny.rb` (recipe-based; this one drives the engine directly with the timm AugReg warm-start knobs) |
 | `08_lmc.rb` | `toy eval lmc --ckpt A --other B` |
-| `09_warm_start_train.rb` | `toy train warm-start` |
+| `09_warm_start_train.rb` | `toy train warm-start`, or `../02_finetune_warm_start.rb` for the library read |
+| `gpt2_train.rb` | `toy train from-scratch --arch gpt2` (`make gpt2_train` still builds this) |
+| `train_from_scratch.rb` | `../01_train_tiny.rb` (same recipe, on the Phase-A value objects; this was the pre-#60 blessed tutorial — `make example_train_from_scratch_blessed` still works) |
 
-These were the right shape before the CLI existed; the CLI now drives the same
-compute runners with a controlled environment. The byte-exact behaviour is
-preserved by the gates (`prep/*_gate.rb`, `prep/smokes/smoke_*`), which are the
-test suite and live at `examples/`, not here.
+These were the right shape before the CLI / the recipe value objects
+existed. The byte-exact behaviour is preserved by the gates
+(`prep/*_gate.rb`, `prep/smokes/smoke_*`), which are the test suite and
+live under `prep/`, not here.

--- a/examples/legacy/gpt2_train.rb
+++ b/examples/legacy/gpt2_train.rb
@@ -22,10 +22,10 @@
 # up). A wrong path is silently ignored by Spinel → TinyNN/Mat unloaded →
 # emit-0 → CE=0. (Bit us once; see docs/notes/gpt2-engine-spinel-blocker.md.)
 
-require_relative "../lib/toy"
-require_relative "../lib/toy/ffi/tinynn"
-require_relative "../lib/toy/llm/engine/gpt2_seq_engine"
-require_relative "../lib/toy/llm/adamw"
+require_relative "../../lib/toy"
+require_relative "../../lib/toy/ffi/tinynn"
+require_relative "../../lib/toy/llm/engine/gpt2_seq_engine"
+require_relative "../../lib/toy/llm/adamw"
 
 VOCAB   = 64
 D_MODEL = 32

--- a/examples/legacy/train_from_scratch.rb
+++ b/examples/legacy/train_from_scratch.rb
@@ -23,12 +23,12 @@
 # Load order is verbatim: TinyNN (via llama_seq_forward_ffi) must load
 # before the recipe + value objects are required.
 
-require_relative "../lib/toy"
-require_relative "../lib/toy/models/toy_smollm2"
-require_relative "../lib/toy/llm/engine/llama_seq_engine"
-require_relative "../lib/toy/llm/adamw"
-require_relative "../lib/toy/llm/labels"
-require_relative "../lib/toy/llm/recipes/from_scratch"
+require_relative "../../lib/toy"
+require_relative "../../lib/toy/models/toy_smollm2"
+require_relative "../../lib/toy/llm/engine/llama_seq_engine"
+require_relative "../../lib/toy/llm/adamw"
+require_relative "../../lib/toy/llm/labels"
+require_relative "../../lib/toy/llm/recipes/from_scratch"
 
 STEPS    = (ENV["STEPS"]   || "5").to_i
 D_MODEL  = (ENV["D_MODEL"] || "64").to_i

--- a/lib/toy/core/cli/new.rb
+++ b/lib/toy/core/cli/new.rb
@@ -15,7 +15,7 @@
 #
 # The 4 algos/ subdirs are the documented convention but optional at use
 # time — discovery also accepts a single algos/my_llama.rb. recipes/ ships
-# a runnable hello.rb (mirrors examples/train_from_scratch.rb) so the very
+# a runnable hello.rb (mirrors examples/legacy/train_from_scratch.rb) so the very
 # first thing a newcomer can do is RUN something end-to-end.
 
 require "fileutils"
@@ -63,7 +63,7 @@ module Toy
         RUBY
 
         # A RUNNABLE L4 from-scratch starter, scaffolded into
-        # algos/recipes/hello.rb. Mirrors examples/train_from_scratch.rb:
+        # algos/recipes/hello.rb. Mirrors examples/legacy/train_from_scratch.rb:
         # the blessed value-object path (SmolLM2Config.mha + Toy::Labels +
         # Toy::AdamW + the FromScratch recipe).
         #
@@ -84,7 +84,7 @@ module Toy
           #
           # The blessed value-object path: a tiny Llama-shape model
           # (RMSNorm + GQA + RoPE + SwiGLU) trained through the L4
-          # FromScratch recipe. Mirrors examples/train_from_scratch.rb.
+          # FromScratch recipe. Mirrors examples/legacy/train_from_scratch.rb.
           #
           # Compile with Spinel (it loads the ffi-bearing TinyNN stack, so
           # it cannot run under MRI). The `toy_lib` symlink (→ a toy source

--- a/lib/toy/core/cli/new.rb
+++ b/lib/toy/core/cli/new.rb
@@ -21,6 +21,7 @@
 require "fileutils"
 require "json"
 require_relative "exit_codes"
+require_relative "../toy_root"
 
 module Toy
   module Core
@@ -98,7 +99,7 @@ module Toy
           #   /abs/path/to/hello   # → step 1: loss=…
 
           require_relative "toy_lib/toy"
-          require_relative "toy_lib/toy_smollm2"
+          require_relative "toy_lib/toy/models/toy_smollm2"
           require_relative "toy_lib/toy/llm/engine/llama_seq_engine"
           require_relative "toy_lib/toy/llm/adamw"
           require_relative "toy_lib/toy/llm/labels"
@@ -470,6 +471,16 @@ module Toy
           write_file(File.join(target, "algos", "recipes", "hello.rb"), HELLO_RECIPE)
           created << "algos/recipes/hello.rb"
 
+          # Seed data/ with the pinned tiny corpus so `toy train
+          # from-scratch` / `warm-start` work IN THE FRESH PROJECT (the
+          # runners read data/ts_seqs.{txt,bin} cwd-relative; without a
+          # seed the quickstart's first `toy train` failed — toy#60).
+          # Source: prep/fixtures/ts_seqs_gate.bin in the toy checkout
+          # (committed; the byte-pinned gate corpus). The .txt twin is
+          # derived from the same stream (32-token lines). Skipped with a
+          # warning when no toy root is locatable — never fatal.
+          created.concat(seed_corpus(target))
+
           # Symlink algos/recipes/toy_lib → $TOY_HOME/lib so hello.rb's
           # literal require_relative "toy_lib/..." resolves at Spinel
           # compile time. If TOY_HOME is unset we still create a dangling
@@ -492,6 +503,27 @@ module Toy
           created << "bin/toy"
 
           created
+        end
+
+        # Seed the scaffold's data/ with the pinned tiny corpus (both the
+        # packed-i32 .bin the warm-start runner streams and the text .txt
+        # the from-scratch runner reads). Returns the created rel paths
+        # ([] + a stderr warning when the toy root / fixture is missing).
+        def seed_corpus(target)
+          root = ToyRoot.locate_root
+          src  = root && File.join(root, "prep", "fixtures", "ts_seqs_gate.bin")
+          unless src && File.file?(src)
+            $stderr.puts "toy new: warning — could not seed data/ts_seqs.{bin,txt} " \
+                         "(no toy checkout found; set TOY_HOME). `toy train` will " \
+                         "need a corpus in data/."
+            return []
+          end
+          bytes = File.binread(src)
+          File.binwrite(File.join(target, "data", "ts_seqs.bin"), bytes)
+          tokens = bytes.unpack("l<*")
+          lines  = tokens.each_slice(32).map { |seq| seq.join(" ") }
+          File.write(File.join(target, "data", "ts_seqs.txt"), lines.join("\n") + "\n")
+          ["data/ts_seqs.bin", "data/ts_seqs.txt"]
         end
 
         # `toy new --lib <path>` — a library-composition project (Gemfile +

--- a/lib/toy/core/cli/train.rb
+++ b/lib/toy/core/cli/train.rb
@@ -118,6 +118,26 @@ module Toy
             return fail_out("--arch gpt2 supports only the `from-scratch` recipe")
           end
 
+          # Existence checks on user-suppliable paths BEFORE any build/shell
+          # (spinel-dev#17 class: the runner side also guards, but the CLI
+          # names the file and the fix first — and exits 2 like infer's /
+          # describe's named-but-missing model). Paths are cwd-relative to
+          # the PROJECT (the runner runs in Dir.pwd).
+          if @recipe == "lora"
+            lora_gguf = @model || "data/smollm2-135m-native.gguf"
+            unless File.file?(lora_gguf)
+              return bad_arg("no such file: #{lora_gguf} (lora needs a " \
+                             "native-layout base GGUF; see `toy list`, or convert one " \
+                             "with prep/convert_smollm2_to_gguf.py --ggml-native)")
+            end
+          elsif @recipe == "warm-start"
+            ws_corpus = @corpus || "data/ts_seqs.bin"
+            unless File.file?(ws_corpus)
+              return bad_arg("no such file: #{ws_corpus} (warm-start streams " \
+                             "packed-i32 tokens; `toy new` seeds data/ts_seqs.bin, or pass --corpus)")
+            end
+          end
+
           root = ToyRoot.locate_root
           unless root
             return fail_out(
@@ -211,7 +231,12 @@ module Toy
           out, status = Open3.capture2e(env, runner)
           unless status.success?
             tail = out.lines.last(20).join
-            return fail_out("runner exited #{status.exitstatus}:\n#{tail}")
+            # exitstatus is nil for a signal death (e.g. SEGV) — say so
+            # instead of the formerly-masked "runner exited :".
+            how = status.exitstatus ? status.exitstatus.to_s
+                                    : "from signal #{status.termsig} (#{Signal.signame(status.termsig) rescue '?'})"
+            tail = "(no output)" if tail.strip.empty?
+            return fail_out("runner exited #{how}:\n#{tail}")
           end
 
           losses = out.lines.select { |l| l.start_with?("step ") }.map(&:chomp)

--- a/lib/toy/io/model_index.rb
+++ b/lib/toy/io/model_index.rb
@@ -19,7 +19,7 @@
 # Filesystem walking goes through tnn_list_ggufs (a small C shim
 # in tinynn/tinynn_gguf.c) because Spinel's stdlib doesn't have
 # Dir.entries / opendir. That keeps the library Spinel-compilable into
-# a single binary (the link edge survives via examples/01_inference_metal.rb).
+# a single binary (the link edge survives via examples/legacy/01_inference_metal.rb).
 
 require_relative "../models/transformer"   # Mat is referenced via tinynn FFI bindings
 require_relative "../models/arch"

--- a/lib/toy/llm/archs/README.md
+++ b/lib/toy/llm/archs/README.md
@@ -24,4 +24,4 @@ Backend twins: `llama_arch_cuda.rb`, `llama_arch_metal.rb`.
 - Data pipeline.
 
 See `prep/smokes/smoke_recipe_*.rb` and the blessed
-`examples/train_from_scratch.rb` for the arch driven end-to-end.
+`examples/01_train_tiny.rb` for the arch driven end-to-end.

--- a/lib/toy/llm/archs/README.md
+++ b/lib/toy/llm/archs/README.md
@@ -23,5 +23,5 @@ Backend twins: `llama_arch_cuda.rb`, `llama_arch_metal.rb`.
 - Training loop, optimizer, schedule.
 - Data pipeline.
 
-See `examples/smoke_recipe_*.rb` and the blessed
+See `prep/smokes/smoke_recipe_*.rb` and the blessed
 `examples/train_from_scratch.rb` for the arch driven end-to-end.

--- a/lib/toy/llm/blocks/README.md
+++ b/lib/toy/llm/blocks/README.md
@@ -24,4 +24,4 @@ Backend twins: `transformer_block_cuda.rb`, `transformer_block_metal.rb`.
 - Whole-graph allocation.
 
 See `prep/smokes/smoke_recipe_*.rb` and the blessed
-`examples/train_from_scratch.rb` for the block driven end-to-end.
+`examples/01_train_tiny.rb` for the block driven end-to-end.

--- a/lib/toy/llm/blocks/README.md
+++ b/lib/toy/llm/blocks/README.md
@@ -23,5 +23,5 @@ Backend twins: `transformer_block_cuda.rb`, `transformer_block_metal.rb`.
 - Block stacking across N layers.
 - Whole-graph allocation.
 
-See `examples/smoke_recipe_*.rb` and the blessed
+See `prep/smokes/smoke_recipe_*.rb` and the blessed
 `examples/train_from_scratch.rb` for the block driven end-to-end.

--- a/lib/toy/llm/engine/vit_tiny_engine.rb
+++ b/lib/toy/llm/engine/vit_tiny_engine.rb
@@ -102,7 +102,7 @@ class ViTTinyEngine
     #
     # Caller responsibility: pre-flatten each patch into
     # [IC*P*P, N_patches] before uploading to t_image. Done host-side
-    # (cheap; see examples/smoke_vit_tiny.rb).
+    # (cheap; see prep/smokes/smoke_vit_tiny.rb).
     @patch_flat_dim = cfg.num_channels * cfg.patch_size * cfg.patch_size
     @t_patch_kernel = TinyNN.tnn_input_2d_f32_persistent(@sess,
                         cfg.d_model, @patch_flat_dim)
@@ -192,7 +192,7 @@ class ViTTinyEngine
 
     # Image input (graph input, NOT a PARAM): pre-flattened patch
     # matrix shape [IC*P*P, N_patches]. Caller does the host-side
-    # patch extraction; see examples/smoke_vit_tiny.rb.
+    # patch extraction; see prep/smokes/smoke_vit_tiny.rb.
     @t_image = TinyNN.tnn_input_2d_f32_persistent(@sess,
                   @n_patches, @patch_flat_dim)
 

--- a/lib/toy/llm/primitives/README.md
+++ b/lib/toy/llm/primitives/README.md
@@ -22,8 +22,8 @@ forward graph into the active session; the L3 Llama arch stacks the
 block N times. See the recipe exemplars that drive the whole stack
 end-to-end:
 
-- `examples/smoke_recipe_from_scratch.rb`
-- `examples/smoke_recipe_warm_start.rb`
-- `examples/smoke_recipe_lora.rb`
+- `prep/smokes/smoke_recipe_from_scratch.rb`
+- `prep/smokes/smoke_recipe_warm_start.rb`
+- `prep/smokes/smoke_recipe_lora.rb`
 
 and the blessed tutorial `examples/train_from_scratch.rb`.

--- a/lib/toy/llm/primitives/README.md
+++ b/lib/toy/llm/primitives/README.md
@@ -26,4 +26,4 @@ end-to-end:
 - `prep/smokes/smoke_recipe_warm_start.rb`
 - `prep/smokes/smoke_recipe_lora.rb`
 
-and the blessed tutorial `examples/train_from_scratch.rb`.
+and the blessed tutorial `examples/01_train_tiny.rb`.

--- a/lib/toy/llm/recipes/README.md
+++ b/lib/toy/llm/recipes/README.md
@@ -35,7 +35,7 @@ Model shape is built with the named `Toy::SmolLM2Config.mha` /
 
 The byte-gated exemplars users read:
 
-- `examples/train_from_scratch.rb` — the blessed short tutorial.
+- `examples/01_train_tiny.rb` — the blessed short tutorial.
 - `prep/smokes/smoke_recipe_from_scratch.rb`
 - `prep/smokes/smoke_recipe_warm_start.rb`
 - `prep/smokes/smoke_recipe_lora.rb`

--- a/lib/toy/llm/recipes/README.md
+++ b/lib/toy/llm/recipes/README.md
@@ -36,6 +36,6 @@ Model shape is built with the named `Toy::SmolLM2Config.mha` /
 The byte-gated exemplars users read:
 
 - `examples/train_from_scratch.rb` — the blessed short tutorial.
-- `examples/smoke_recipe_from_scratch.rb`
-- `examples/smoke_recipe_warm_start.rb`
-- `examples/smoke_recipe_lora.rb`
+- `prep/smokes/smoke_recipe_from_scratch.rb`
+- `prep/smokes/smoke_recipe_warm_start.rb`
+- `prep/smokes/smoke_recipe_lora.rb`

--- a/lib/toy/llm/recipes/from_scratch.rb
+++ b/lib/toy/llm/recipes/from_scratch.rb
@@ -2,7 +2,7 @@
 # random-init training plan. This is the MINIMAL viable surface that
 # encapsulates the EXISTING random_init training loop (the inlined loop
 # in prep/smokes/smoke_projection_lens.rb:97-112 and the fuller driver in
-# examples/06_train_from_scratch.rb): realize a random-init forward+
+# examples/legacy/06_train_from_scratch.rb): realize a random-init forward+
 # backward+AdamW graph on a Toy::LLM::Engine::LlamaSeqEngine, then drive one
 # training step at a time.
 #

--- a/lib/toy/llm/recipes/from_scratch.rb
+++ b/lib/toy/llm/recipes/from_scratch.rb
@@ -1,7 +1,7 @@
 # lib/toy/llm/recipes/from_scratch.rb — L4 recipe: the from-scratch
 # random-init training plan. This is the MINIMAL viable surface that
 # encapsulates the EXISTING random_init training loop (the inlined loop
-# in examples/smoke_projection_lens.rb:97-112 and the fuller driver in
+# in prep/smokes/smoke_projection_lens.rb:97-112 and the fuller driver in
 # examples/06_train_from_scratch.rb): realize a random-init forward+
 # backward+AdamW graph on a Toy::LLM::Engine::LlamaSeqEngine, then drive one
 # training step at a time.

--- a/lib/toy/llm/recipes/lora.rb
+++ b/lib/toy/llm/recipes/lora.rb
@@ -27,7 +27,7 @@
 # (landmine #4). Members uniquely lora_-prefixed for type-isolation. No
 # Card/step_bind/FFI :str args at class load. Experiment config (GGUF
 # path, RANK, tokens, labels, hp, LR, seed/scale) stays in the FIXTURE
-# (examples/smoke_recipe_lora.rb) per lib-vs-example scope, never here.
+# (prep/smokes/smoke_recipe_lora.rb) per lib-vs-example scope, never here.
 #
 # Like FromScratch, this file does NOT `require_relative "tinynn"`: the
 # loading module (lib/llama_seq_forward_ffi.rb, required by the fixture

--- a/lib/toy/llm/recipes/lora.rb
+++ b/lib/toy/llm/recipes/lora.rb
@@ -17,7 +17,7 @@
 # download-loss. Per the L4 design note in from_scratch.rb, a sibling
 # class duplicating the ~8-line step! is acceptable and simpler than a
 # shared module; we do NOT over-abstract. Op order is VERBATIM from the
-# frozen reference examples/03_finetune_lora.rb:179-191.
+# frozen reference examples/legacy/03_finetune_lora.rb:179-191.
 #
 # This recipe just CALLS realize_for_mmap — it does not refactor it — so
 # no realize-bulk coverage rules apply.

--- a/lib/toy/llm/recipes/vit_tiny.rb
+++ b/lib/toy/llm/recipes/vit_tiny.rb
@@ -1,6 +1,6 @@
 # lib/toy/llm/recipes/vit_tiny.rb — L4 recipe: ViT-Tiny from-scratch
 # random-init image-classifier training plan. Encapsulates the EXISTING
-# ViT training loop (examples/07_train_vit_tiny.rb at INIT=scratch): realize
+# ViT training loop (examples/legacy/07_train_vit_tiny.rb at INIT=scratch): realize
 # a random-init forward+CE+backward+AdamW graph on a Toy::LLM::Engine::ViTTinyEngine,
 # then drive one training step at a time.
 #
@@ -48,7 +48,7 @@ module Toy; module LLM; module Recipes
     end
 
     # ONE training step. Op order is VERBATIM from
-    # examples/07_train_vit_tiny.rb:269-281: graph_reset on the first step
+    # examples/legacy/07_train_vit_tiny.rb:269-281: graph_reset on the first step
     # else reset_grads_only; the four uploads in order
     # (image/cls_idx/labels/hp); compute_backward; download_row_major(t_loss,
     # 1, 1). is_first selects the reset, so the caller stays in full control

--- a/lib/toy/llm/recipes/warm_start.rb
+++ b/lib/toy/llm/recipes/warm_start.rb
@@ -10,7 +10,7 @@
 # SPLIT into separate public methods (realize_scratch! / realize_warm! /
 # build!) so the fixture can upload the donor embedding (and/or the PCA
 # lens) BETWEEN realize and build — mirroring the frozen reference
-# examples/09_warm_start_train.rb: realize (L138) → upload donor
+# examples/legacy/09_warm_start_train.rb: realize (L138) → upload donor
 # (L145-184) / PCA lens (L188-229) → build_training_step (L231).
 # FromScratch FUSES realize_for_random_init + build_training_step into
 # one realize! because it has nothing to upload between; WarmStart must

--- a/lib/toy/run/eval.rb
+++ b/lib/toy/run/eval.rb
@@ -42,6 +42,14 @@ require_relative "../models/transformer_lm"
 GGUF  = ENV["GGUF"] || "data/smollm2-135m-f32.gguf"
 TOP_K = (ENV["TOP_K"] || "5").to_i
 
+# Explicit existence check BEFORE any GGUF read (spinel-dev#17 class:
+# missing user-suppliable paths fail loud and name the path + the fix).
+if !File.exist?(GGUF)
+  puts "toy-eval: no such file: " + GGUF +
+       " (set GGUF= to a llama-family model; `toy list` shows local caches)"
+  exit 1
+end
+
 arch = Arch.load_or_fail(GGUF, "toy-eval")
 
 lm = ToyLM.new(arch, :cpu)

--- a/lib/toy/run/eval_cuda.rb
+++ b/lib/toy/run/eval_cuda.rb
@@ -32,6 +32,13 @@ require_relative "../dev/toy_logprobs"
 GGUF  = ENV["GGUF"] || "data/smollm2-135m-f32.gguf"
 TOP_K = (ENV["TOP_K"] || "5").to_i
 
+# Explicit existence check BEFORE any GGUF read (spinel-dev#17 class).
+if !File.exist?(GGUF)
+  puts "toy-eval-cuda: no such file: " + GGUF +
+       " (set GGUF= to a llama-family model; `toy list` shows local caches)"
+  exit 1
+end
+
 arch = Arch.load_or_fail(GGUF, "toy-eval")
 
 lm = ToyLMCuda.new(arch)

--- a/lib/toy/run/eval_lmc.rb
+++ b/lib/toy/run/eval_lmc.rb
@@ -62,7 +62,19 @@ RUN_DIR  = ENV["TAO_RUN_DIR"] || ""
 RUN_ID   = ENV["TOY_RUN_ID"]  || "lmc"
 
 if LMC_A == "" || LMC_B == ""
-  STDERR.puts "toy-eval-lmc: LMC_A and LMC_B are required"
+  puts "toy-eval-lmc: LMC_A and LMC_B are required"
+  exit 1
+end
+# Explicit existence checks BEFORE the gguf open (spinel-dev#17 class:
+# a missing user-suppliable path must fail loud and name the path).
+if !File.exist?(LMC_A)
+  puts "toy-eval-lmc: no such file: LMC_A=" + LMC_A +
+       " (pass a from-scratch checkpoint GGUF, e.g. runs/<id>/weights/latest)"
+  exit 1
+end
+if !File.exist?(LMC_B)
+  puts "toy-eval-lmc: no such file: LMC_B=" + LMC_B +
+       " (pass a from-scratch checkpoint GGUF, e.g. runs/<id>/weights/latest)"
   exit 1
 end
 
@@ -81,10 +93,10 @@ end
 ggA = TinyNN.tnn_gguf_load(LMC_A)
 ggB = TinyNN.tnn_gguf_load(LMC_B)
 if ggA == nil || ggA == TinyNN.tnn_null_ptr
-  STDERR.puts "toy-eval-lmc: cannot open LMC_A=" + LMC_A; exit 1
+  puts "toy-eval-lmc: cannot open LMC_A=" + LMC_A; exit 1
 end
 if ggB == nil || ggB == TinyNN.tnn_null_ptr
-  STDERR.puts "toy-eval-lmc: cannot open LMC_B=" + LMC_B; exit 1
+  puts "toy-eval-lmc: cannot open LMC_B=" + LMC_B; exit 1
 end
 
 vocab     = TinyNN.tnn_gguf_get_u32(ggA, "llama.vocab_size")
@@ -158,7 +170,7 @@ def fused_lookup_a(fused_names, fused_a, fused_b, ggA, ggB, fused_name, nel_full
   idx_a = TinyNN.tnn_gguf_find_index(ggA, fused_name)
   idx_b = TinyNN.tnn_gguf_find_index(ggB, fused_name)
   if idx_a < 0 || idx_b < 0
-    STDERR.puts "toy-eval-lmc: missing fused " + fused_name +
+    puts "toy-eval-lmc: missing fused " + fused_name +
                 " in A=" + idx_a.to_s + " B=" + idx_b.to_s
     return -1
   end
@@ -235,7 +247,7 @@ while ai < alphas_arr.length
       idx_a = TinyNN.tnn_gguf_find_index(ggA, name)
       idx_b = TinyNN.tnn_gguf_find_index(ggB, name)
       if idx_a < 0 || idx_b < 0
-        STDERR.puts "toy-eval-lmc: missing " + name +
+        puts "toy-eval-lmc: missing " + name +
                     " in A=" + idx_a.to_s + " B=" + idx_b.to_s
         pi = pi + 1
       else

--- a/lib/toy/run/eval_lmc.rb
+++ b/lib/toy/run/eval_lmc.rb
@@ -11,7 +11,7 @@
 # this runner (`make libexec/toy-eval-lmc`), and shells out to it via Open3
 # with a CONTROLLED ENV.
 #
-# It is a FUSED-FORMAT-AWARE port of examples/08_lmc.rb. 08_lmc predates the
+# It is a FUSED-FORMAT-AWARE port of examples/legacy/08_lmc.rb. 08_lmc predates the
 # #3 fused-llama checkpoint format; `toy train` now writes a STANDARD FUSED
 # llama GGUF (projection-lens folded + per-head attention FUSED to
 # blk.N.attn_q.weight at write time). The session realized here is the

--- a/lib/toy/run/eval_metal.rb
+++ b/lib/toy/run/eval_metal.rb
@@ -33,6 +33,13 @@ require_relative "../dev/toy_logprobs"
 GGUF  = ENV["GGUF"] || "data/smollm2-135m-f32.gguf"
 TOP_K = (ENV["TOP_K"] || "5").to_i
 
+# Explicit existence check BEFORE any GGUF read (spinel-dev#17 class).
+if !File.exist?(GGUF)
+  puts "toy-eval-metal: no such file: " + GGUF +
+       " (set GGUF= to a llama-family model; `toy list` shows local caches)"
+  exit 1
+end
+
 arch = Arch.load_or_fail(GGUF, "toy-eval")
 
 lm = ToyLMMetal.new(arch)

--- a/lib/toy/run/infer.rb
+++ b/lib/toy/run/infer.rb
@@ -43,6 +43,14 @@ N_NEW  = (ENV["N_NEW"] || "16").to_i
 # caller passes raw ids. Empty when unset.
 PROMPT_IDS = ENV["PROMPT_IDS"] || ""
 
+# Explicit existence check BEFORE any GGUF read (spinel-dev#17 class:
+# missing user-suppliable paths fail loud and name the path + the fix).
+if !File.exist?(GGUF)
+  puts "toy-infer: no such file: " + GGUF +
+       " (set GGUF= to a llama-family model; `toy list` shows local caches)"
+  exit 1
+end
+
 arch = Arch.load_or_fail(GGUF, "toy-infer")
 puts arch.summary
 

--- a/lib/toy/run/infer_cuda.rb
+++ b/lib/toy/run/infer_cuda.rb
@@ -51,6 +51,13 @@ def all_digits?(s)
   true
 end
 
+# Explicit existence check BEFORE any GGUF read (spinel-dev#17 class).
+if !File.exist?(GGUF)
+  puts "toy-infer-cuda: no such file: " + GGUF +
+       " (set GGUF= to a llama-family model; `toy list` shows local caches)"
+  exit 1
+end
+
 arch = Arch.load_or_fail(GGUF, "toy-infer")
 puts arch.summary
 

--- a/lib/toy/run/infer_metal.rb
+++ b/lib/toy/run/infer_metal.rb
@@ -52,6 +52,13 @@ def all_digits?(s)
   true
 end
 
+# Explicit existence check BEFORE any GGUF read (spinel-dev#17 class).
+if !File.exist?(GGUF)
+  puts "toy-infer-metal: no such file: " + GGUF +
+       " (set GGUF= to a llama-family model; `toy list` shows local caches)"
+  exit 1
+end
+
 arch = Arch.load_or_fail(GGUF, "toy-infer")
 puts arch.summary
 

--- a/lib/toy/run/train.rb
+++ b/lib/toy/run/train.rb
@@ -92,7 +92,7 @@ EVENTS = TAO_RUN_DIR.length > 0 ? (TAO_RUN_DIR + "/events.jsonl") : ""
 if RECIPE == "warm-start"
   # ==================================================================
   # WARM-START BRANCH — fully self-contained (landmine #16). Mirrors
-  # examples/smoke_recipe_warm_start.rb at INIT=scratch (the gate ground
+  # prep/smokes/smoke_recipe_warm_start.rb at INIT=scratch (the gate ground
   # truth). INIT=scratch skips realize_warm! (no donor GGUF).
   # ==================================================================
   lr_max = 0.001

--- a/lib/toy/run/train.rb
+++ b/lib/toy/run/train.rb
@@ -100,6 +100,16 @@ if RECIPE == "warm-start"
   warmup = 5
   corpus = ENV["CORPUS"] || "data/ts_seqs.bin"
 
+  # FAIL LOUD on a missing corpus BEFORE realize (spinel-dev#17 class:
+  # ToyCorpusLoader zero-fills a failed read with a WARN line, so a
+  # missing path would silently train on zeros). Named + actionable.
+  if !File.exist?(corpus)
+    puts "toy-train: corpus not found: " + corpus
+    puts "  warm-start streams packed-i32 tokens from CORPUS= (default data/ts_seqs.bin)."
+    puts "  `toy new` seeds a project copy; in a toy checkout run prep/prep_tinystories.rb."
+    exit 1
+  end
+
   cfg_ws = Toy::SmolLM2Config.mha(VOCAB, D_MODEL, N_HEADS,
                                   D_FF, N_LAYERS, CONTEXT, 10000.0, 1.0e-5)
   cfg_ws.donor_d_in = DONOR_D
@@ -259,6 +269,17 @@ ToyDescribeFlow.emit_flow_json(TAO_RUN_DIR, recipe.fs_cache.sess)
 
 # Per-step inputs built IN THE RUNNER (the from-scratch entrypoint, the
 # fixture's analog under lib-vs-example), byte-identical to smoke L56-84.
+#
+# FAIL LOUD on the missing corpus FIRST: under Spinel, File.read on a
+# missing path silently returns "" (spinel-dev#17) and the nil first
+# line then SEGVs (observed: `toy train` from a fresh `toy new` project
+# died with signal 11 and no message). Named + actionable instead.
+if !File.exist?("data/ts_seqs.txt")
+  puts "toy-train: corpus not found: data/ts_seqs.txt (cwd-relative)"
+  puts "  from-scratch reads the first line of data/ts_seqs.txt."
+  puts "  `toy new` seeds a project copy; in a toy checkout run prep/prep_tinystories.rb."
+  exit 1
+end
 raw        = File.read("data/ts_seqs.txt")
 first_line = raw.split("\n")[0]
 parts      = first_line.split(" ")

--- a/lib/toy/run/train_cuda.rb
+++ b/lib/toy/run/train_cuda.rb
@@ -104,6 +104,15 @@ if RECIPE == "warm-start"
   warmup = 5
   corpus = ENV["CORPUS"] || "data/ts_seqs.bin"
 
+  # FAIL LOUD on a missing corpus (spinel-dev#17 class: the loader
+  # zero-fills failed reads with only a WARN line).
+  if !File.exist?(corpus)
+    puts "toy-train: corpus not found: " + corpus
+    puts "  warm-start streams packed-i32 tokens from CORPUS= (default data/ts_seqs.bin)."
+    puts "  `toy new` seeds a project copy; in a toy checkout run prep/prep_tinystories.rb."
+    exit 1
+  end
+
   cfg_ws = Toy::SmolLM2Config.mha(VOCAB, D_MODEL, N_HEADS,
                                   D_FF, N_LAYERS, CONTEXT, 10000.0, 1.0e-5)
   cfg_ws.donor_d_in = DONOR_D
@@ -257,6 +266,12 @@ recipe.realize!(cfg, opts)
 ToyDescribeFlow.emit_flow_json(TAO_RUN_DIR, recipe.fs_cache.sess)
 
 # Per-step inputs built IN THE RUNNER, byte-identical to the CPU runner.
+# FAIL LOUD on a missing corpus (spinel-dev#17: silent "" then nil SEGV).
+if !File.exist?("data/ts_seqs.txt")
+  puts "toy-train-cuda: corpus not found: data/ts_seqs.txt (cwd-relative)"
+  puts "  `toy new` seeds a project copy; in a toy checkout run prep/prep_tinystories.rb."
+  exit 1
+end
 raw        = File.read("data/ts_seqs.txt")
 first_line = raw.split("\n")[0]
 parts      = first_line.split(" ")

--- a/lib/toy/run/train_gpt2.rb
+++ b/lib/toy/run/train_gpt2.rb
@@ -48,6 +48,13 @@ engine = Toy::LLM::Engine::GPT2SeqEngine.new
 engine.realize!(VOCAB, D_MODEL, N_HEADS, D_FF, N_LAYERS, CONTEXT, SEED)
 
 # First corpus line → CONTEXT token ids, zero-padded (from-scratch ground truth).
+# FAIL LOUD first: Spinel's File.read on a missing path silently returns ""
+# (spinel-dev#17) and the nil first line SEGVs. Named + actionable instead.
+if !File.exist?("data/ts_seqs.txt")
+  puts "toy-train-gpt2: corpus not found: data/ts_seqs.txt (cwd-relative)"
+  puts "  `toy new` seeds a project copy; in a toy checkout run prep/prep_tinystories.rb."
+  exit 1
+end
 raw     = File.read("data/ts_seqs.txt")
 lines   = raw.split("\n")
 parts   = lines[0].split(" ")

--- a/lib/toy/run/train_gpt2_cuda.rb
+++ b/lib/toy/run/train_gpt2_cuda.rb
@@ -30,6 +30,12 @@ CONTEXT  = 32
 engine = Toy::LLM::Engine::GPT2SeqEngineCuda.new
 engine.realize!(VOCAB, D_MODEL, N_HEADS, D_FF, N_LAYERS, CONTEXT, SEED)
 
+# FAIL LOUD on a missing corpus (spinel-dev#17: silent "" then nil SEGV).
+if !File.exist?("data/ts_seqs.txt")
+  puts "toy-train-gpt2-cuda: corpus not found: data/ts_seqs.txt (cwd-relative)"
+  puts "  `toy new` seeds a project copy; in a toy checkout run prep/prep_tinystories.rb."
+  exit 1
+end
 raw     = File.read("data/ts_seqs.txt")
 lines   = raw.split("\n")
 parts   = lines[0].split(" ")

--- a/lib/toy/run/train_gpt2_metal.rb
+++ b/lib/toy/run/train_gpt2_metal.rb
@@ -30,6 +30,12 @@ CONTEXT  = 32
 engine = Toy::LLM::Engine::GPT2SeqEngineMetal.new
 engine.realize!(VOCAB, D_MODEL, N_HEADS, D_FF, N_LAYERS, CONTEXT, SEED)
 
+# FAIL LOUD on a missing corpus (spinel-dev#17: silent "" then nil SEGV).
+if !File.exist?("data/ts_seqs.txt")
+  puts "toy-train-gpt2-metal: corpus not found: data/ts_seqs.txt (cwd-relative)"
+  puts "  `toy new` seeds a project copy; in a toy checkout run prep/prep_tinystories.rb."
+  exit 1
+end
 raw     = File.read("data/ts_seqs.txt")
 lines   = raw.split("\n")
 parts   = lines[0].split(" ")

--- a/lib/toy/run/train_lora.rb
+++ b/lib/toy/run/train_lora.rb
@@ -25,7 +25,7 @@
 # (default the 135m native gguf), TAO_RUN_DIR (events + checkpoint sink),
 # TOY_RUN_ID (run metadata). The gate-fixed lora knobs (LR=0.001,
 # TARGET_ID=99, TOKENS, seed=42, init_scale=0.01, hp) are HARDCODED here,
-# byte-mirroring examples/smoke_recipe_lora.rb (the gate ground truth).
+# byte-mirroring prep/smokes/smoke_recipe_lora.rb (the gate ground truth).
 #
 # CONFIG NOTE: we deliberately do NOT `require toy_smollm2_loader` (it
 # transitively pulls gpt2.rb, whose CausalSelfAttention/FFN share an

--- a/lib/toy/run/train_metal.rb
+++ b/lib/toy/run/train_metal.rb
@@ -97,6 +97,12 @@ recipe.realize!(cfg, opts)
 ToyDescribeFlow.emit_flow_json(TAO_RUN_DIR, recipe.fs_cache.sess)
 
 # Per-step inputs built IN THE RUNNER, byte-identical to the CPU runner.
+# FAIL LOUD on a missing corpus (spinel-dev#17: silent "" then nil SEGV).
+if !File.exist?("data/ts_seqs.txt")
+  puts "toy-train-metal: corpus not found: data/ts_seqs.txt (cwd-relative)"
+  puts "  `toy new` seeds a project copy; in a toy checkout run prep/prep_tinystories.rb."
+  exit 1
+end
 raw        = File.read("data/ts_seqs.txt")
 first_line = raw.split("\n")[0]
 parts      = first_line.split(" ")

--- a/prep/README.md
+++ b/prep/README.md
@@ -4,6 +4,16 @@ Everything in here is *development tooling*: nothing under `prep/` ships
 in the library, and `lib/` never requires a `prep/` file. Three families
 live side by side; the filename tells you which one you're holding.
 
+## Gate smokes (`smokes/smoke_*.rb`) — the compiled fixtures
+
+`prep/smokes/` holds the Spinel-compiled smoke fixtures the gates build
+and run (formerly `examples/smoke_*.rb` — they are GATES, not tutorials,
+so they live in gate-land). Each `smoke_<name>.rb` compiles to
+`prep/smokes/smoke_<name>` via `make prep/smokes/smoke_<name>` and
+asserts one primitive/recipe/branch end-to-end; `docs/gating.md` is the
+index. Binaries are gitignored; run them from the repo root (they read
+`data/` fixtures relative to the cwd).
+
 ## Gates (`*_gate.rb`) — the acceptance bar
 
 A gate is a self-contained CRuby script that builds whatever it needs

--- a/prep/consumer_gate.rb
+++ b/prep/consumer_gate.rb
@@ -1,0 +1,187 @@
+#!/usr/bin/env ruby
+# prep/consumer_gate.rb — toy#60 item 4: the COLD-START consumer gate.
+#
+# Proves the README / docs/framework.md quickstart is TESTED, not
+# aspirational. Two legs, both in a throwaway tmpdir:
+#
+#   APP leg  — `toy new gatelab`:
+#     * the scaffold seeds data/ts_seqs.{bin,txt} (so `toy train` works)
+#     * algos/recipes/hello.rb compiles with $SPINEL_DIR's spinel
+#     * ./hello runs with default ENV (3 "step N: loss=" lines, finite)
+#     * D_MODEL=128 STEPS=10 ./hello runs WITHOUT recompiling (one
+#       compile, many runs) and produces a different curve
+#     * `toy train from-scratch --steps 2` in the project prints losses
+#       AND writes runs/<id>/events.jsonl (run_start + step events)
+#     * the fail-loud guard: with data/ts_seqs.txt removed, `toy train`
+#       exits non-zero and NAMES the missing path (spinel-dev#17 class)
+#
+#   LIB leg  — `toy new gatelib --lib`:
+#     * Gemfile pointed at this checkout (path:), `bundle lock`
+#     * `spinel-compat vendor` builds ggml + tinynn INSIDE vendor/
+#     * `./build.sh cpu` compiles, `./experiment_cpu` trains to
+#       "experiment: ok (device=cpu)"
+#     SKIPS LOUDLY (exit 0, like the model-gated gates) when bundler or
+#     spinel-compat is not available — the app leg always runs.
+#
+# Structural gate (loss finite + decreasing-ish, files exist), NOT
+# byte-exact: a consumer cold-start exercises scaffold + build + run
+# wiring, not numerics (those are train_gate's job).
+#
+#   make gate-consumer            # or: ruby prep/consumer_gate.rb
+#
+# Env: SPINEL_DIR (default ~/sites/spinel), SPINELGEMS_DIR (default
+# ~/sites/spinelgems), KEEP=1 to keep the tmpdir for inspection.
+
+require "open3"
+require "tmpdir"
+require "fileutils"
+require "json"
+
+ROOT       = File.expand_path("..", __dir__)
+SPINEL_DIR = ENV["SPINEL_DIR"] || File.join(Dir.home, "sites", "spinel")
+SPINEL_BIN = File.join(SPINEL_DIR, "spinel")
+
+abort "GATE FAIL [consumer]: no spinel at #{SPINEL_BIN} (set SPINEL_DIR=)" unless File.executable?(SPINEL_BIN)
+
+def run!(desc, cmd, env: {}, chdir: Dir.pwd, expect_fail: false)
+  out, status = Open3.capture2e(env, *cmd, chdir: chdir)
+  if expect_fail
+    if status.success?
+      puts out
+      abort "GATE FAIL [consumer]: #{desc} — expected non-zero exit, got success"
+    end
+  elsif !status.success?
+    puts out
+    abort "GATE FAIL [consumer]: #{desc} — exit #{status.exitstatus.inspect}"
+  end
+  out
+end
+
+def loss_lines(out)
+  out.lines.select { |l| l.start_with?("step ") && l.include?("loss=") }
+end
+
+def losses(out)
+  loss_lines(out).map { |l| l[/loss=([-\d.eE+]+)/, 1].to_f }
+end
+
+# Tool discovery for the LIB leg (loud skip when absent).
+def find_bundle
+  return "bundle" if system("command -v bundle >/dev/null 2>&1")
+  rv = File.join(Dir.home, ".local", "share", "rv", "rubies", "ruby-3.4.9", "bin", "bundle")
+  return rv if File.executable?(rv)
+  nil
+end
+
+def find_spinel_compat
+  env = ENV["SPINELGEMS_DIR"]
+  cands = []
+  cands << File.join(env, "exe", "spinel-compat") if env && !env.empty?
+  cands << File.join(Dir.home, "sites", "spinelgems", "exe", "spinel-compat")
+  cands.find { |c| File.executable?(c) }
+end
+
+# Precondition: the checkout's CPU archive (hello links -Ltinynn from ROOT).
+run!("build tinynn archive", ["make", "-C", ROOT, "tinynn/libtinynn_ggml.a"])
+
+tmp = Dir.mktmpdir("toy60-consumer-")
+puts "consumer gate: tmpdir #{tmp}#{ENV['KEEP'] == '1' ? ' (kept)' : ''}"
+begin
+  base_env = { "TOY_HOME" => ROOT, "SPINEL_DIR" => SPINEL_DIR }
+
+  # ── APP leg ─────────────────────────────────────────────────────────
+  lab = File.join(tmp, "gatelab")
+  out = run!("toy new gatelab", ["ruby", File.join(ROOT, "bin", "toy"), "new", lab], env: base_env)
+  %w[algos/recipes/hello.rb data/ts_seqs.bin data/ts_seqs.txt toy.yml bin/toy].each do |rel|
+    abort "GATE FAIL [consumer]: scaffold missing #{rel}\n#{out}" unless File.exist?(File.join(lab, rel))
+  end
+  link = File.join(lab, "algos", "recipes", "toy_lib")
+  abort "GATE FAIL [consumer]: toy_lib symlink missing/dangling" unless File.exist?(link)
+  puts "  ok: scaffold tree + seeded corpus + toy_lib link"
+
+  hello = File.join(lab, "hello")
+  out = run!("compile hello.rb",
+             [SPINEL_BIN, File.join(lab, "algos", "recipes", "hello.rb"), "-o", hello],
+             chdir: ROOT)   # relative -Ltinynn/-Lvendor link flags resolve in ROOT
+  abort "GATE FAIL [consumer]: hello binary not produced\n#{out}" unless File.executable?(hello)
+  compile_mtime = File.mtime(hello)
+  puts "  ok: hello.rb compiled (#{SPINEL_BIN})"
+
+  out1 = run!("./hello (defaults)", [hello], chdir: lab)
+  l1 = losses(out1)
+  abort "GATE FAIL [consumer]: expected 3 default-step loss lines, got #{l1.length}\n#{out1}" unless l1.length == 3
+  abort "GATE FAIL [consumer]: non-finite loss in default run\n#{out1}" unless l1.all?(&:finite?)
+  puts "  ok: hello defaults — #{loss_lines(out1).first.strip} … #{loss_lines(out1).last.strip}"
+
+  out2 = run!("./hello (D_MODEL=128 STEPS=10, no recompile)", [hello],
+              env: { "D_MODEL" => "128", "STEPS" => "10" }, chdir: lab)
+  l2 = losses(out2)
+  abort "GATE FAIL [consumer]: expected 10 override-step lines, got #{l2.length}\n#{out2}" unless l2.length == 10
+  abort "GATE FAIL [consumer]: non-finite loss in override run\n#{out2}" unless l2.all?(&:finite?)
+  abort "GATE FAIL [consumer]: hello was recompiled between runs" unless File.mtime(hello) == compile_mtime
+  abort "GATE FAIL [consumer]: D_MODEL override had no effect (identical curves)" if l1 == l2.first(3)
+  puts "  ok: ENV override (one compile, many runs) — final loss #{l2.last}"
+
+  out = run!("toy train from-scratch in the scaffold",
+             ["ruby", File.join(lab, "bin", "toy"), "train", "from-scratch", "--steps", "2"],
+             env: base_env, chdir: lab)
+  lt = losses(out)
+  abort "GATE FAIL [consumer]: toy train printed #{lt.length} loss lines (want 2)\n#{out}" unless lt.length == 2
+  bundles = Dir[File.join(lab, "runs", "*", "events.jsonl")]
+  abort "GATE FAIL [consumer]: toy train wrote no runs/<id>/events.jsonl\n#{out}" if bundles.empty?
+  first_ev = JSON.parse(File.readlines(bundles.first).first)
+  abort "GATE FAIL [consumer]: events.jsonl first event is not run_start" unless first_ev["kind"] == "run_start"
+  puts "  ok: toy train — losses print + #{bundles.first.sub(lab + '/', '')} written"
+
+  # Fail-loud leg: a missing corpus must NAME the path, never SEGV/mask.
+  FileUtils.mv(File.join(lab, "data", "ts_seqs.txt"), File.join(lab, "data", "ts_seqs.txt.off"))
+  out = run!("toy train with corpus removed (must fail loud)",
+             ["ruby", File.join(lab, "bin", "toy"), "train", "from-scratch", "--steps", "1"],
+             env: base_env, chdir: lab, expect_fail: true)
+  unless out.include?("corpus not found: data/ts_seqs.txt")
+    puts out
+    abort "GATE FAIL [consumer]: missing-corpus error does not name the path"
+  end
+  FileUtils.mv(File.join(lab, "data", "ts_seqs.txt.off"), File.join(lab, "data", "ts_seqs.txt"))
+  puts "  ok: fail-loud — missing corpus names the path (no silent \"\" read)"
+
+  # ── LIB leg ─────────────────────────────────────────────────────────
+  bundle = find_bundle
+  compat = find_spinel_compat
+  if bundle.nil? || compat.nil?
+    puts "GATE SKIP [consumer/lib]: #{bundle ? '' : 'bundler '}#{compat ? '' : 'spinel-compat '}not available — app leg passed; lib leg skipped loudly"
+  else
+    libp = File.join(tmp, "gatelib")
+    run!("toy new gatelib --lib", ["ruby", File.join(ROOT, "bin", "toy"), "new", libp, "--lib"], env: base_env)
+    # Point the Gemfile at THIS checkout (the scaffold's rubygems form
+    # works once toy is published; the gate must be hermetic).
+    File.write(File.join(libp, "Gemfile"), <<~GEMFILE)
+      source "https://rubygems.org"
+      ruby "3.2.3", engine: "spinel", engine_version: "0.0.0"
+      gem "toy", path: #{ROOT.inspect}
+    GEMFILE
+    run!("bundle lock", [bundle, "lock"], chdir: libp)
+    run!("spinel-compat vendor", [compat, "vendor"], env: { "SPINEL_DIR" => SPINEL_DIR }, chdir: libp)
+    %w[vendor/spinel/toy/tinynn/libtinynn_ggml.a vendor/spinel/toy/vendor/ggml/build/src/libggml.a].each do |rel|
+      abort "GATE FAIL [consumer]: vendor step did not build #{rel}" unless File.file?(File.join(libp, rel))
+    end
+    puts "  ok: vendored (lib/ + ggml + tinynn archives inside the project)"
+
+    # build.sh calls bare `spinel` — give it a PATH shim to $SPINEL_BIN.
+    shim = File.join(tmp, "binshim"); FileUtils.mkdir_p(shim)
+    FileUtils.ln_sf(SPINEL_BIN, File.join(shim, "spinel"))
+    run!("./build.sh cpu", ["./build.sh", "cpu"],
+         env: { "PATH" => "#{shim}:#{ENV['PATH']}" }, chdir: libp)
+    exp = File.join(libp, "experiment_cpu")
+    abort "GATE FAIL [consumer]: build.sh produced no experiment_cpu" unless File.executable?(exp)
+    out = run!("./experiment_cpu", [exp], env: { "STEPS" => "5" }, chdir: libp)
+    le = losses(out)
+    abort "GATE FAIL [consumer]: experiment_cpu printed #{le.length} loss lines (want 5)\n#{out}" unless le.length == 5
+    abort "GATE FAIL [consumer]: experiment_cpu missing final ok line\n#{out}" unless out.include?("experiment: ok (device=cpu)")
+    puts "  ok: --lib leg — vendored build + experiment_cpu trains (final loss #{le.last})"
+  end
+
+  puts "GATE PASS [consumer]: cold-start quickstart works (scaffold + hello compile/run + ENV re-run + toy train runs/ bundle#{bundle && compat ? ' + --lib vendor/build/run' : ''})"
+ensure
+  FileUtils.remove_entry(tmp) unless ENV["KEEP"] == "1"
+end

--- a/prep/full_finetune_gate.rb
+++ b/prep/full_finetune_gate.rb
@@ -21,7 +21,7 @@ require "open3"
 
 ROOT     = File.expand_path("..", __dir__)
 GGUF     = File.join(ROOT, "data", "smollm2-135m-native.gguf")
-RUNNER   = File.join(ROOT, "examples", "smoke_full_finetune")
+RUNNER   = File.join(ROOT, "prep", "smokes", "smoke_full_finetune")
 BASELINE = File.join(ROOT, "prep", "fixtures", "full_finetune_baseline.txt")
 RECORD   = ARGV.include?("--record")
 
@@ -31,7 +31,7 @@ unless File.exist?(GGUF)
   exit 0
 end
 
-build_out, build_st = Open3.capture2e("make", "examples/smoke_full_finetune", chdir: ROOT)
+build_out, build_st = Open3.capture2e("make", "prep/smokes/smoke_full_finetune", chdir: ROOT)
 unless build_st.success? && File.exist?(RUNNER)
   puts "GATE FAIL [full-finetune]: build failed"
   puts build_out

--- a/prep/gen_cuda_mirror.rb
+++ b/prep/gen_cuda_mirror.rb
@@ -70,7 +70,7 @@ MIRRORABLE = [
   "lib/gpt2_ffi.rb",                    # GPT-2 full-forward FFI (Phase 0.6 step 3)
   "lib/gpt2_ffi_kv.rb",                 # GPT-2 KV-cache decode (Phase 0.6 step 3)
   "examples/06_train_from_scratch.rb",  # #152: from-scratch training entry (CPU/CUDA)
-  "examples/smoke_projection_lens.rb",  # P2.6 CUDA gate: realize_for_random_init forward on GPU
+  "prep/smokes/smoke_projection_lens.rb", # P2.6 CUDA gate: realize_for_random_init forward on GPU
 ]
 
 # Per-backend codegen parameters.
@@ -366,15 +366,17 @@ def subs_for(cpu_path, backend)
       [/\bLlamaSeqEngine\b/, "LlamaSeqEngine" + suffix],
     ] + common_module_tail
 
-  when "examples/smoke_projection_lens.rb"
+  when "prep/smokes/smoke_projection_lens.rb"
     # P2.6 CUDA gate — mirror of the projection-lens smoke so the
     # realize_for_random_init forward can be parity-gated on the GPU
     # backend (CUDA self-consistency, not CPU bit-equality). Same
     # rewrites as the 06 example: require the GPU engine mirror,
     # rename the engine class, TinyNN. -> TinyNN<Suffix>. via the tail.
+    # (Smokes live two levels below repo root — prep/smokes/ — hence
+    # the ../../ require depth, unlike the examples/ entry above.)
     [
-      [/^require_relative "..\/lib\/toy\/llm\/engine\/llama_seq_engine"$/,
-       'require_relative "../lib/toy/llm/engine/llama_seq_engine_' + backend.to_s + '"'],
+      [/^require_relative "..\/..\/lib\/toy\/llm\/engine\/llama_seq_engine"$/,
+       'require_relative "../../lib/toy/llm/engine/llama_seq_engine_' + backend.to_s + '"'],
       [/\bLlamaSeqEngine\b/, "LlamaSeqEngine" + suffix],
     ] + common_module_tail
 
@@ -424,7 +426,7 @@ def derive_mirror_path(cpu_path, backend)
   # lib/toy/llm/primitives/<name>.rb → ..._<backend>.rb (P2.3 L1 primitives)
   unless cpu_path =~ /_ffi(_[a-z]+)?\.rb$/ ||
          cpu_path =~ %r{^examples/\d+_[a-z0-9_]+\.rb$} ||
-         cpu_path =~ %r{^examples/smoke_[a-z0-9_]+\.rb$} ||
+         cpu_path =~ %r{^prep/smokes/smoke_[a-z0-9_]+\.rb$} ||
          cpu_path =~ %r{^lib/toy/llm/primitives/[a-z0-9_]+\.rb$} ||
          cpu_path =~ %r{^lib/toy/llm/blocks/[a-z0-9_]+\.rb$} ||
          cpu_path =~ %r{^lib/toy/llm/archs/[a-z0-9_]+\.rb$} ||

--- a/prep/gen_cuda_mirror.rb
+++ b/prep/gen_cuda_mirror.rb
@@ -69,7 +69,7 @@ MIRRORABLE = [
   "lib/toy/llm/engine/llama_kv_engine.rb", # KV-cache decode engine (was lib/toy_smollm2_ffi_kv.rb; toy#65 item 2)
   "lib/gpt2_ffi.rb",                    # GPT-2 full-forward FFI (Phase 0.6 step 3)
   "lib/gpt2_ffi_kv.rb",                 # GPT-2 KV-cache decode (Phase 0.6 step 3)
-  "examples/06_train_from_scratch.rb",  # #152: from-scratch training entry (CPU/CUDA)
+  "examples/legacy/06_train_from_scratch.rb",  # #152: from-scratch training entry (CPU/CUDA)
   "prep/smokes/smoke_projection_lens.rb", # P2.6 CUDA gate: realize_for_random_init forward on GPU
 ]
 
@@ -355,14 +355,15 @@ def subs_for(cpu_path, backend)
       [/^module GPT2KV$/,             "module GPT2KV" + suffix],
     ] + common_module_tail
 
-  when "examples/06_train_from_scratch.rb"
+  when "examples/legacy/06_train_from_scratch.rb"
     # #152 — CUDA mirror of the from-scratch training entry. Rewrites
     # the require to the GPU-side engine mirror, renames LlamaSeqEngine
     # to its backend variant, and swaps every TinyNN. call to
-    # TinyNN<Suffix>. (handled by common_module_tail).
+    # TinyNN<Suffix>. (handled by common_module_tail). Lives two levels
+    # below repo root (examples/legacy/) — hence the ../../ depth.
     [
-      [/^require_relative "..\/lib\/toy\/llm\/engine\/llama_seq_engine"$/,
-       'require_relative "../lib/toy/llm/engine/llama_seq_engine_' + backend.to_s + '"'],
+      [/^require_relative "..\/..\/lib\/toy\/llm\/engine\/llama_seq_engine"$/,
+       'require_relative "../../lib/toy/llm/engine/llama_seq_engine_' + backend.to_s + '"'],
       [/\bLlamaSeqEngine\b/, "LlamaSeqEngine" + suffix],
     ] + common_module_tail
 
@@ -425,7 +426,7 @@ def derive_mirror_path(cpu_path, backend)
   # examples/NN_name.rb → examples/NN_name_<backend>.rb (#152)
   # lib/toy/llm/primitives/<name>.rb → ..._<backend>.rb (P2.3 L1 primitives)
   unless cpu_path =~ /_ffi(_[a-z]+)?\.rb$/ ||
-         cpu_path =~ %r{^examples/\d+_[a-z0-9_]+\.rb$} ||
+         cpu_path =~ %r{^examples/(legacy/)?\d+_[a-z0-9_]+\.rb$} ||
          cpu_path =~ %r{^prep/smokes/smoke_[a-z0-9_]+\.rb$} ||
          cpu_path =~ %r{^lib/toy/llm/primitives/[a-z0-9_]+\.rb$} ||
          cpu_path =~ %r{^lib/toy/llm/blocks/[a-z0-9_]+\.rb$} ||

--- a/prep/smokes/smoke_card_derive.rb
+++ b/prep/smokes/smoke_card_derive.rb
@@ -1,9 +1,9 @@
-require_relative "../lib/toy"
-require_relative "../lib/toy/models/toy_smollm2"
-require_relative "../lib/toy/io/loaders/toy_smollm2_loader"
-require_relative "../lib/toy/llm/engine/llama_seq_engine"
-require_relative "../lib/toy/dev/toy_describe_flow"
-require_relative "../lib/toy/train/toy_drift_grad"
+require_relative "../../lib/toy"
+require_relative "../../lib/toy/models/toy_smollm2"
+require_relative "../../lib/toy/io/loaders/toy_smollm2_loader"
+require_relative "../../lib/toy/llm/engine/llama_seq_engine"
+require_relative "../../lib/toy/dev/toy_describe_flow"
+require_relative "../../lib/toy/train/toy_drift_grad"
 
 GGUF    = ENV["GGUF"]    || "data/smollm2-135m-native.gguf"
 CONTEXT = (ENV["CONTEXT"] || "16").to_i

--- a/prep/smokes/smoke_compute_surface.rb
+++ b/prep/smokes/smoke_compute_surface.rb
@@ -1,4 +1,4 @@
-# examples/smoke_compute_surface.rb — proves the toy#42 full-API require
+# prep/smokes/smoke_compute_surface.rb — proves the toy#42 full-API require
 # (lib/toy/compute.rb) compiles under Spinel and yields a working compute
 # surface from ONE require, via the RECIPE path.
 #
@@ -11,11 +11,11 @@
 # combined-surface gate (every file compute.rb pulls co-compiles); the RUN
 # proves the surface is live.
 #
-#   make examples/smoke_compute_surface && ./examples/smoke_compute_surface
+#   make prep/smokes/smoke_compute_surface && ./prep/smokes/smoke_compute_surface
 #
 # Expected last line: "compute-surface: ok".
 
-require_relative "../lib/toy/compute"
+require_relative "../../lib/toy/compute"
 
 VOCAB   = 627
 CONTEXT = 16

--- a/prep/smokes/smoke_compute_surface_cuda.rb
+++ b/prep/smokes/smoke_compute_surface_cuda.rb
@@ -1,4 +1,4 @@
-# examples/smoke_compute_surface_cuda.rb — proves the CUDA compute
+# prep/smokes/smoke_compute_surface_cuda.rb — proves the CUDA compute
 # entry (lib/toy/compute_cuda.rb, toy#64 item 8) compiles under Spinel
 # and yields a working compute surface from ONE require, via the
 # RECIPE path on the GPU.
@@ -13,7 +13,7 @@
 #
 # Expected last line: "compute-surface-cuda: ok".
 
-require_relative "../lib/toy/compute_cuda"
+require_relative "../../lib/toy/compute_cuda"
 
 VOCAB   = 627
 CONTEXT = 16

--- a/prep/smokes/smoke_corpus_loader.rb
+++ b/prep/smokes/smoke_corpus_loader.rb
@@ -1,18 +1,18 @@
 # E2.4 / GH#14 — smoke for the streaming corpus loader + cosine LR.
 #
 #   uv run prep/pretokenize_corpus.py            # one-time: ts_seqs.bin
-#   make examples/smoke_corpus_loader
-#   ./examples/smoke_corpus_loader
+#   make prep/smokes/smoke_corpus_loader
+#   ./prep/smokes/smoke_corpus_loader
 #
 # Reads 5 successive 32-token sequences from data/ts_seqs.bin and
 # prints the first few tokens of each — should not repeat. Then
 # prints cosine LR at a few representative steps to verify the
 # schedule shape (warmup → cosine → tail).
 
-require_relative "../lib/toy/models/transformer"
-require_relative "../lib/toy/ffi/tinynn"
-require_relative "../lib/toy/io/toy_corpus_loader"
-require_relative "../lib/toy/train/toy_lr_schedule"
+require_relative "../../lib/toy/models/transformer"
+require_relative "../../lib/toy/ffi/tinynn"
+require_relative "../../lib/toy/io/toy_corpus_loader"
+require_relative "../../lib/toy/train/toy_lr_schedule"
 
 PATH    = ENV["CORPUS"] || "data/ts_seqs.bin"
 SEQ_LEN = (ENV["SEQ_LEN"] || "32").to_i

--- a/prep/smokes/smoke_decode_logprobs.rb
+++ b/prep/smokes/smoke_decode_logprobs.rb
@@ -3,11 +3,11 @@
 # (token_id, logprob) pairs. Tep's future /v1/chat/completions with
 # `logprobs=true` consumes the same building block.
 #
-#   make examples/smoke_decode_logprobs
-#   GGUF=data/llama-3.2-1b-native.gguf ./examples/smoke_decode_logprobs
+#   make prep/smokes/smoke_decode_logprobs
+#   GGUF=data/llama-3.2-1b-native.gguf ./prep/smokes/smoke_decode_logprobs
 
-require_relative "../lib/toy/models/arch"
-require_relative "../lib/toy/models/transformer_lm"
+require_relative "../../lib/toy/models/arch"
+require_relative "../../lib/toy/models/transformer_lm"
 
 GGUF = ENV["GGUF"] || "data/llama-3.2-1b-native.gguf"
 TOP_K = (ENV["TOP_K"] || "5").to_i

--- a/prep/smokes/smoke_embed_api.rb
+++ b/prep/smokes/smoke_embed_api.rb
@@ -3,15 +3,15 @@
 # couple of values. Tep's future /v1/embeddings consumes this primitive
 # (then mean-pools or returns per-token).
 #
-#   make examples/smoke_embed_api
-#   GGUF=data/smollm2-135m-native.gguf ./examples/smoke_embed_api
+#   make prep/smokes/smoke_embed_api
+#   GGUF=data/smollm2-135m-native.gguf ./prep/smokes/smoke_embed_api
 #
 # Default path uses a from-scratch toy ckpt because that's the cheapest
 # end-to-end smoke; vocab is small (627) and the embedding rows are f32.
 # For a quantized-table test, set GGUF=data/qwen25-0.5b-native-q8.gguf.
 
-require_relative "../lib/toy/models/arch"
-require_relative "../lib/toy/models/transformer_lm"
+require_relative "../../lib/toy/models/arch"
+require_relative "../../lib/toy/models/transformer_lm"
 
 GGUF = ENV["GGUF"] || "data/llama-3.2-1b-native.gguf"
 

--- a/prep/smokes/smoke_full_finetune.rb
+++ b/prep/smokes/smoke_full_finetune.rb
@@ -1,4 +1,4 @@
-# examples/smoke_full_finetune.rb — full fine-tune (F3) loss-curve driver.
+# prep/smokes/smoke_full_finetune.rb — full fine-tune (F3) loss-curve driver.
 #
 # The 6th realize-gate's compiled runner (CPU). Drives the engine's
 # realize_for_full_finetune + build_training_step on a real GGUF and prints
@@ -12,11 +12,11 @@
 # gitignored dev artifact — the gate SKIPs loudly when it is absent). Train
 # losses are ggml-internal → byte-exact across CPU backends + machines.
 
-require_relative "../lib/toy"
-require_relative "../lib/toy/models/toy_smollm2"
-require_relative "../lib/toy/io/loaders/toy_smollm2_loader"
-require_relative "../lib/toy/llm/engine/llama_seq_engine"
-require_relative "../lib/toy/llm/adamw"
+require_relative "../../lib/toy"
+require_relative "../../lib/toy/models/toy_smollm2"
+require_relative "../../lib/toy/io/loaders/toy_smollm2_loader"
+require_relative "../../lib/toy/llm/engine/llama_seq_engine"
+require_relative "../../lib/toy/llm/adamw"
 
 GGUF      = ENV["GGUF"]   || "data/smollm2-135m-native.gguf"
 STEPS     = (ENV["STEPS"] || "8").to_i

--- a/prep/smokes/smoke_gate_b_gt_1.rb
+++ b/prep/smokes/smoke_gate_b_gt_1.rb
@@ -24,7 +24,7 @@
 # of data/ts_seqs.txt + single unscaled opt_step per step => bit-
 # reproducible loss curve.
 #
-# Layout adopted from examples/06_train_from_scratch.rb (the proven B>1
+# Layout adopted from examples/legacy/06_train_from_scratch.rb (the proven B>1
 # path): flat [T*B] token + position vectors, per-(batch,position)
 # shift-by-one one-hot labels. NO GRAD_ACCUM LR-scaling — this gate is
 # ONLY about batching. head_dim defaults to d_model/n_heads (16) so

--- a/prep/smokes/smoke_gate_b_gt_1.rb
+++ b/prep/smokes/smoke_gate_b_gt_1.rb
@@ -16,8 +16,8 @@
 #
 # Pure-Ruby CPU, Spinel-compiled. NO lib/ behavior change, NO mirror regen.
 #
-#   make examples/smoke_gate_b_gt_1
-#   STEPS=5 SEED=0 ./examples/smoke_gate_b_gt_1   (run from repo root)
+#   make prep/smokes/smoke_gate_b_gt_1
+#   STEPS=5 SEED=0 ./prep/smokes/smoke_gate_b_gt_1   (run from repo root)
 #
 # Determinism: SEED=0 + weight_dtype=0 (F32, no F16/BF16 reduction-order
 # nondeterminism across the larger T*B score matrix) + fixed FIRST 2 lines
@@ -30,11 +30,11 @@
 # ONLY about batching. head_dim defaults to d_model/n_heads (16) so
 # n_heads*head_dim == d_model (no w_o divergence — that is a separate gate).
 
-require_relative "../lib/toy"
-require_relative "../lib/toy/models/toy_smollm2"
-require_relative "../lib/toy/llm/engine/llama_seq_engine"
-require_relative "../lib/toy/llm/adamw"
-require_relative "../lib/toy/train/toy_drift_grad"
+require_relative "../../lib/toy"
+require_relative "../../lib/toy/models/toy_smollm2"
+require_relative "../../lib/toy/llm/engine/llama_seq_engine"
+require_relative "../../lib/toy/llm/adamw"
+require_relative "../../lib/toy/train/toy_drift_grad"
 
 STEPS    = (ENV["STEPS"] || "5").to_i
 SEED     = (ENV["SEED"]  || "0").to_i

--- a/prep/smokes/smoke_gate_gqa_divergent.rb
+++ b/prep/smokes/smoke_gate_gqa_divergent.rb
@@ -10,17 +10,17 @@
 #
 # Pure-Ruby CPU, Spinel-compiled. NO lib/ behavior change, NO mirror regen.
 #
-#   make examples/smoke_gate_gqa_divergent
-#   STEPS=5 SEED=0 ./examples/smoke_gate_gqa_divergent   (run from repo root)
+#   make prep/smokes/smoke_gate_gqa_divergent
+#   STEPS=5 SEED=0 ./prep/smokes/smoke_gate_gqa_divergent   (run from repo root)
 #
 # Determinism: SEED=0 + weight_dtype=0 (F32, bit-identical) + B=1 +
 # fixed first line of data/ts_seqs.txt => bit-reproducible loss curve.
 
-require_relative "../lib/toy"
-require_relative "../lib/toy/models/toy_smollm2"
-require_relative "../lib/toy/llm/engine/llama_seq_engine"
-require_relative "../lib/toy/llm/adamw"
-require_relative "../lib/toy/train/toy_drift_grad"
+require_relative "../../lib/toy"
+require_relative "../../lib/toy/models/toy_smollm2"
+require_relative "../../lib/toy/llm/engine/llama_seq_engine"
+require_relative "../../lib/toy/llm/adamw"
+require_relative "../../lib/toy/train/toy_drift_grad"
 
 STEPS    = (ENV["STEPS"] || "5").to_i
 SEED     = (ENV["SEED"]  || "0").to_i

--- a/prep/smokes/smoke_gate_llama3_tensor.rb
+++ b/prep/smokes/smoke_gate_llama3_tensor.rb
@@ -48,12 +48,12 @@
 # Spinel: needs compilation (ffi_lib is a Spinel intrinsic). NO Struct.new
 # (#16; cfg objects are hand-written ctors). NO lib/ change. One commit.
 #
-#   make examples/smoke_gate_llama3_tensor
-#   ./examples/smoke_gate_llama3_tensor        # run from repo root
+#   make prep/smokes/smoke_gate_llama3_tensor
+#   ./prep/smokes/smoke_gate_llama3_tensor        # run from repo root
 
-require_relative "../lib/toy"
-require_relative "../lib/toy/models/toy_smollm2"
-require_relative "../lib/toy/llm/engine/llama_seq_engine"
+require_relative "../../lib/toy"
+require_relative "../../lib/toy/models/toy_smollm2"
+require_relative "../../lib/toy/llm/engine/llama_seq_engine"
 
 # llama-3.2 rope params (factor=8.0, low=1.0, high=4.0, orig_max_pos=8192,
 # base=500000) + d_head=64. T sequence positions, single batch.

--- a/prep/smokes/smoke_gate_q8_preserve.rb
+++ b/prep/smokes/smoke_gate_q8_preserve.rb
@@ -56,15 +56,15 @@
 #
 # Needs Spinel compilation (ffi_lib is a Spinel intrinsic). Branch-hit
 # verification is make + run:
-#   make examples/smoke_gate_q8_preserve
-#   ./examples/smoke_gate_q8_preserve     # MUST run from repo root (data/)
+#   make prep/smokes/smoke_gate_q8_preserve
+#   ./prep/smokes/smoke_gate_q8_preserve     # MUST run from repo root (data/)
 #
 # Exits non-zero (loud, with first mismatch index) on ANY divergence/NaN
 # or if the Q8 path is not taken; prints VERDICT + baseline logits on success.
 
-require_relative "../lib/toy"
-require_relative "../lib/toy/models/toy_smollm2"
-require_relative "../lib/toy/llm/engine/llama_seq_engine"
+require_relative "../../lib/toy"
+require_relative "../../lib/toy/models/toy_smollm2"
+require_relative "../../lib/toy/llm/engine/llama_seq_engine"
 
 # VERIFIED Qwen2.5-0.5B-Instruct native-Q8 GGUF dims.
 VOCAB   = 151936

--- a/prep/smokes/smoke_gate_qkv_bias.rb
+++ b/prep/smokes/smoke_gate_qkv_bias.rb
@@ -55,15 +55,15 @@
 # This fixture needs Spinel compilation (ffi_lib is a Spinel intrinsic; it
 # cannot run under MRI), so branch-hit verification is make + run.
 #
-#   make examples/smoke_gate_qkv_bias
-#   ./examples/smoke_gate_qkv_bias        # MUST run from repo root (data/)
+#   make prep/smokes/smoke_gate_qkv_bias
+#   ./prep/smokes/smoke_gate_qkv_bias        # MUST run from repo root (data/)
 #
 # Exits non-zero (loud, with first mismatch index) on ANY divergence/NaN;
 # prints the VERDICT line + the baseline logits on success.
 
-require_relative "../lib/toy"
-require_relative "../lib/toy/models/toy_smollm2"
-require_relative "../lib/toy/llm/engine/llama_seq_engine"
+require_relative "../../lib/toy"
+require_relative "../../lib/toy/models/toy_smollm2"
+require_relative "../../lib/toy/llm/engine/llama_seq_engine"
 
 # VERIFIED Qwen2.5-0.5B-Instruct native GGUF dims.
 VOCAB   = 151936

--- a/prep/smokes/smoke_gguf_roundtrip.rb
+++ b/prep/smokes/smoke_gguf_roundtrip.rb
@@ -25,17 +25,17 @@
 # slice math. So a faithful round-trip MUST reproduce the logits exactly.
 # No tolerance — strict ==. A mismatch means the round-trip is unfaithful.
 #
-#   make examples/smoke_gguf_roundtrip
-#   SEED=0 ./examples/smoke_gguf_roundtrip
+#   make prep/smokes/smoke_gguf_roundtrip
+#   SEED=0 ./prep/smokes/smoke_gguf_roundtrip
 #
 # Exits non-zero (with the first mismatching index + both values on
 # STDERR) on ANY logit divergence; prints the VERDICT line on full match.
 
-require_relative "../lib/toy"
-require_relative "../lib/toy/models/toy_smollm2"
-require_relative "../lib/toy/llm/engine/llama_seq_engine"
-require_relative "../lib/toy/train/toy_gguf_fuse"
-require_relative "../lib/toy/train/toy_gguf_writer"
+require_relative "../../lib/toy"
+require_relative "../../lib/toy/models/toy_smollm2"
+require_relative "../../lib/toy/llm/engine/llama_seq_engine"
+require_relative "../../lib/toy/train/toy_gguf_fuse"
+require_relative "../../lib/toy/train/toy_gguf_writer"
 
 SEED     = (ENV["SEED"] || "0").to_i
 VOCAB    = 627

--- a/prep/smokes/smoke_image_loader.rb
+++ b/prep/smokes/smoke_image_loader.rb
@@ -3,12 +3,12 @@
 # stats to verify the round-trip.
 #
 #   uv run prep/preprocess_images.py            # produces data/vit_smoke/
-#   make examples/smoke_image_loader
-#   ./examples/smoke_image_loader
+#   make prep/smokes/smoke_image_loader
+#   ./prep/smokes/smoke_image_loader
 
-require_relative "../lib/toy/models/transformer"
-require_relative "../lib/toy/ffi/tinynn"
-require_relative "../lib/toy/io/toy_image_loader"
+require_relative "../../lib/toy/models/transformer"
+require_relative "../../lib/toy/ffi/tinynn"
+require_relative "../../lib/toy/io/toy_image_loader"
 
 DIR        = ENV["IMG_DIR"]      || "data/vit_smoke"
 N          = (ENV["N"]           || "3").to_i

--- a/prep/smokes/smoke_projection_lens.rb
+++ b/prep/smokes/smoke_projection_lens.rb
@@ -4,19 +4,19 @@
 # Verifies the forward graph compiles, the backward propagates
 # through W_proj only (token_embd stays frozen), and loss decreases.
 #
-#   make examples/smoke_projection_lens
-#   STEPS=5 ./examples/smoke_projection_lens
+#   make prep/smokes/smoke_projection_lens
+#   STEPS=5 ./prep/smokes/smoke_projection_lens
 #
 # Tied output is incompatible with donor_d_in > 0 because LM-head
 # matmul(token_embd, x_final) would need ne[0] = d_model on
 # token_embd, but token_embd has ne[0] = donor_d_in. So we always
 # realize_for_random_init with untied=true.
 
-require_relative "../lib/toy"
-require_relative "../lib/toy/models/toy_smollm2"
-require_relative "../lib/toy/llm/engine/llama_seq_engine"
-require_relative "../lib/toy/llm/adamw"
-require_relative "../lib/toy/train/toy_drift_grad"
+require_relative "../../lib/toy"
+require_relative "../../lib/toy/models/toy_smollm2"
+require_relative "../../lib/toy/llm/engine/llama_seq_engine"
+require_relative "../../lib/toy/llm/adamw"
+require_relative "../../lib/toy/train/toy_drift_grad"
 
 STEPS    = (ENV["STEPS"]    || "5").to_i
 D_MODEL  = (ENV["D_MODEL"]  || "64").to_i

--- a/prep/smokes/smoke_recipe_from_scratch.rb
+++ b/prep/smokes/smoke_recipe_from_scratch.rb
@@ -5,8 +5,8 @@
 # Its loss curve MUST byte-equal the reference captured from
 # smoke_projection_lens.
 #
-#   make examples/smoke_recipe_from_scratch
-#   SEED=0 STEPS=5 ./examples/smoke_recipe_from_scratch | grep '^step'
+#   make prep/smokes/smoke_recipe_from_scratch
+#   SEED=0 STEPS=5 ./prep/smokes/smoke_recipe_from_scratch | grep '^step'
 #
 # Reference (must reproduce byte-for-byte):
 #   step 1: loss=6.440947532653809
@@ -24,12 +24,12 @@
 # Load order is verbatim so the backend TinyNN loads (via
 # llama_seq_forward_ffi) before the recipe is required.
 
-require_relative "../lib/toy"
-require_relative "../lib/toy/models/toy_smollm2"
-require_relative "../lib/toy/llm/engine/llama_seq_engine"
-require_relative "../lib/toy/llm/adamw"
-require_relative "../lib/toy/llm/labels"
-require_relative "../lib/toy/llm/recipes/from_scratch"
+require_relative "../../lib/toy"
+require_relative "../../lib/toy/models/toy_smollm2"
+require_relative "../../lib/toy/llm/engine/llama_seq_engine"
+require_relative "../../lib/toy/llm/adamw"
+require_relative "../../lib/toy/llm/labels"
+require_relative "../../lib/toy/llm/recipes/from_scratch"
 
 STEPS    = (ENV["STEPS"]    || "5").to_i
 D_MODEL  = (ENV["D_MODEL"]  || "64").to_i

--- a/prep/smokes/smoke_recipe_lora.rb
+++ b/prep/smokes/smoke_recipe_lora.rb
@@ -1,12 +1,12 @@
 # L4 LoRA recipe gate. Drives the SAME LoRA fine-tune config as the
-# frozen reference examples/03_finetune_lora.rb (at the fixed config
+# frozen reference examples/legacy/03_finetune_lora.rb (at the fixed config
 # below) THROUGH Toy::LLM::Recipes::LoRA and prints "step N: loss="
 # lines whose loss VALUES MUST byte-equal the reference's per-step CE.
 #
 #   make prep/smokes/smoke_recipe_lora
 #   STEPS=5 RANK=8 ./prep/smokes/smoke_recipe_lora | grep '^step'
 #
-# Reference (examples/03_finetune_lora.rb, STEPS=5 RANK=8 LR=0.001
+# Reference (examples/legacy/03_finetune_lora.rb, STEPS=5 RANK=8 LR=0.001
 # GGUF=data/smollm2-135m-native.gguf, seeded upload_lora_q_init!(42,0.01)):
 #   step 1: loss=9.236274719238281
 #   step 2: loss=9.213868141174316

--- a/prep/smokes/smoke_recipe_lora.rb
+++ b/prep/smokes/smoke_recipe_lora.rb
@@ -3,8 +3,8 @@
 # below) THROUGH Toy::LLM::Recipes::LoRA and prints "step N: loss="
 # lines whose loss VALUES MUST byte-equal the reference's per-step CE.
 #
-#   make examples/smoke_recipe_lora
-#   STEPS=5 RANK=8 ./examples/smoke_recipe_lora | grep '^step'
+#   make prep/smokes/smoke_recipe_lora
+#   STEPS=5 RANK=8 ./prep/smokes/smoke_recipe_lora | grep '^step'
 #
 # Reference (examples/03_finetune_lora.rb, STEPS=5 RANK=8 LR=0.001
 # GGUF=data/smollm2-135m-native.gguf, seeded upload_lora_q_init!(42,0.01)):
@@ -24,12 +24,12 @@
 # Load order is verbatim so the backend TinyNN loads (via
 # llama_seq_forward_ffi) before the recipe is required.
 
-require_relative "../lib/toy"
-require_relative "../lib/toy/models/toy_smollm2"
-require_relative "../lib/toy/io/loaders/toy_smollm2_loader"
-require_relative "../lib/toy/llm/engine/llama_seq_engine"
-require_relative "../lib/toy/llm/adamw"
-require_relative "../lib/toy/llm/recipes/lora"
+require_relative "../../lib/toy"
+require_relative "../../lib/toy/models/toy_smollm2"
+require_relative "../../lib/toy/io/loaders/toy_smollm2_loader"
+require_relative "../../lib/toy/llm/engine/llama_seq_engine"
+require_relative "../../lib/toy/llm/adamw"
+require_relative "../../lib/toy/llm/recipes/lora"
 
 GGUF  = ENV["GGUF"]  || "data/smollm2-135m-native.gguf"
 RANK  = (ENV["RANK"]  || "8").to_i

--- a/prep/smokes/smoke_recipe_warm_start.rb
+++ b/prep/smokes/smoke_recipe_warm_start.rb
@@ -4,8 +4,8 @@
 # Toy::LLM::Recipes::WarmStart and prints "step N: loss=" lines whose
 # loss VALUES MUST byte-equal the reference's per-step loss.
 #
-#   make examples/smoke_recipe_warm_start
-#   SEED=0 STEPS=5 ./examples/smoke_recipe_warm_start | grep '^step'
+#   make prep/smokes/smoke_recipe_warm_start
+#   SEED=0 STEPS=5 ./prep/smokes/smoke_recipe_warm_start | grep '^step'
 #
 # Reference (SEED=0 STEPS=5 INIT=scratch ./examples/example_warm_start_train):
 #   step 1: loss=6.440947532653809   (lr=0.0002)
@@ -34,14 +34,14 @@
 # Load order is verbatim so the backend TinyNN loads (via
 # llama_seq_forward_ffi) before the recipe is required.
 
-require_relative "../lib/toy"
-require_relative "../lib/toy/models/toy_smollm2"
-require_relative "../lib/toy/llm/engine/llama_seq_engine"
-require_relative "../lib/toy/io/toy_corpus_loader"
-require_relative "../lib/toy/train/toy_lr_schedule"
-require_relative "../lib/toy/llm/adamw"
-require_relative "../lib/toy/llm/labels"
-require_relative "../lib/toy/llm/recipes/warm_start"
+require_relative "../../lib/toy"
+require_relative "../../lib/toy/models/toy_smollm2"
+require_relative "../../lib/toy/llm/engine/llama_seq_engine"
+require_relative "../../lib/toy/io/toy_corpus_loader"
+require_relative "../../lib/toy/train/toy_lr_schedule"
+require_relative "../../lib/toy/llm/adamw"
+require_relative "../../lib/toy/llm/labels"
+require_relative "../../lib/toy/llm/recipes/warm_start"
 
 # All 09 defaults (the gate's resolved config).
 STEPS    = (ENV["STEPS"]    || "5").to_i

--- a/prep/smokes/smoke_recipe_warm_start.rb
+++ b/prep/smokes/smoke_recipe_warm_start.rb
@@ -1,5 +1,5 @@
 # P2.6 — L4 WarmStart recipe gate. Drives the EXACT same warm-start
-# config as the frozen reference examples/09_warm_start_train.rb at
+# config as the frozen reference examples/legacy/09_warm_start_train.rb at
 # INIT=scratch (09's DEFAULT, so no donor GGUF dependency) THROUGH
 # Toy::LLM::Recipes::WarmStart and prints "step N: loss=" lines whose
 # loss VALUES MUST byte-equal the reference's per-step loss.

--- a/prep/smokes/smoke_toy_ckpt_reload.rb
+++ b/prep/smokes/smoke_toy_ckpt_reload.rb
@@ -10,11 +10,11 @@
 # by ~5 orders of magnitude (5 steps on a 2-layer-4-head model) and
 # its outputs are not expected to be coherent.
 #
-#   make examples/smoke_toy_ckpt_reload
-#   GGUF=/tmp/ckpt/weights/latest ./examples/smoke_toy_ckpt_reload
+#   make prep/smokes/smoke_toy_ckpt_reload
+#   GGUF=/tmp/ckpt/weights/latest ./prep/smokes/smoke_toy_ckpt_reload
 
-require_relative "../lib/toy/models/arch"
-require_relative "../lib/toy/models/transformer_lm"
+require_relative "../../lib/toy/models/arch"
+require_relative "../../lib/toy/models/transformer_lm"
 
 GGUF = ENV["GGUF"] || "/tmp/ckpt_test/weights/latest"
 

--- a/prep/smokes/smoke_vit_tiny.rb
+++ b/prep/smokes/smoke_vit_tiny.rb
@@ -1,16 +1,16 @@
 # E1.3 / GH#13 — ViT-Tiny forward + training smoke.
 #
-#   make examples/smoke_vit_tiny
-#   STEPS=5 ./examples/smoke_vit_tiny
+#   make prep/smokes/smoke_vit_tiny
+#   STEPS=5 ./prep/smokes/smoke_vit_tiny
 #
 # Runs a tiny ViT (image 16×16, patch 4, d_model 64, 2 layers, 4
 # heads, 10 classes). Trains 5 steps on the same random image →
 # random class label; verifies forward + backward + AdamW step
 # without crashing and that loss decreases.
 
-require_relative "../lib/toy/models/toy_vit"
-require_relative "../lib/toy/llm/engine/vit_tiny_engine"
-require_relative "../lib/toy/llm/adamw"
+require_relative "../../lib/toy/models/toy_vit"
+require_relative "../../lib/toy/llm/engine/vit_tiny_engine"
+require_relative "../../lib/toy/llm/adamw"
 
 IMAGE_SIZE  = (ENV["IMAGE_SIZE"]  || "16").to_i
 PATCH_SIZE  = (ENV["PATCH_SIZE"]  || "4").to_i


### PR DESCRIPTION
Implements **#60 — examples curation + DevEx hardening** (part of #58). Base: main @ 2d6b75a. Three gated commits.

## Half 1 — examples curation (the design review)

**1. Gate fixtures out of `examples/`** (`a963b71`): all 20 `smoke_*.rb` moved to **`prep/smokes/`** (they are gates, wired into `docs/gating.md` + `make gate-*`, not tutorials). Pure relocation, byte-exact: Makefile (27 refs), `prep/gen_cuda_mirror.rb` (MIRRORABLE + rewrite rules + path regex), `.gitignore`, `prep/full_finetune_gate.rb`, six docs pages, lib comments. prep/README.md documents the new family.

**2. Curated teaching set** (`be33666`): old tutorials → `examples/legacy/` (appended; still build), seven NEW narrated single-file examples on the Phase-A API (each: what-you'll-see / how-long / what-to-tweak header, ENV knobs, `make example_NN`):

| # | file | shows | evidence |
|---|---|---|---|
| 01 | `01_train_tiny.rb` | `FromScratch` + `SmolLM2Config.tiny` + `RecipeOptions` + `TrainingBatch` + `AdamW.for_from_scratch` on the committed corpus; writes a RunLog-parseable `runs/<id>/events.jsonl` | loss 6.4409→6.0248 / 30 steps; step 1 byte-equals the gate curve |
| 02 | `02_finetune_warm_start.rb` | WarmStart from a real GGUF donor (embed width read from the GGUF); `INIT=scratch` diff arm | scratch arm byte-matches the warm-start gate reference |
| 03 | `03_lora.rb` | LoRA/QLoRA over a frozen mmap'd base | steps 1–5 byte-match `smoke_recipe_lora`; 9.24→3.60 CE |
| 04 | `04_generate.rb` | GGUF → KV decode → text | ids byte-match the infer-gate baseline; text path verified ("Once upon a time, there was a little girl named Lily…") |
| 05 | `05_eval_logprobs.rb` | top-K logprobs | byte-match the eval baseline |
| 06 | `06_runlog_compare.rb` | CRuby `RunLog.scan` comparison table | shows lr=0.01 diverging vs lr=0.001 at a glance |
| 07 | `07_vit_tiny.rb` | `Recipes::VitTiny` on committed `data/vit_smoke` | CE 2.30→0.0008 / 20 steps |

Bonus fix: the previously-relocated legacy examples kept `../lib` requires — **Spinel treats an unresolvable `require_relative` as a warning and compiles without it**, so their binaries built silently broken. All repaired + rebuilt clean.

**3.** README.md pointer, `docs/framework.md` (example truth pointer → 01), `docs/cli.md` examples section, `make help` updated.

## Half 2 — DevEx hardening (`97e3f10`)

**4. `make gate-consumer`** (`prep/consumer_gate.rb`) — the cold-start proof. App leg: `toy new gatelab` → hello.rb compiles with `$SPINEL_DIR` → runs → `D_MODEL=128 STEPS=10` re-run with **no recompile** → `toy train from-scratch` prints losses + writes `runs/<id>/events.jsonl` → missing-corpus guard fails loud naming the path. Lib leg: `toy new gatelib --lib` → `bundle lock` → `spinel-compat vendor` (ggml+tinynn built **inside** the project) → `./build.sh cpu` → `experiment_cpu` trains to "experiment: ok". **PASSES end-to-end on gx10.** It immediately caught two real cold-start breaks (now fixed): the scaffold's stale `toy_lib/toy_smollm2` require, and `toy train` in a fresh project **SEGV-ing** on the spinel-dev#17 silent-`""` corpus read — `toy new` now seeds `data/ts_seqs.{bin,txt}` from the committed gate fixture, so the scaffold quickstart trains the gate-exact curve.

**5. Short-SHA ggml fetch**: `GGML_REV` expanded to the full 40-char SHA; GitHub serves shallow fetch-by-SHA only for full SHAs. Exact clone recipe replayed **cold** against github.com/ggml-org/ggml: OK.

**6. Fail-loud audit at the user boundary**: every user-suppliable path (GGUF / corpus / LMC ckpts) in the compiled runners (incl. cuda/metal twins) gets an explicit existence check with a named, actionable error before any silent read; `eval_lmc`'s five `STDERR.puts` (a **no-op** under Spinel — all its errors were silent) → `puts`; CLI-side checks for lora GGUF / warm-start corpus (exit 2 per the documented contract); signal deaths reported as `runner exited from signal 11 (SIGSEGV)` instead of the masked `runner exited :`. Every error path verified by hand; happy paths untouched.

## Gate evidence (SPINEL_DIR=/tmp/spinel-a699cf9-serve, gx10)

verify-mirrors • gate-compute-surface(+cuda) • recipe==lens byte-exact • infer/train/eval/run_log/lmc/ckpt_roundtrip • gpt2(+engine,+cuda) • train_cuda • mixed_precision • full_finetune • moe_kquant • gate-cuda • gate-consumer — **ALL PASS**; poly-degrade **PASS** (35 known-benign, unchanged); metal twins `ruby -c` clean (no Mac available). Serve untouched (out of scope, spinel-dev#14).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
