### PR TITLE
feat(#69): adopt sig/*.rbs type roots — produce + consume + the #52 probe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -266,3 +266,7 @@ examples/legacy/06_train_from_scratch_cuda.rb
 examples/legacy/06_train_from_scratch_metal.rb
 prep/smokes/smoke_projection_lens_cuda.rb
 prep/smokes/smoke_projection_lens_metal.rb
+
+# toy#69 — vendored gems' aggregated RBS root, symlinked into toy's
+# --rbs sig root by `make vendor-tep` (machine-generated; spinelgems#13).
+/sig/vendor

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,19 @@
 SPINEL_DIR  ?= $(HOME)/sites/spinel
 SPINEL_BIN  ?= $(SPINEL_DIR)/spinel
 
+# toy#69 — sig/*.rbs type roots. Every Spinel compile seeds the analyzer
+# with toy's shipped RBS tree (`--rbs sig`): uncalled public methods
+# keep their DECLARED param/return/ivar types instead of widening to
+# poly (the spinel-dev#11/#12 facet family). Seeds are ADVISORY —
+# inference runs on top and widens on observed contradiction (spinel
+# docs/RBS-EXTRACT.md), and the full gate sweep was byte-exact at
+# adoption. Vendored gems' sig roots ride along through the gitignored
+# sig/vendor symlink -> ../vendor/spinel/sig, refreshed by `make
+# vendor-tep` (spinel takes ONE --rbs dir; spinel_rbs_extract walks it
+# recursively and follows symlinks). Set SPINEL_RBS= (empty) to compile
+# without seeds when chasing an analyzer issue.
+SPINEL_RBS ?= --rbs $(CURDIR)/sig
+
 # --- DevEx polish knobs (cosmetic, never gate correctness) ----------------
 # QUIET=1 (default) routes known-harmless build chatter through the
 # prep/quietly + prep/progress helpers so the terminal stays readable
@@ -34,12 +47,12 @@ QUIET    ?= 1
 QUIETLY  := $(CURDIR)/prep/quietly
 PROGRESS := $(CURDIR)/prep/progress
 ifeq ($(QUIET),0)
-  SPINEL = $(SPINEL_BIN)
+  SPINEL = $(SPINEL_BIN) $(SPINEL_RBS)
 else
   SPINEL = $(QUIETLY) \
       'cannot resolve call to' \
       'ignoring duplicate libraries' \
-      -- $(SPINEL_BIN)
+      -- $(SPINEL_BIN) $(SPINEL_RBS)
 endif
 # Sentinel deps so example/demo Spinel-compiled binaries get re-spun
 # when the Spinel compiler itself changes. Without this, stale .o /
@@ -126,6 +139,17 @@ vendor-tep:
 	fi
 	bundle lock
 	SPINEL_EXT_DISABLE=pg SPINEL_DIR=$(HOME)/sites/spinel ../spinelgems/exe/spinel-compat vendor
+	@# toy#69 — fold the vendored gems' aggregated sig root (advertised
+	@# by vendor/spinel/deps.rb, spinelgems#13) into toy's own --rbs
+	@# root via a gitignored symlink: spinel accepts ONE --rbs dir and
+	@# spinel_rbs_extract follows symlinks. Removed when no gem ships
+	@# sig (a dangling link would warn on every compile).
+	@if [ -d vendor/spinel/sig ]; then \
+	    ln -sfn ../vendor/spinel/sig sig/vendor; \
+	    echo "  sig/vendor -> ../vendor/spinel/sig (rbs ride-along)"; \
+	else \
+	    rm -f sig/vendor; \
+	fi
 
 # Build vendor/spinel/tep/lib/tep.rb on demand for tep_demo/* targets.
 # Triggers vendor-tep, which gates on sibling checkouts.

--- a/docs/consuming-toy.md
+++ b/docs/consuming-toy.md
@@ -110,6 +110,43 @@ need `spinel --cc='cc -Wl,-u,tnn_cuda_force_link' …` — without the force-lin
 symbol the linker drops the CUDA backend registration and ggml silently
 computes on CPU (verified: the loss curve flips to the CPU fixture).
 
+## RBS type roots ride along automatically (toy#69)
+
+Toy ships `sig/*.rbs` covering its public surface — the pure-Ruby
+models (`sig/toy.rbs`: Mat, the `Toy::` blocks, SmolLM2, GPT2LM,
+Tokenizer) **and** the Spinel compute surface (`sig/toy_compute.rbs`:
+`RecipeOptions`, `TrainingBatch`, `AdamW`, `Labels`, the recipes'
+`realize!`/`step!`, the engines' scalar config + ptr-free methods,
+`ViTTinyConfig`, the KV decode classes, `GGUFLoad::SmolLM2Flags`).
+
+`spinel-compat vendor` copies each gem's `sig/` and aggregates ONE root
+at `vendor/spinel/sig` (spinelgems#13), advertised in the generated
+`vendor/spinel/deps.rb` header. Compile with it:
+
+```sh
+spinel --rbs vendor/spinel/sig experiment.rb -o experiment
+```
+
+(The `toy new --lib` scaffold's `build.sh` does this automatically when
+the directory exists.) The seeds are **advisory** — Spinel's inference
+runs on top and widens on observed contradiction — but they pin a
+method's param/ivar/return types **without needing a call site**, which
+defends against the uncalled-param poly-widening family (spinel-dev#11/
+#12): a toy method your experiment never calls stays concretely typed
+instead of unioning poly into shared callees.
+
+Two honest limits (probed on spinel a699cf9):
+
+- **FFI `:ptr` has no RBS spelling.** Methods with a ptr param or return
+  (the `realize_for_mmap` family, tensor-handle accessors) can't be
+  declared — sig roots can NOT rescue the lora-in-compute exclusion
+  (toy#52) because `LoRA#realize!`'s leading `gguf_handle` is a ptr and
+  the poison is a CONSTRUCTOR slot (spinel-dev#12).
+- **Arity must be exact or absent.** A truncated declaration against a
+  default-arg method is NOT a no-op: it breaks the C compile with a
+  "too few arguments" error (the one non-advisory failure mode; toy's
+  `Tokenizer#initialize` hit this during adoption).
+
 ## The `sp_Mat undeclared` landmine
 
 If your consumer compile fails with `sp_Mat undeclared` (or a poly-dispatch crash

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -164,6 +164,18 @@ Env knobs honored by `prep/post_vendor_toy.rb`:
 For the full consumer recipe see the worked example at
 `~/sites/tao_transfer`.
 
+**RBS type roots (toy#69 / spinelgems#13).** toy both CONSUMES and
+PRODUCES sig roots. Consuming: `make vendor-tep` re-vendors and, when
+any vendored gem ships `sig/` (spinel_kit does), symlinks the
+aggregated `vendor/spinel/sig` to the gitignored `sig/vendor` so toy's
+own `--rbs sig` compiles (every `$(SPINEL)` invocation; `SPINEL_RBS=`
+disables) seed the vendored gems' types too. Producing: the gemspec
+ships `sig/**/*.rbs`, so consumers' vendor trees get toy's sig
+automatically and their `--rbs vendor/spinel/sig` keeps UNCALLED toy
+methods concretely typed (the spinel-dev#11/#12 poly-widening
+defense). See `docs/consuming-toy.md` for coverage and the two limits
+(no `:ptr` spelling; arity must be exact or absent).
+
 ---
 
 ## `Mat#add` was renamed to `Mat#plus`

--- a/lib/toy/core/cli/new.rb
+++ b/lib/toy/core/cli/new.rb
@@ -317,16 +317,23 @@ module Toy
           # device. Usage: ./build.sh [cpu] [cuda] [metal]   (default: cpu)
           set -e
           devs="${*:-cpu}"
+          # RBS type roots (toy#69 / spinelgems#13): `spinel-compat vendor`
+          # aggregates every vendored gem's sig/ (toy's included) under
+          # vendor/spinel/sig and advertises it in vendor/spinel/deps.rb.
+          # Seeding the analyzer with it keeps UNCALLED gem methods at
+          # their declared types (advisory; safe to omit).
+          rbs=""
+          [ -d vendor/spinel/sig ] && rbs="--rbs vendor/spinel/sig"
           for dev in $devs; do
             entry="main_$dev.rb"
             out="experiment_$dev"
             case "$dev" in
               cpu)
-                spinel "$entry" -o "$out" ;;
+                spinel $rbs "$entry" -o "$out" ;;
               cuda)
-                spinel --cc='cc -Wl,-u,tnn_cuda_force_link' "$entry" -o "$out" ;;
+                spinel $rbs --cc='cc -Wl,-u,tnn_cuda_force_link' "$entry" -o "$out" ;;
               metal)
-                spinel --cc='cc -Wl,-u,_tnn_metal_force_link -framework Foundation -framework Metal -framework MetalKit' "$entry" -o "$out" ;;
+                spinel $rbs --cc='cc -Wl,-u,_tnn_metal_force_link -framework Foundation -framework Metal -framework MetalKit' "$entry" -o "$out" ;;
               *)
                 echo "build.sh: unknown device '$dev' (want cpu|cuda|metal)" >&2
                 exit 2 ;;

--- a/prep/poly_degrade_gate.rb
+++ b/prep/poly_degrade_gate.rb
@@ -52,11 +52,31 @@ unless File.executable?(SPINEL)
   exit 2
 end
 
+# toy#69 — seed the analyzer with sig/*.rbs exactly like the Makefile's
+# $(SPINEL) wrapper does, so this gate scans the SAME compile the runners
+# ship from. Override with SPINEL_RBS (e.g. SPINEL_RBS="" to scan an
+# unseeded compile when bisecting whether a warning comes from inference
+# or from a seed).
+RBS_ARGS = if ENV.key?("SPINEL_RBS")
+             ENV["SPINEL_RBS"].split(" ")
+           else
+             ["--rbs", File.join(ROOT, "sig")]
+           end
+
 # Compile one entrypoint and return the sorted-unique set of emit-0 resolve
 # warnings, each prefixed with the entrypoint so a regression names its file.
 def scan(entry)
   out_bin = "/tmp/poly_degrade_#{File.basename(entry, '.rb')}_#{Process.pid}"
-  stdout_err, _status = Open3.capture2e(SPINEL, entry, "-o", out_bin, chdir: ROOT)
+  stdout_err, status = Open3.capture2e(SPINEL, *RBS_ARGS, entry, "-o", out_bin, chdir: ROOT)
+  # Fail LOUD on a failed compile (toy#69): a broken build emits ZERO
+  # emit-0 warnings and would otherwise sail through as "clean" — this
+  # exact masking hid a wrong-arity RBS seed breaking toy-infer's C
+  # compile while the gate stayed green.
+  unless status.success?
+    warn "GATE FAIL [poly-degrade]: #{entry} did not compile (spinel exit #{status.exitstatus})"
+    warn stdout_err.lines.last(15).join
+    exit 1
+  end
   FileUtils.rm_f(out_bin)
   found = []
   stdout_err.each_line do |line|

--- a/sig/toy.rbs
+++ b/sig/toy.rbs
@@ -2,12 +2,12 @@
 #
 # Used by Steep (typecheck), the Phuong–Hutter algorithm-card emitter
 # (source of truth), and Spinel's `--rbs sig` flag (analyzer-arbitration
-# hint). The Makefile doesn't pass --rbs by default — it adds a few
-# polymorphic-dispatch warnings on GPT2LM's Array<Mat> accessors that
-# we'd want to silence first — but feeding the file in costs 3 extra
-# warnings (was 45 before matz/spinel#97bf268 fixed Mat-in-Toy::
-# resolution), so enabling it per-build is now reasonable. Keep this
-# file accurate against lib/.
+# hint; seeds are ADVISORY — see spinel docs/RBS-EXTRACT.md for the
+# supported subset). Since toy#69 the Makefile passes `--rbs sig` on
+# every spinel invocation (SPINEL_RBS_FLAG), and `spinel-compat vendor`
+# ships this tree to consumers (spinelgems#13). The compute surface
+# (recipes / engines / value objects) lives in sig/toy_compute.rbs.
+# Keep this file accurate against lib/.
 #
 # Conventions:
 #   - Mat is a 2-D Float matrix with flat f64 storage. Where shape is
@@ -23,7 +23,7 @@
 
 # ============================================================================
 # Mat — 2D Float matrix, flat row-major f64 storage.
-# (Lives in lib/transformer.rb.)
+# (Lives in lib/toy/models/transformer.rb.)
 # ============================================================================
 class Mat
   attr_accessor nrows: Integer
@@ -202,22 +202,68 @@ module Toy
 
   # ========================================================================
   # SmolLM2 / Llama-family model.
-  # (Lives in lib/toy_smollm2.rb.)
+  # (Lives in lib/toy/models/toy_smollm2.rb.)
   # ========================================================================
-  class SmolLM2Config
-    attr_accessor vocab:     Integer
-    attr_accessor d_model:   Integer
-    attr_accessor n_heads:   Integer
-    attr_accessor n_kv:      Integer
-    attr_accessor d_ff:      Integer
-    attr_accessor n_layers:  Integer
-    attr_accessor ctx:       Integer
-    attr_accessor rope_base: Float
-    attr_accessor rms_eps:   Float
 
-    def initialize: (Integer, Integer, Integer, Integer, Integer,
-                     Integer, Integer, Float, Float) -> void
-    def self.smollm2_135m: () -> SmolLM2Config
+  # ---- RopeScaling — RoPE frequency-scaling parameters --------------------
+  # Carried on SmolLM2Config; the GGUF loader sets it from
+  # rope_scaling.* metadata. kind ∈ :none / :linear / :llama3.
+  class RopeScaling
+    attr_accessor kind:             Symbol
+    attr_accessor freq_scale:       Float
+    attr_accessor orig_max_pos:     Integer
+    attr_accessor factor:           Float
+    attr_accessor low_freq_factor:  Float
+    attr_accessor high_freq_factor: Float
+    attr_accessor ext_factor:       Float
+    attr_accessor attn_factor:      Float
+    attr_accessor beta_fast:        Float
+    attr_accessor beta_slow:        Float
+
+    def initialize: (Symbol kind, Float freq_scale, Integer orig_max_pos,
+                     Float factor, Float low_freq_factor,
+                     Float high_freq_factor, Float ext_factor,
+                     Float attn_factor, Float beta_fast,
+                     Float beta_slow) -> void
+    def self.none:   () -> Toy::RopeScaling
+    def self.linear: (Float factor) -> Toy::RopeScaling
+    def self.llama3: (Float factor, Float low_freq, Float high_freq,
+                      Integer orig_max_pos) -> Toy::RopeScaling
+    # Returns the (d_head/2)-element per-dim freq_factors array.
+    def self.compute_llama3_freq_factors: (Integer d_head, Float freq_base,
+                                           Integer orig_max_pos, Float factor,
+                                           Float low_freq, Float high_freq) -> Array[Float]
+  end
+
+  class SmolLM2Config
+    attr_accessor vocab:        Integer
+    attr_accessor d_model:      Integer
+    attr_accessor n_heads:      Integer
+    attr_accessor n_kv:         Integer
+    attr_accessor d_ff:         Integer
+    attr_accessor n_layers:     Integer
+    attr_accessor ctx:          Integer
+    attr_accessor rope_base:    Float
+    attr_accessor rms_eps:      Float
+    attr_accessor rope_scaling: Toy::RopeScaling
+    attr_accessor head_dim:     Integer
+    attr_accessor donor_d_in:   Integer
+
+    # THE #52 CONSTRUCTOR SLOT: this ctor sits on the shared path that
+    # uncalled forwarders (LoRA#realize! → realize_for_mmap → .new)
+    # union poly args into (spinel-dev#12). The seed pins it.
+    def initialize: (Integer vocab, Integer d_model, Integer n_heads,
+                     Integer n_kv, Integer d_ff, Integer n_layers,
+                     Integer ctx, Float rope_base, Float rms_eps) -> void
+    def self.smollm2_135m: () -> Toy::SmolLM2Config
+    def self.tiny:         () -> Toy::SmolLM2Config
+    def self.mid:          () -> Toy::SmolLM2Config
+    def self.mha: (Integer vocab, Integer d_model, Integer heads,
+                   Integer d_ff, Integer layers, Integer ctx,
+                   Float rope_base, Float rms_eps) -> Toy::SmolLM2Config
+    def self.gqa: (Integer vocab, Integer d_model, Integer heads,
+                   Integer n_kv, Integer d_ff, Integer layers, Integer ctx,
+                   Float rope_base, Float rms_eps) -> Toy::SmolLM2Config
   end
 
   class SmolLM2Block
@@ -247,7 +293,6 @@ module Toy
     # Returns logits of shape [T, V].
     def forward:                  (Array[Integer] ids, Integer pos_start) -> Mat
     def param_count:              () -> Integer
-    def describe:                 () -> String
   end
 
   # ========================================================================
@@ -320,22 +365,29 @@ class GPT2LM
 end
 
 # ============================================================================
-# Tokenizer — GGUF-embedded BPE decoder. (lib/tokenizer.rb)
+# Tokenizer — GGUF-embedded BPE decoder. (lib/toy/io/tokenizer.rb)
 # Declared here to pin Spinel's analyzer; cross-class polymorphism on
 # `length` was widening Mat#nrows to sp_RbVal in compiled artifacts.
 # ============================================================================
 class Tokenizer
-  attr_reader vocab_size: Integer
-  attr_reader bos_id:     Integer
-  attr_reader eos_id:     Integer
-  attr_reader pad_id:     Integer
-  attr_reader unk_id:     Integer
-  attr_reader present:    bool
+  attr_reader vocab_size:  Integer
+  attr_reader bos_id:      Integer
+  attr_reader eos_id:      Integer
+  attr_reader pad_id:      Integer
+  attr_reader unk_id:      Integer
+  attr_reader present:     bool
+  attr_reader spm:         bool
+  attr_reader spm_unigram: bool
+  attr_accessor add_bos:   bool
 
-  def initialize: (Array[String] vocab,
-                   Array[String] merges,
-                   Integer bos_id, Integer eos_id,
-                   Integer pad_id, Integer unk_id) -> void
+  # initialize is NOT declared: it takes 2 trailing DEFAULT args
+  # (model_name = "", add_bos = false), which are outside the RBS
+  # subset — and a deliberately-truncated 6-param declaration is NOT
+  # safe: the seed pinned a 6-slot signature against the 8-slot
+  # compiled ctor and broke the C compile of toy-infer with
+  # "too few arguments to function 'sp_Tokenizer_new'" (probed on
+  # a699cf9 during toy#69 adoption — a wrong-ARITY seed is the one
+  # case that is NOT an advisory no-op). Keep arity exact or absent.
 
   def token_at: (Integer id) -> String
   def decode:   (Array[Integer] ids) -> String

--- a/sig/toy_compute.rbs
+++ b/sig/toy_compute.rbs
@@ -1,0 +1,357 @@
+# sig/toy_compute.rbs — type signatures for the SPINEL-ONLY compute
+# surface (lib/toy/compute.rb and everything it pulls). Companion to
+# sig/toy.rbs (the pure-Ruby Mat / model surface).
+#
+# WHY (toy#69): RBS type roots pin a method's param/return/ivar types
+# WITHOUT needing a call site — a standing defense against the
+# uncalled-param poly-widening family (spinel-dev#11/#12, the f7ae245
+# facets). As a published gem, this sig/ tree flows automatically into
+# every consumer's vendor tree (spinelgems#13: `spinel-compat vendor`
+# copies sig/ and advertises one `--rbs <into>/sig` root), so uncalled
+# toy methods in consumer builds stay concretely typed.
+#
+# SUPPORTED SUBSET (spinel docs/RBS-EXTRACT.md — seeds are ADVISORY;
+# inference runs on top and widens on observed contradiction):
+#   - Integer/Float/String/Symbol/bool/void/nil, nominal Foo::Bar,
+#     Array[T], Hash[String|Symbol, T], T?.
+#   - NO optional/keyword/rest/block params — a signature touching any
+#     is dropped WHOLESALE. NO untyped/self/tuples/generics.
+#   - FFI `:ptr` values have NO RBS spelling: every ptr-typed accessor
+#     (sess, t_seq_* tensor handles, gguf handles, g_* arch handles)
+#     and every method with a ptr param or ptr return is intentionally
+#     OMITTED here — the analyzer's own inference handles those. This
+#     is also why LoRA#realize! / *#realize_for_mmap can NOT be rescued
+#     by sig alone: their leading gguf_handle param is a ptr (see the
+#     lora-exclusion note in lib/toy/compute.rb; spinel-dev#12).
+#   - Unqualified type names resolve to TOP-LEVEL (probed on a699cf9),
+#     so every non-top-level reference below is fully qualified.
+#
+# Conventions match sig/toy.rbs: Array[Integer] = token-id lists,
+# Array[Float] = flat f32/f64 buffers, Mat = 2-D Float matrix.
+# Keep this file accurate against lib/.
+
+# ============================================================================
+# Toy:: value objects shared by the recipes (pure Ruby, no FFI).
+# ============================================================================
+module Toy
+  # ---- AdamW (lib/toy/llm/adamw.rb) — named hyper-params → Mat(1,7) ------
+  # Slots 5/6 are DUAL-MEANING per graph family; `mode` declares the
+  # convention and hp() fails loud when unset/mismatched.
+  class AdamW
+    attr_accessor lr:           Float
+    attr_accessor beta1:        Float
+    attr_accessor beta2:        Float
+    attr_accessor eps:          Float
+    attr_accessor weight_decay: Float
+    attr_accessor bias_correct: bool
+    attr_accessor mode:         Integer
+
+    def initialize: () -> void
+    def self.for_from_scratch: () -> Toy::AdamW
+    def self.for_lora:         () -> Toy::AdamW
+    # step is the caller's 1-indexed step; ignored when bias_correct
+    # is false. Returns the Mat(1,7) handed to the recipes' step!.
+    def hp: (Integer step) -> Mat
+  end
+
+  # ---- Labels (lib/toy/llm/labels.rb) — shift-by-one one-hot builders ----
+  module Labels
+    def self.next_token:         (Array[Integer] seq_ids, Integer vocab,
+                                  Integer context, Integer batch) -> Mat
+    def self.next_token_guarded: (Array[Integer] seq_ids, Integer vocab,
+                                  Integer context, Integer batch) -> Mat
+  end
+
+  # ---- Device (lib/toy/compute{,_cuda,_metal}.rb) ------------------------
+  # The device-agnostic construction seam. ONLY `name` is declared:
+  # the factory methods (llama_engine, gpt2_engine, from_scratch_recipe,
+  # warm_start_recipe) return DIFFERENT classes per compute entry
+  # (LlamaSeqEngine vs LlamaSeqEngineCuda, ...), and this one sig tree
+  # serves all device builds — pinning a CPU return type would seed a
+  # contradiction into every CUDA/Metal build.
+  module Device
+    def self.name: () -> String
+  end
+end
+
+# ============================================================================
+# Toy::LLM:: — recipe options, training batch, recipes, engines.
+# ============================================================================
+module Toy
+  module LLM
+    # ---- RecipeOptions (lib/toy/llm/recipe_options.rb) -------------------
+    # Named realize-time options. Feed MONOMORPHIC values only (a poly
+    # assignment silently shifts training numerics — see the file's
+    # loud warning); these ivar seeds pin the expected types.
+    class RecipeOptions
+      attr_accessor t_seq:        Integer
+      attr_accessor t_batch:      Integer
+      attr_accessor weight_dtype: Integer
+      attr_accessor untied:       bool
+      attr_accessor qkv_bias:     bool
+      attr_accessor seed:         Integer
+      attr_accessor init_scale:   Float
+
+      def initialize: () -> void
+    end
+
+    # ---- TrainingBatch (lib/toy/llm/training_batch.rb) -------------------
+    # Validating wrapper for the per-step quartet. hp is caller-owned
+    # (Mat(1,7) from Toy::AdamW#hp).
+    class TrainingBatch
+      attr_accessor vocab:     Integer
+      attr_accessor context:   Integer
+      attr_accessor batch:     Integer
+      attr_accessor seq_ids:   Array[Integer]
+      attr_accessor positions: Array[Integer]
+      attr_accessor labels:    Mat
+      attr_accessor hp:        Mat
+
+      def initialize: (Integer vocab, Integer context, Integer batch_size) -> void
+      def fill!: (Array[Integer] new_seq_ids) -> void
+    end
+
+    # ======================================================================
+    # Recipes (lib/toy/llm/recipes/) — the L4 named training plans.
+    # The engine-handle ivars (fs_cache, ws_cache, lora_cache, vt_cache)
+    # and stashed tensor handles (*_t_loss/_t_labels/_t_hp) are ptr-
+    # adjacent internals and stay inference-typed.
+    # ======================================================================
+    module Recipes
+      # ---- FromScratch — random-init train --------------------------------
+      class FromScratch
+        attr_accessor fs_cache:      Toy::LLM::Engine::LlamaSeqEngine
+        attr_accessor fs_step_index: Integer
+
+        def initialize: () -> void
+        def realize!: (Toy::SmolLM2Config cfg, Toy::LLM::RecipeOptions opts) -> void
+        # Returns the loss. m_labels/m_hp from Toy::Labels / Toy::AdamW#hp.
+        def step!: (Array[Integer] seq_ids, Array[Integer] positions,
+                    Mat m_labels, Mat m_hp, bool is_first) -> Float
+      end
+
+      # ---- WarmStart — random-init + donor-embed upload window ------------
+      class WarmStart
+        attr_accessor ws_cache:      Toy::LLM::Engine::LlamaSeqEngine
+        attr_accessor ws_step_index: Integer
+
+        def initialize: () -> void
+        def realize_scratch!: (Toy::SmolLM2Config cfg, Toy::LLM::RecipeOptions opts) -> void
+        # donor_buf_flat is the ALREADY-READ flat donor embedding.
+        def realize_warm!: (Array[Float] donor_buf_flat, Integer n_floats) -> void
+        def build!: () -> void
+        def step!: (Array[Integer] seq_ids, Array[Integer] positions,
+                    Mat m_labels, Mat m_hp, bool is_first) -> Float
+      end
+
+      # ---- LoRA — frozen mmap base + rank-r Q adapters ---------------------
+      # realize!(gguf_handle, cfg, rank, opts) is NOT declarable: its
+      # leading param is an FFI ptr (out of the RBS subset; the whole
+      # signature would be dropped). This is exactly why sig roots can
+      # not independently rescue the lora-in-compute exclusion (toy#52,
+      # spinel-dev#12) — see lib/toy/compute.rb.
+      class LoRA
+        attr_accessor lora_cache:      Toy::LLM::Engine::LlamaSeqEngine
+        attr_accessor lora_step_index: Integer
+
+        def initialize: () -> void
+        def step!: (Array[Integer] seq_ids, Array[Integer] positions,
+                    Mat m_labels, Mat m_hp, bool is_first) -> Float
+      end
+
+      # ---- VitTiny — ViT-Tiny from-scratch image classifier ----------------
+      class VitTiny
+        attr_accessor vt_cache: Toy::LLM::Engine::ViTTinyEngine
+
+        def initialize: () -> void
+        def realize!: (ViTTinyConfig cfg, Toy::LLM::RecipeOptions opts) -> void
+        # cls_idx is the single-element class-index array.
+        def step!: (Mat m_image, Array[Integer] cls_idx,
+                    Mat m_labels, Mat m_hp, bool is_first) -> Float
+      end
+    end
+
+    # ======================================================================
+    # Engines (lib/toy/llm/engine/) — the L4 forward/train drivers.
+    # Tensor-handle accessors (sess, t_seq_*, g_*, ft_globals_*) are
+    # FFI ptrs / ptr arrays — intentionally omitted (no RBS spelling).
+    # ======================================================================
+    module Engine
+      # ---- LlamaSeqEngine (llama_seq_engine.rb) ----------------------------
+      class LlamaSeqEngine
+        attr_accessor seq_has_untied_output:       bool
+        attr_accessor seq_has_qkv_bias:            bool
+        attr_accessor seq_t:                       Integer
+        attr_accessor seq_b:                       Integer
+        attr_accessor seq_d_model:                 Integer
+        attr_accessor seq_d_ff:                    Integer
+        attr_accessor seq_n_heads:                 Integer
+        attr_accessor seq_n_kv:                    Integer
+        attr_accessor seq_d_head:                  Integer
+        attr_accessor seq_group_size:              Integer
+        attr_accessor seq_n_layers:                Integer
+        attr_accessor seq_vocab_size:              Integer
+        attr_accessor seq_rope_base:               Float
+        attr_accessor seq_rope_scaling:            Toy::RopeScaling
+        attr_accessor seq_rms_eps:                 Float
+        attr_accessor seq_realized:                bool
+        attr_accessor seq_weight_dtype:            Integer
+        attr_accessor seq_lora_q_enabled:          bool
+        attr_accessor seq_lora_q_rank:             Integer
+        attr_accessor seq_lora_q_adamw_enabled:    bool
+        attr_accessor seq_full_finetune_enabled:   bool
+        attr_accessor ft_train_embeddings_enabled: bool
+
+        def initialize: () -> void
+        def enable_full_finetune_embeddings!: () -> bool
+        def enable_full_finetune!: () -> bool
+        def enable_lora_q!: (Integer r) -> Integer
+        def enable_lora_q_adamw!: () -> bool
+        # Pure ivar writes from cfg.*; pins the cfg slot CONCRETELY even
+        # from call sites the analyzer never sees live (the #52 chain).
+        def apply_seq_cfg!: (Toy::SmolLM2Config cfg) -> Float
+        # The from-scratch/warm-start realize. (The gguf-handle realizes —
+        # realize_for_mmap / realize_for_q8_copy / realize_for_full_finetune
+        # — take a leading FFI ptr and can not be declared.)
+        def realize_for_random_init: (Toy::SmolLM2Config cfg, Integer t_seq,
+                                      Integer t_batch, Integer weight_dtype,
+                                      bool untied, bool qkv_bias,
+                                      Integer seed, Float init_scale) -> bool
+        def upload_block_causal_mask!: () -> Integer
+        def upload_random_init!: (Integer seed, Float init_scale,
+                                  bool qkv_bias, bool untied) -> void
+        def upload_lora_q_init!: (Integer seed, Float init_scale) -> void
+        def build_and_realize!: () -> bool
+      end
+
+      # ---- GPT2SeqEngine (gpt2_seq_engine.rb) ------------------------------
+      class GPT2SeqEngine
+        attr_accessor g_vocab:    Integer
+        attr_accessor g_d_model:  Integer
+        attr_accessor g_n_heads:  Integer
+        attr_accessor g_d_head:   Integer
+        attr_accessor g_d_ff:     Integer
+        attr_accessor g_n_layers: Integer
+        attr_accessor g_context:  Integer
+        attr_accessor g_rng:      Integer
+
+        def initialize: () -> void
+        def realize!: (Integer vocab, Integer d_model, Integer n_heads,
+                       Integer d_ff, Integer n_layers, Integer context,
+                       Integer seed) -> void
+        def build_forward!: () -> void
+        def build_train_step!: () -> void
+        def step!: (Array[Integer] seq_ids, Array[Integer] positions,
+                    Mat m_labels, Mat m_hp, bool is_first) -> Float
+      end
+
+      # ---- ViTTinyEngine (vit_tiny_engine.rb) ------------------------------
+      class ViTTinyEngine
+        attr_accessor cfg:            ViTTinyConfig
+        attr_accessor n_patches:      Integer
+        attr_accessor seq_t:          Integer
+        attr_accessor patch_flat_dim: Integer
+        attr_accessor realized:       bool
+
+        def initialize: () -> void
+        def realize_for_random_init: (ViTTinyConfig cfg, Integer seed,
+                                      Float init_scale) -> bool
+        def upload_random_init!: (Integer seed, Float init_scale) -> void
+      end
+    end
+  end
+end
+
+# ============================================================================
+# ViTTinyConfig (lib/toy/models/toy_vit.rb) — top-level.
+# ============================================================================
+class ViTTinyConfig
+  attr_accessor image_size:   Integer
+  attr_accessor patch_size:   Integer
+  attr_accessor num_channels: Integer
+  attr_accessor d_model:      Integer
+  attr_accessor n_heads:      Integer
+  attr_accessor d_head:       Integer
+  attr_accessor d_ff:         Integer
+  attr_accessor n_layers:     Integer
+  attr_accessor num_classes:  Integer
+  attr_accessor ln_eps:       Float
+
+  def initialize: (Integer image_size, Integer patch_size,
+                   Integer num_channels, Integer d_model, Integer n_heads,
+                   Integer d_ff, Integer n_layers, Integer num_classes,
+                   Float ln_eps) -> void
+end
+
+# ============================================================================
+# KV-cache decode engine (lib/toy/llm/engine/llama_kv_engine.rb) —
+# top-level classes ("LlamaKvEngine" is the FILE name; the classes keep
+# their historical names). Heavily ptr-typed; only the scalar config /
+# flag surface and the ptr-free methods are declared.
+# ============================================================================
+class SmolLM2KVFFICache
+  attr_accessor max_T:      Integer
+  attr_accessor d_model:    Integer
+  attr_accessor d_ff:       Integer
+  attr_accessor n_heads:    Integer
+  attr_accessor n_kv:       Integer
+  attr_accessor d_head:     Integer
+  attr_accessor group_size: Integer
+  attr_accessor n_layers:   Integer
+  attr_accessor vocab_size: Integer
+  attr_accessor rope_base:  Float
+  attr_accessor rms_eps:    Float
+  attr_accessor realized:   bool
+
+  def initialize: () -> void
+  def enable_kv_q8!: () -> bool
+  def enable_flash_attn!: () -> bool
+  def enable_moe!: (Integer n_experts, Integer n_experts_used) -> Integer
+  def enable_lora_q!: (Integer r) -> Integer
+  def enable_lora_q_adamw!: () -> bool
+  def set_weight_type: (Integer t) -> Integer
+  def upload_lora_q_init!: (Integer seed, Float init_scale) -> void
+  # realize_for_mmap / realize_and_load_auto / build_decode_step /
+  # load_weights / read_persistent_mat traffic in FFI ptrs — omitted.
+  def realize_for: (Integer max_T, Integer d_model, Integer d_ff,
+                    Integer n_heads, Integer n_kv, Integer n_layers,
+                    Integer vocab_size, Float rope_base, Float rms_eps,
+                    bool untied, bool qkv_bias) -> bool
+end
+
+module SmolLM2KV
+  # decode_step returns the [1, vocab] logits Mat for one token.
+  def self.upload_from: (SmolLM2KVFFICache kv_cache, Toy::SmolLM2 model) -> void
+  def self.decode_step: (SmolLM2KVFFICache kv_cache, Integer token_id,
+                         Integer pos) -> Mat
+end
+
+# ============================================================================
+# GGUFLoad (lib/toy/io/loaders/toy_smollm2_loader.rb, lib/toy/io/gguf_load.rb)
+# — capability flags + path-level loaders (ptr-free subset).
+# ============================================================================
+module GGUFLoad
+  # SmolLM2Flags#initialize takes optional positional args (out of the
+  # RBS subset — would be dropped wholesale), so only the ivars are
+  # seeded. These pins matter: flags readers feed RecipeOptions /
+  # engine realize params, and a poly flag value silently shifts
+  # training numerics (see lib/toy/llm/recipe_options.rb's warning).
+  class SmolLM2Flags
+    attr_accessor untied:         bool
+    attr_accessor qkv_bias:       bool
+    attr_accessor qk_norm:        bool
+    attr_accessor swa_window:     Integer
+    attr_accessor is_moe:         bool
+    attr_accessor n_experts:      Integer
+    attr_accessor n_experts_used: Integer
+    attr_accessor qk_norm_kind:   Integer
+    attr_accessor has_post_norms: bool
+    attr_accessor embed_scale:    Float
+    attr_accessor attn_softcap:   Float
+    attr_accessor final_softcap:  Float
+    attr_accessor swa_alternates: bool
+  end
+
+  def self.detect_smollm2_flags: (String path) -> GGUFLoad::SmolLM2Flags
+  def self.detect_weight_type: (String path) -> Integer
+end

--- a/toy.gemspec
+++ b/toy.gemspec
@@ -61,6 +61,13 @@ Gem::Specification.new do |s|
     "Makefile",
     "prep/quietly", "prep/progress",
     "lib/**/*.rb",
+    # sig/*.rbs type roots (toy#69): `spinel-compat vendor` copies sig/
+    # alongside lib/ and aggregates it into the consumer's single
+    # `--rbs vendor/spinel/sig` root (spinelgems#13), so UNCALLED toy
+    # methods in consumer builds keep their declared types instead of
+    # poly-widening (spinel-dev#11/#12). The tracked-filter keeps the
+    # machine-generated sig/vendor symlink out.
+    "sig/**/*.rbs",
     "vendor-patches/*.patch",
     "tinynn/tinynn_ggml.h",   "tinynn/tinynn_ggml.c",
     "tinynn/tinynn_gguf.h",   "tinynn/tinynn_gguf.c",


### PR DESCRIPTION
Closes #69.

## Probe 0
`--rbs DIR` exists at ALL three pinned toolchains (a699cf9 / 08a189c / 96c6c48) — **adopted directly, nothing staged behind a pin-bump**.

## Produce
- `sig/toy_compute.rbs` (new): RecipeOptions, TrainingBatch, AdamW, Labels, the recipes' `realize!`/`step!` (FromScratch / WarmStart / LoRA / VitTiny), the engines' scalar config + ptr-free methods (LlamaSeqEngine, GPT2SeqEngine, ViTTinyEngine, SmolLM2KVFFICache/SmolLM2KV), ViTTinyConfig, `GGUFLoad::SmolLM2Flags`, `Toy::Device.name` (Device factory returns deliberately unpinned — they differ per device entry).
- `sig/toy.rbs` refreshed: RopeScaling, SmolLM2Config additions (rope_scaling/head_dim/donor_d_in + factories), stale paths fixed, **wrong-arity Tokenizer#initialize removed** (see landmines).
- `toy.gemspec` ships `sig/**/*.rbs` → consumers' `spinel-compat vendor` aggregates toy's sig into their `--rbs vendor/spinel/sig` root (spinelgems#13).

## Consume
- Makefile: `SPINEL_RBS ?= --rbs $(CURDIR)/sig` folded into `$(SPINEL)` — every runner/gate/example compile is seeded; `SPINEL_RBS=` opts out.
- `make vendor-tep` refreshes a gitignored `sig/vendor -> ../vendor/spinel/sig` symlink (spinel takes ONE `--rbs` dir; the extractor recurses + follows symlinks), so vendored gems' sigs (spinel_kit ships them) ride along.
- `prep/poly_degrade_gate.rb` compiles with the same seeds AND now fails loud on a failed compile (it previously masked a compile break as "0 warnings = green").
- `toy new --lib` scaffold's build.sh passes `--rbs vendor/spinel/sig` when present.

## Gates (gx10, a699cf9)
All PASS, byte-exact where applicable: poly-degrade (identical warning set seeded vs unseeded; baseline untouched — note it was already 35-warnings-loose on main), run-log, gpt2-min/gpt2/gpt2-train, ckpt-roundtrip, lmc, full-finetune, mixed-precision, compute-surface(+cuda), moe-kquant, consumer (incl. the --lib leg), cuda, train-cuda (from-scratch/warm/lora), gpt2-train-cuda. Serve gates out of scope (spinel-dev#14); metal is Mac-side.

## The #52 interplay probe (pre-#12 rev 08a189c) — VERDICT: sig seeds alone fix it
1. **At today's main (d605aea) the lora-in-compute exclusion NO LONGER REPRODUCES even unseeded**: scratch re-add of `require_relative "llm/recipes/lora"` compiles + runs at 08a189c, and the generated C already types `LoRA#realize!`'s cfg as `sp_Toy_SmolLM2Config *`. Something in the #53/Phase-A/B refactors (most plausibly the RecipeOptions lift reshaping the forwarder) removed the poison path.
2. **At the 2026-06-09-era tree (73092e7) the failure reproduces exactly** (rc=1: `sp_Toy_RoPE_new` incompatible arg, `sp_poly_to_s` on `@cfg.d_model.to_s`) — and a **minimal 35-line chain sig** (RoPE/SmolLM2Config/SmolLM2Block/SmolLM2 ctors + Config ivars) **rescues it**: rc=0, binary trains, final_loss byte-identical to the lora-less canonical value (6.14494514465332), `lv_cfg` concrete in the C.
3. So: **RBS ctor-slot seeds remove the spinel-dev#12 precondition without the compiler fix** — the stronger pin-bump story #69 hoped for. Caveat: probed at 08a189c only; the scratch re-add stays reverted, actual re-add remains toy#52.

## Landmines found (documented in sig headers + consuming-toy.md)
- **A wrong-ARITY seed is NOT advisory**: the old 6-param `Tokenizer#initialize` declaration vs the real 8-slot default-arg ctor broke toy-infer's C compile (`too few arguments to 'sp_Tokenizer_new'`). Arity must be exact or absent.
- **Ivar seed conflicts are FATAL, not advisory**: `RBS conflict on ...@seq_t: declared "int" but a literal write inferred "obj_..."` → `analyze failed` (hit when pointing the new sig at the old tree). Good fail-loud behavior, but it means sig/ MUST track lib/.
- FFI `:ptr` has no RBS spelling — ptr-touching signatures are deliberately omitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)