### PR TITLE
docs(#61): coverage & perf re-verification at spinel a699cf9 — provenance, honest verdicts, two fixes

### DIFF
--- a/bench/check.rb
+++ b/bench/check.rb
@@ -86,7 +86,10 @@ def build_bench(source, binary)
   # linker's `-o bench/build/<bin>` then fails with errno=2. Create it first
   # so `make bench` works on a clean clone (e.g. Mac), not just where a prior
   # run already made the dir.
-  cmd = "cd #{ROOT} && mkdir -p #{File.dirname(binary)} && ~/sites/spinel/spinel #{source} -o #{binary} 2>&1"
+  # Honor SPINEL_DIR (the Makefile's pin knob) so a pinned-rev bench run
+  # actually builds with the pinned compiler instead of ~/sites/spinel.
+  spinel = File.join(ENV["SPINEL_DIR"] || File.expand_path("~/sites/spinel"), "spinel")
+  cmd = "cd #{ROOT} && mkdir -p #{File.dirname(binary)} && #{spinel} #{source} -o #{binary} 2>&1"
   out = `#{cmd}`
   unless $?.success?
     warn "build failed: #{source}\n#{out}"; return false

--- a/docs/bench-vs-pytorch.md
+++ b/docs/bench-vs-pytorch.md
@@ -20,16 +20,32 @@ make bench-vs-pytorch-update   # re-record the budget after an intended change
 make bench-vs-pytorch-report   # measure + print, no gate
 ```
 
-Latest GB10 (SmolLM2-135M, measured live, same session):
+Latest GB10 (SmolLM2-135M, measured live, same session — 2026-06-11,
+toy `d605aea` / spinel `a699cf9` / ggml `41e7949`, toy#61 pass):
 
 | Workload | toy (CUDA) | PyTorch (CUDA) | ratio toy/pt |
 | --- | --- | --- | --- |
-| Full-FT training step (T=4) | ~77 ms | ~77 ms | **~1.0× (parity)** |
-| KV-cache decode | ~82 tok/s | ~113 tok/s | **~1.38×** |
+| Full-FT training step (T=4) | 82.05 ms | 82.48 ms | **0.995× (parity)** |
+| KV-cache decode | — see below | 98.9 tok/s | **not measurable** |
 
 For a transformer you can read top-to-bottom, parity on the training
-step and ~1.4× on decode at 135M is a healthy place to be. (The CPU
-story is different — see "Caveats".)
+step at 135M is a healthy place to be. (The CPU story is different —
+see "Caveats".)
+
+> **Known-broken (2026-06-11): the decode leg.** `demos/qwen25_bench_cuda`
+> segfaults at startup (`sp_gc_mark` → `sp_PtrArray_new_scan` inside
+> `SmolLM2KVCuda.decode_step`, right after `ggml_cuda_init`), so the
+> infer ratio cannot be measured at this pin. Not an `a699cf9`
+> regression — a main-tree binary built 2026-05-31 segfaults
+> identically, so the leg has been dead since shortly after the budget
+> was recorded (2026-05-24). Worse, `bench/check_vs_pytorch.rb`
+> silently skips a ratio whose inputs are missing and still prints
+> `ok` — a fail-loud violation. The last good decode numbers (~82 vs
+> ~113 tok/s, 1.38×) are RETIRED until the demo is fixed and the leg
+> re-measured; reported on toy#61.
+>
+> The *CPU* decode bench (`make bench`, `bench/inference.rb`) is alive
+> and green: 85.4 tok/s vs a 64.4 baseline on 2026-06-11.
 
 ## What it measures
 

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -6,16 +6,20 @@ hand-edit — run `make coverage` to regenerate.
 This is the canonical "what we support" matrix. One row per ggml op
 (`enum ggml_op` in `vendor/ggml/include/ggml.h`), with columns for the
 CPU + CUDA + Metal FFI bindings and backward support. Models built on
-top of these ops are tracked separately in `docs/models-verified.md`.
+top of these ops are tracked separately in `docs/models.md`.
+
+Last full re-verification: 2026-06-11 (toy#61) at toy `d605aea` /
+spinel `a699cf9` / ggml `41e7949` — table regenerated against that
+tree, runner + training + smoke gates green on CPU and CUDA.
 
 ## Summary
 
-- **30 of 98** ops have a dedicated `tnn_*` wrapper bound on the CPU side (31%).
-- **2** more are composed inside other wrappers (status `via`) — usable in graphs we build but no standalone entry point.
+- **34 of 98** ops have a dedicated `tnn_*` wrapper bound on the CPU side (35%).
+- **1** more are composed inside other wrappers (status `via`) — usable in graphs we build but no standalone entry point.
 - **0** bound ops are CPU-only (no CUDA binding) — see "Parity drift" below.
-- **3** bound ops are not bound on Metal — the Metal mirror (`lib/toy/ffi/tinynn_metal.rb`) is an intentionally thin smoke surface today, see "Metal mirror" below.
-- **5** ops with a `*_BACK` enum case have an explicit backward wrapper; **1** more are emitted automatically by ggml's autodiff (`ggml_build_backward_expand`) without needing a wrapper.
-- **62** ops have no wrapper at all (and aren't composed by another).
+- **2** bound ops are not bound on Metal — the Metal mirror (`lib/toy/ffi/tinynn_metal.rb`) is an intentionally thin smoke surface today, see "Metal mirror" below.
+- **6** ops with a `*_BACK` enum case have an explicit backward wrapper; **2** more are emitted automatically by ggml's autodiff (`ggml_build_backward_expand`) without needing a wrapper.
+- **58** ops have no wrapper at all (and aren't composed by another).
 - **4** ops are dispatch-internal (no public `ggml_<x>()` constructor — e.g. `UNARY`, `MAP_CUSTOM1`).
 
 Backend caveats not captured by the table:
@@ -62,14 +66,14 @@ Backend caveats not captured by the table:
 | `GGML_OP_L2_NORM` | — | missing | missing | missing | — | no tnn_ wrapper |
 | `GGML_OP_MUL_MAT` | `tnn_matmul` | yes | yes | yes | — |  |
 | `GGML_OP_MUL_MAT_ID` | `tnn_mul_mat_id` | yes | yes | yes | — |  |
-| `GGML_OP_OUT_PROD` | — | missing | missing | missing | — | no tnn_ wrapper |
+| `GGML_OP_OUT_PROD` | `tnn_out_prod` | no | yes | no | — |  |
 | `GGML_OP_SCALE` | `tnn_scale` | yes | yes | yes | — |  |
 | `GGML_OP_SET` | — | missing | missing | missing | — | no tnn_ wrapper |
 | `GGML_OP_CPY` | `tnn_cpy` | yes | yes | yes | — |  |
-| `GGML_OP_CONT` | — | via | via | via | — | composed inside other wrappers (no dedicated tnn_) |
+| `GGML_OP_CONT` | `tnn_cont_2d` | yes | yes | yes | — |  |
 | `GGML_OP_RESHAPE` | `tnn_reshape_2d` | yes | yes | yes | — |  |
 | `GGML_OP_VIEW` | `tnn_view_1d` | yes | yes | yes | — |  |
-| `GGML_OP_PERMUTE` | — | missing | missing | missing | — | no tnn_ wrapper |
+| `GGML_OP_PERMUTE` | `tnn_permute` | yes | yes | yes | — |  |
 | `GGML_OP_TRANSPOSE` | `tnn_transpose` | yes | yes | yes | — |  |
 | `GGML_OP_GET_ROWS` | `tnn_get_rows` | yes | yes | yes | yes |  |
 | `GGML_OP_SET_ROWS` | `tnn_set_rows` | yes | yes | yes | — |  |
@@ -80,9 +84,9 @@ Backend caveats not captured by the table:
 | `GGML_OP_ROPE` | `tnn_rope_ext` | yes | yes | yes | yes |  |
 | `GGML_OP_CLAMP` | — | missing | missing | missing | — | no tnn_ wrapper |
 | `GGML_OP_CONV_TRANSPOSE_1D` | — | missing | missing | missing | — | no tnn_ wrapper |
-| `GGML_OP_IM2COL` | — | missing | missing | missing | — | no tnn_ wrapper |
+| `GGML_OP_IM2COL` | `tnn_im2col` | yes | yes | yes | yes |  |
 | `GGML_OP_IM2COL_3D` | — | missing | missing | missing | — | no tnn_ wrapper |
-| `GGML_OP_CONV_2D` | — | missing | missing | missing | — | no tnn_ wrapper |
+| `GGML_OP_CONV_2D` | `tnn_conv_2d` | yes | yes | yes | — |  |
 | `GGML_OP_CONV_3D` | — | missing | missing | missing | — | no tnn_ wrapper |
 | `GGML_OP_CONV_2D_DW` | — | missing | missing | missing | — | no tnn_ wrapper |
 | `GGML_OP_CONV_TRANSPOSE_2D` | — | missing | missing | missing | — | no tnn_ wrapper |
@@ -111,11 +115,11 @@ Backend caveats not captured by the table:
 | `GGML_OP_RWKV_WKV7` | — | missing | missing | missing | — | no tnn_ wrapper |
 | `GGML_OP_SOLVE_TRI` | — | missing | missing | missing | — | no tnn_ wrapper |
 | `GGML_OP_GATED_DELTA_NET` | — | missing | missing | missing | — | no tnn_ wrapper |
-| `GGML_OP_GELU` | `tnn_gelu` | yes | yes | yes | — | unary sub-op (dispatches via GGML_OP_UNARY) |
+| `GGML_OP_GELU` | `tnn_gelu` | yes | yes | yes | autodiff | unary sub-op (dispatches via GGML_OP_UNARY) |
 | `GGML_OP_SILU` | `tnn_silu` | yes | yes | yes | yes | unary sub-op (dispatches via GGML_OP_UNARY) |
 | `GGML_OP_RELU` | — | missing | missing | missing | — | unary sub-op (dispatches via GGML_OP_UNARY) |
 | `GGML_OP_GELU_QUICK` | — | missing | missing | missing | — | unary sub-op (dispatches via GGML_OP_UNARY) |
-| `GGML_OP_TANH` | `tnn_tanh` | yes | yes | no | — | unary sub-op (dispatches via GGML_OP_UNARY) |
+| `GGML_OP_TANH` | `tnn_tanh` | yes | yes | yes | — | unary sub-op (dispatches via GGML_OP_UNARY) |
 | `GGML_OP_ELU` | — | missing | missing | missing | — | unary sub-op (dispatches via GGML_OP_UNARY) |
 | `GGML_OP_SIGMOID` | — | missing | missing | missing | — | unary sub-op (dispatches via GGML_OP_UNARY) |
 | `GGML_OP_HARDSIGMOID` | — | missing | missing | missing | — | unary sub-op (dispatches via GGML_OP_UNARY) |
@@ -149,8 +153,8 @@ smoke binding today — just enough to prove `ggml_backend_metal_init`
 regression signal; it's the to-do list for whoever wires real model
 inference on Metal (issue #2 follow-up).
 
-_Metal-bound ops_: **27** of 30 CPU-bound.
-_Not yet on Metal_: 3.
+_Metal-bound ops_: **32** of 34 CPU-bound.
+_Not yet on Metal_: 2.
 
 ## Tnn surface not directly tied to a ggml op
 
@@ -160,21 +164,37 @@ helpers, trace primitive, etc. Listed here for completeness; not
 covered by the table above.
 
 <details>
-<summary>71 infrastructure / helper wrappers</summary>
+<summary>104 infrastructure / helper wrappers</summary>
 
 - `tnn_adam_step_scratch`
 - `tnn_add_to_graph`
 - `tnn_backend_name`
 - `tnn_build_backward`
 - `tnn_build_forward_only`
+- `tnn_cast`
 - `tnn_compute`
 - `tnn_compute_b`
 - `tnn_compute_backward`
+- `tnn_cuda_get_device_count`
+- `tnn_cuda_get_device_count_internal`
 - `tnn_download`
 - `tnn_download_to_f64_array`
+- `tnn_embed_lookup_to_doubles`
 - `tnn_extend_backward_graph`
+- `tnn_filesystem_mkdir`
+- `tnn_filesystem_symlink`
 - `tnn_finalize_weights`
 - `tnn_gelu_back_scratch`
+- `tnn_gguf_w_add_tensor`
+- `tnn_gguf_w_finalize`
+- `tnn_gguf_w_free`
+- `tnn_gguf_w_init`
+- `tnn_gguf_w_set_bool`
+- `tnn_gguf_w_set_f32`
+- `tnn_gguf_w_set_str`
+- `tnn_gguf_w_set_u32`
+- `tnn_graph_n_nodes`
+- `tnn_graph_node`
 - `tnn_graph_reset`
 - `tnn_graph_reset_grads_only`
 - `tnn_input_1d_f32`
@@ -189,11 +209,16 @@ covered by the table above.
 - `tnn_input_3d_f32_persistent`
 - `tnn_input_3d_persistent_mmap`
 - `tnn_input_3d_persistent_typed`
+- `tnn_input_4d_f32_persistent`
 - `tnn_layer_norm`
 - `tnn_link_check`
 - `tnn_matmul_axb`
 - `tnn_null_ptr`
 - `tnn_pin_all_graph_b_nodes`
+- `tnn_pinned_alloc`
+- `tnn_pinned_free`
+- `tnn_read_f32_file`
+- `tnn_read_i32_file`
 - `tnn_realize`
 - `tnn_realize_b`
 - `tnn_realize_backward`
@@ -214,19 +239,31 @@ covered by the table above.
 - `tnn_session_attach_weight_mmap`
 - `tnn_session_free`
 - `tnn_session_new`
+- `tnn_session_new_on`
+- `tnn_session_set_graph_capacity`
 - `tnn_set_2d`
 - `tnn_set_loss`
 - `tnn_set_output`
 - `tnn_set_param`
 - `tnn_shutdown_engines`
 - `tnn_soft_max_ext`
+- `tnn_swiglu_split`
 - `tnn_switch_a`
 - `tnn_switch_b`
+- `tnn_tensor_dtype`
+- `tnn_tensor_flags`
 - `tnn_tensor_grad`
+- `tnn_tensor_name`
 - `tnn_tensor_nbytes`
 - `tnn_tensor_ne0`
 - `tnn_tensor_ne1`
+- `tnn_tensor_ne2`
+- `tnn_tensor_ne3`
 - `tnn_tensor_nelements`
+- `tnn_tensor_op`
+- `tnn_tensor_op_name`
+- `tnn_tensor_set_name`
+- `tnn_tensor_src`
 - `tnn_upload`
 - `tnn_upload_from_float_array`
 - `tnn_upload_from_int_array`

--- a/docs/gating.md
+++ b/docs/gating.md
@@ -155,7 +155,7 @@ mirror is a gate failure; edit the CPU source and run `make gen-mirrors`.
 
 ## Vendored ggml patches
 
-Six local patches sit on top of vendored upstream `ggml@e484d08`, in
+Nine local patches sit on top of vendored upstream `ggml@41e7949`, in
 `vendor-patches/`. They are applied in filename order to `vendor/ggml/` by the
 Makefile's `$(GGML_DIR)/.patched` sentinel target, which `setup-ggml` /
 `setup-ggml-cuda` / `setup-ggml-metal` depend on through `CMakeLists.txt`.
@@ -172,6 +172,9 @@ the next build.
 | `0004-cuda-cpy-strided.patch` | `src/ggml-cuda/cpy.cu` | **CUDA KV-cache bit-identity** — guards `cpy_scalar_transpose` behind a contiguous-dst check; without it, KV writes into a strided `view_2d` silently miswrite. |
 | `0005-concat-backward.patch` | `src/ggml.c` | **Training** — adds the `GGML_OP_CONCAT` case to `ggml_compute_backward`; live at `vendor/ggml/src/ggml.c:6514`. Without it autograd aborts on per-head concat before the O projection. |
 | `0006-getrows-back-large-vocab.patch` | `src/ggml-cuda/getrows.cu` | **Training (large vocab)** — chunks the `get_rows_back` launch; the original `gridDim.y = vocab` aborts for Qwen-class vocabs (V > 65535). |
+| `0007-gpt2-backward-kernels.patch` | `include/ggml.h`, `src/ggml.c`, `src/ggml-cpu/*` | **GPT-2 training** — `gelu_back` + `norm_back` (our ggml#1514); without them GPT-2 backward aborts. |
+| `0008-mul-mat-backward-mixed-precision.patch` | `src/ggml.c` | **f16 training (GH#9)** — mul_mat backward for non-f32 weight dtypes; gated by `make gate-mixed-precision`. |
+| `0009-sched-unsupported-node-diagnostic.patch` | `src/ggml-backend.cpp` | **Diagnostics** — names the offending node when sched-alloc hits an unsupported op instead of a bare abort. |
 
 Patches 0001–0003 (the CUDA BYO-pointer path) are documented in
 `docs/reference/memory-design.md`. Patch 0005 (concat-backward) has its

--- a/docs/models.md
+++ b/docs/models.md
@@ -5,22 +5,30 @@ The canonical "what's actually wired" reference is
 is the model-level view: which checkpoints run, in which precision, on
 which backend — and the footnotes that keep the table honest.
 
+> **Verified at:** toy `d605aea` / spinel `a699cf9` / ggml `41e7949`
+> on 2026-06-11 (toy#61 re-verification pass; serve leg at spinel
+> `f6d5eef`, see spinel-dev#14). Every ✓ below was re-run on that
+> date on the gx10 (GB10, aarch64) except where a footnote says
+> otherwise. Greedy `toy infer` decode, CUDA asserted token-identical
+> to CPU; GPT-2 family additionally parity-checked against recorded
+> HuggingFace/PyTorch logits.
+
 | Model              | Family               | Params      | F32 | Q8_0 | CPU | CUDA F32 | CUDA Q8 | Metal F32 |
 | ------------------ | -------------------- | ----------- | --- | ---- | --- | -------- | ------- | --------- |
 | DistilGPT-2        | GPT-2                | 82M         | ✓   |      | ✓   | ✓        |         | ‡         |
 | GPT-2 small        | GPT-2                | 124M        | ✓   |      | ✓   | ✓        |         | ‡         |
-| SmolLM2-135M       | Llama family         | 135M        | ✓   | ✓    | ✓   | ✓        |         | ✓         |
+| SmolLM2-135M       | Llama family         | 135M        | ✓   | ✓    | ✓   | ✓        |         | ✓◇        |
 | SmolLM2-360M       | Llama family         | 360M        | ✓   |      | ✓   | ✓        |         | ‡         |
 | TinyLlama-1.1B     | Llama + SPM-BPE tok  | 1.1B        | ✓   | ✓    | ✓   | ✓        |         | ‡         |
 | Llama-3.2-1B       | Llama family         | 1B          | ✓   |      | ✓   | ✓        |         | ‡         |
 | Llama-3.2-3B       | Llama family         | 3B          | ✓   |      | ✓   | ✓        |         | ‡         |
 | Mistral-7B-v0.2    | Llama + SPM-BPE tok  | 7B          | ✓   | ✓    | ✓   |          | ✓       |           |
 | Qwen2.5-0.5B       | Llama + QKV bias     | 0.5B        | ✓   | ✓    | ✓   | ✓        |         | ‡         |
-| Qwen2.5-1.5B       | Llama + QKV bias     | 1.5B        | ✓   | ✓    | ✓   | ✓        | †       | ‡         |
-| Qwen2.5-3B         | Llama + QKV bias     | 3B          | ✓   | ✓    | ✓   | ✓        | †       | ‡         |
+| Qwen2.5-1.5B       | Llama + QKV bias     | 1.5B        | ✓   | ✓    | ✓   | ✓        | ✓†      | ‡         |
+| Qwen2.5-3B         | Llama + QKV bias     | 3B          | ✓   | ✓    | ✓   | ✓        | ✓†      | ‡         |
 | Qwen2.5-7B         | Llama + QKV bias     | 7B          | ✓   | ✓    | ✓   |          | ✓       |           |
-| Qwen3-0.6B         | Qwen3 + QK-norm      | 0.6B        | ✓   |      | ✓   | ✓        |         | ‡         |
-| Qwen3-1.7B         | Qwen3 + QK-norm      | 1.7B        | ✓   | ✓    | ✓   | ✓        |         | ‡         |
+| Qwen3-0.6B         | Qwen3 + QK-norm      | 0.6B        | ✓   |      | ✓   | ✗※       |         | ‡         |
+| Qwen3-1.7B         | Qwen3 + QK-norm      | 1.7B        | ✓   | ✓°   | ✓   | ✗※       |         | ‡         |
 | Qwen3-4B           | Qwen3 + QK-norm      | 4B          | ✓   |      | ✓   |          |         | ‡         |
 | OLMoE-1B-7B-Instr  | Llama + MoE + QK-norm⁂  | 7B (1B act) |     | ✓    | ✓   |          |         | ‡         |
 | Gemma 2-2b-it      | Llama + Gemma extras⁂⁂  | 2B          |     | ✓    | ✓   |          |         | ‡         |
@@ -37,9 +45,25 @@ each sublayer, and per-layer alternating SWA/full attention. All
 auto-detected from the GGUF (`gemma2.*` metadata). Its tokenizer is
 SPM-Unigram (no merges), enabled automatically.
 
-† Qwen2.5-1.5B/3B Q8 abort on CUDA at weight-load time: ggml-cuda's
-quantized matmul requires `d_ff` aligned to 512, and those models'
-`d_ff` (8960, 11008) aren't. The F32 path works for all sizes.
+† These cells used to read "aborts on CUDA at weight-load time
+(ggml-cuda quantized matmul required `d_ff` aligned to 512)". At the
+current ggml pin (`41e7949`) that restriction no longer reproduces:
+Qwen2.5-1.5B/3B Q8 run on CUDA and decode token-identical to the CPU
+Q8 and F32 paths (re-verified 2026-06-11).
+
+※ **Qwen3 on CUDA is broken** (caught by the 2026-06-11 re-verification;
+previously over-claimed). CPU decode is coherent; the CUDA binary runs
+but decodes degenerate output (`Once upon a time Answer Answer Answer…`
+on 0.6B, `Once upon a time::::::` on 1.7B), and `toy eval --device cuda`
+returns a top-5 disjoint from CPU's. Not a spinel-pin regression — a
+main-tree binary built 2026-06-06 reproduces it. Qwen3 is the only
+QK-norm + explicit-head_dim arch in the CUDA matrix; every other
+CUDA row above passes token-identical. Reported on toy#61 (needs its
+own issue).
+
+° Qwen3-1.7B Q8 was not re-verified on 2026-06-11: no Q8 checkpoint of
+it on the bench box (re-quantizing needs an HF download we don't keep).
+The ✓ is carried over from the original v0.5 validation.
 
 ‡ Metal: validated end-to-end only on SmolLM2-135M F32 (bit-identical
 to CPU). Other Llama-family models should work — same FFI surface,
@@ -47,6 +71,10 @@ same graph builder, same ggml-metal kernel coverage — but haven't been
 smoked. GPT-2-family isn't wired on Metal. Quantized weights on Metal
 are untested. The Metal path uses copy-load rather than mmap, so
 multi-GB models pay the copy cost.
+
+◇ The SmolLM2-135M Metal ✓ is Mac-gated (#27) and was not re-run in the
+2026-06-11 gx10 pass; it stands from the 2026-05-31 Mac validation
+(`9b5131a`).
 
 ## Tokenizer / RoPE coverage
 

--- a/prep/gen_coverage.rb
+++ b/prep/gen_coverage.rb
@@ -313,7 +313,11 @@ md << <<~MD
   This is the canonical "what we support" matrix. One row per ggml op
   (`enum ggml_op` in `vendor/ggml/include/ggml.h`), with columns for the
   CPU + CUDA + Metal FFI bindings and backward support. Models built on
-  top of these ops are tracked separately in `docs/models-verified.md`.
+  top of these ops are tracked separately in `docs/models.md`.
+
+  Last full re-verification: 2026-06-11 (toy#61) at toy `d605aea` /
+  spinel `a699cf9` / ggml `41e7949` — table regenerated against that
+  tree, runner + training + smoke gates green on CPU and CUDA.
 
   ## Summary
 
@@ -327,11 +331,12 @@ md << <<~MD
 
   Backend caveats not captured by the table:
 
-  - **`MUL_MAT_ID` × Q4_K / Q6_K source weights**: ggml's mul_mat_id
-    kernel produces garbage on K-quantized expert tensors. Q8_0 / F16 /
-    F32 sources work. Tracked in `docs/notes/mul_mat_id_quant.md` once
-    we write it; for now see commit `42b8609` (M2.3) for the
-    repro/workaround.
+  - **`MUL_MAT_ID` × Q4_K / Q6_K source weights — RESOLVED (was ours, not
+    ggml's).** OLMoE-Q4_K_M produced degenerate output and was long misfiled as a
+    ggml mul_mat_id K-quant kernel bug (ggml#1506). The op is correct for K-quants;
+    the real cause was `head_nbytes` returning 0 for K-quant ATTENTION weights,
+    collapsing every head onto head 0 (fixed). K-quant MoE experts load and run
+    coherently. See `docs/notes/mul_mat_id_quants.md` + `make gate-moe-kquant`.
   - **`FLASH_ATTN_BACK`**: ggml's backward kernel calls `GGML_ABORT` at
     runtime (see `vendor/ggml/src/ggml.c::ggml_flash_attn_back`). The
     op is "missing" for us, but it's also broken upstream — wait for


### PR DESCRIPTION
Executes toy#61 (part of #58). Full re-run of every claim in docs/models.md + the gate suite + benches at **toy d605aea / spinel a699cf9 / ggml 41e7949** (serve leg at **spinel f6d5eef**, spinel-dev#14), 2026-06-11, gx10. Docs now carry explicit provenance so the final-pin re-run is a cheap diff.

## Commits (gated)
1. `fix`: `prep/gen_coverage.rb` — coverage.md had drifted (coverage-check FAILED on main: 4 newly-bound ops + 33 infra wrappers missing) and the resolved MUL_MAT_ID prose lived only as a hand-edit that regeneration reverted. Corrected text moved into the generator; dangling `models-verified.md` ref fixed; provenance stamped; regenerated.
2. `fix`: `bench/check.rb` honors `SPINEL_DIR` (was hardcoding `~/sites/spinel`).
3. `docs`: models.md provenance header + verdict changes; bench-vs-pytorch.md re-measured; gating.md patch table caught up (six → nine patches, e484d08 → 41e7949).

## Verdict changes in the models table
- **Qwen2.5-1.5B/3B CUDA Q8: † → ✓** — the d_ff%512 abort no longer reproduces at ggml 41e7949; both token-identical to CPU.
- **Qwen3-0.6B/1.7B CUDA F32: ✓ → ✗** — CPU coherent, CUDA degenerate (eval top-5 disjoint). Pre-existing (Jun 6 main binary reproduces) ⇒ over-claim, not an a699cf9 regression. Needs its own issue.
- **Qwen3-1.7B Q8** marked not-re-verified (no Q8 checkpoint on the box); **SmolLM2 Metal ✓** marked as standing on the 2026-05-31 Mac pass (#27).

Everything else re-verified ✓ (full row×precision×backend table in the toy#61 comment): GPT-2 family against recorded HF/PyTorch logits (CUDA bit-identical to the May recordings), 15 llama-family checkpoints F32/Q8 × CPU/CUDA token-identical incl. all three 7B-class, all runner/training/smoke/poly/mirror/compute-surface gates green, serve gates green at f6d5eef.

## Bench
- `make bench` green; CPU decode +32.6% vs baseline (85.4 tok/s), LoRA/tokenizer within tolerance.
- `bench-vs-pytorch` train ratio **0.995×** (budget 1.031, ok). **Decode leg retired**: `demos/qwen25_bench_cuda` segfaults (`sp_gc_mark` → `SmolLM2KVCuda.decode_step`) since ~May 31, and `check_vs_pytorch.rb` silently skips the missing ratio and prints ok — fail-loud violation, called out in the doc; needs its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)