### PR TITLE
feat(#52): re-add recipes/lora to toy/compute (exclusion dissolved by #64 reshape)

### DIFF
--- a/docs/consuming-toy.md
+++ b/docs/consuming-toy.md
@@ -76,11 +76,12 @@ require that engine's file directly instead of `toy/compute`. The
 `gate-compute-surface` make target proves the one-require surface co-compiles +
 runs a from-scratch training step (`prep/smokes/smoke_compute_surface`).
 
-> One exception: `toy/compute` does **not** pull `recipes/lora` — loading it
-> uncalled trips a Spinel analyzer bug that poisons `cfg` to poly program-wide
-> ([spinel-dev#11](https://github.com/OriPekelman/spinel-dev/issues/11);
-> re-add tracked by toy#52). A consumer that trains LoRA requires
-> `toy/llm/recipes/lora` itself (and calls it, which pins the type).
+> `toy/compute` pulls **all four** recipes, LoRA included (the historical
+> lora exclusion — a Spinel uncalled-forwarder/constructor-slot facet,
+> [spinel-dev#12](https://github.com/OriPekelman/spinel-dev/issues/12) —
+> was dissolved by the toy#64 RecipeOptions reshape and closed as toy#52;
+> the compute-surface gate keeps an uncalled-LoRA tripwire against
+> regressions).
 
 From here you write your experiment loop against
 `Toy::LLM::Engine::LlamaSeqEngine` / `Toy::LLM::Engine::ViTTinyEngine` /
@@ -139,9 +140,9 @@ Two honest limits (probed on spinel a699cf9):
 
 - **FFI `:ptr` has no RBS spelling.** Methods with a ptr param or return
   (the `realize_for_mmap` family, tensor-handle accessors) can't be
-  declared — sig roots can NOT rescue the lora-in-compute exclusion
-  (toy#52) because `LoRA#realize!`'s leading `gguf_handle` is a ptr and
-  the poison is a CONSTRUCTOR slot (spinel-dev#12).
+  declared. (This briefly mattered for the historical lora-in-compute
+  exclusion — spinel-dev#12 / toy#52, since dissolved by the toy#64
+  reshape — and still means ptr-surfaces rely on call-site inference.)
 - **Arity must be exact or absent.** A truncated declaration against a
   default-arg method is NOT a no-op: it breaks the C compile with a
   "too few arguments" error (the one non-advisory failure mode; toy's

--- a/lib/toy/compute.rb
+++ b/lib/toy/compute.rb
@@ -46,30 +46,19 @@ require_relative "llm/engine/llama_kv_engine"
 # Recipes — the named training/init compositions. Realize-path orchestration
 # over the engines.
 #
-# NOTE: `recipes/lora` is deliberately NOT required here — a SECOND Spinel facet,
-# distinct from spinel-dev#11 (which matz/spinel#1385 fixed + landed). Re-adding
-# the require and rebuilding against the #11-fixed Spinel STILL fails the C
-# compile (verified 2026-06-09): `@cfg.d_model.to_s` → `sp_poly_to_s`,
-# `RoPE.new(...)` arg → poly, `cache.token_ids = token_ids` → IntArray←PolyArray.
-#
-# Root cause (spinel-dev#12, isolated to a 22-line repro): #11's fix back-
-# propagates a callee's param type to an UNCALLED forwarder's param — but ONLY
-# when the shared callee is a regular instance method. It does NOT cover a
-# CONSTRUCTOR slot: `Klass.new(x)` from an uncalled method does not pin `x` from
-# `Klass#initialize`'s param type. LoRA#realize! forwards `cfg` (uncalled in the
-# compute surface) into realize_for_mmap, which builds the model via `.new`
-# (RoPE.new etc.); `cfg` never gets pinned, stays poly, and UNIONS into the
-# shared SmolLM2/RoPE constructor — which FromScratch's live realize_for_random_init
-# path also feeds concretely — poisoning it program-wide (`sp_Cfg` vs `sp_Cfg *`,
-# same shape as #11 but on the constructor argument). The untyped FFI leading
-# param on realize_for_mmap is INCIDENTAL (a no-handle, cfg-leading variant of
-# the repro fails identically); it only means an RBS sig can't independently
-# rescue it. A consumer that actually trains LoRA requires `toy/llm/recipes/lora`
-# itself (and calls realize! with a concrete cfg, which pins the type). Re-add
-# tracked by toy#52 — blocked on spinel-dev#12 (constructor-slot back-prop), not #11.
+# HISTORY (toy#52, closed 2026-06-11): `recipes/lora` was excluded from this
+# surface for three days — an UNCALLED LoRA#realize! forwarding `cfg` into a
+# constructor slot poisoned the shared SmolLM2/RoPE ctor to poly program-wide
+# (spinel-dev#12, the constructor-slot sibling of spinel-dev#11). The Phase-A
+# RecipeOptions reshape of realize! (toy#64) dissolved the poison path: the
+# re-add compiles + trains byte-identically even on pre-#12-fix Spinel revs
+# (probed at 08a189c, 2026-06-11, toy#69). The compute-surface smoke keeps an
+# instantiated-but-UNCALLED LoRA as a tripwire so any regression re-breaks
+# that gate's C compile loudly.
 require_relative "llm/recipe_options"
 require_relative "llm/recipes/from_scratch"
 require_relative "llm/recipes/warm_start"
+require_relative "llm/recipes/lora"
 require_relative "llm/recipes/vit_tiny"
 
 # Inference I/O: GGUF model loading + the BPE tokenizer.

--- a/lib/toy/compute_cuda.rb
+++ b/lib/toy/compute_cuda.rb
@@ -41,14 +41,14 @@ require_relative "llm/engine/gpt2_seq_engine_cuda"
 # KV-cache decode engine (inference), CUDA mirror.
 require_relative "llm/engine/llama_kv_engine_cuda"
 
-# Recipes — the hand-maintained CUDA twins. Exclusions mirror the CPU
-# entry's where they exist and the backend's gaps where they don't:
-#   - lora_cuda: NOT required, same spinel-dev#12 constructor-slot
-#     facet as compute.rb's lora exclusion (toy#52).
-#   - vit_tiny: no CUDA recipe (no CUDA vit engine).
+# Recipes — the generated CUDA twins. lora_cuda included since toy#52
+# closed (the spinel-dev#12 constructor-slot facet was dissolved by the
+# toy#64 RecipeOptions reshape; see compute.rb's HISTORY note). Backend
+# gap that remains: vit_tiny has no CUDA recipe (no CUDA vit engine).
 require_relative "llm/recipe_options"
 require_relative "llm/recipes/from_scratch_cuda"
 require_relative "llm/recipes/warm_start_cuda"
+require_relative "llm/recipes/lora_cuda"
 
 # Inference I/O (shared): GGUF model loading + the BPE tokenizer.
 require_relative "io/gguf_load"

--- a/lib/toy/compute_metal.rb
+++ b/lib/toy/compute_metal.rb
@@ -22,7 +22,8 @@
 # Backend gaps (consumers needing more require the files directly):
 #   - warm-start: NO Metal recipe exists (from-scratch only, matching
 #     libexec/toy-train-metal) — Device.warm_start_recipe is absent.
-#   - vit: no Metal engine. lora: no Metal recipe (and see toy#52).
+#   - vit: no Metal engine. lora: no Metal recipe (a backend gap only —
+#     the toy#52 exclusion is history, see compute.rb's HISTORY note).
 
 # FFI compute layer: Metal TinyNN + the MRI-safe sugar (Mat + Card).
 require_relative "ffi/tinynn_metal"

--- a/prep/smokes/smoke_compute_surface.rb
+++ b/prep/smokes/smoke_compute_surface.rb
@@ -29,6 +29,15 @@ llama = Toy::LLM::Engine::LlamaSeqEngine.new
 vit   = Toy::LLM::Engine::ViTTinyEngine.new
 gpt2  = Toy::LLM::Engine::GPT2SeqEngine.new
 
+# LoRA tripwire (toy#52): instantiated, realize! left deliberately UNCALLED.
+# The uncalled-forwarder-into-constructor-slot shape is exactly what poisoned
+# cfg to poly program-wide (spinel-dev#12) before the RecipeOptions reshape
+# (toy#64) dissolved it — keeping it uncalled here means a Spinel regression
+# re-breaks this gate's C COMPILE loudly. Calling realize! would pin cfg and
+# mask the bug (and drag a GGUF into a data-free gate; byte-exact LoRA
+# training lives in prep/smokes/smoke_recipe_lora.rb).
+lora = Toy::LLM::Recipes::LoRA.new
+
 # Named realize options (toy#64): canonical defaults (t_batch=1,
 # weight_dtype=0/f32, untied=false, qkv_bias=false, seed=0,
 # init_scale=1.0); only t_seq needs setting.


### PR DESCRIPTION
Supersedes draft PR #57 (stale form + stale merge gate): toy#69's interplay probe showed the spinel-dev#12 poison path **no longer exists on current main** — the Phase-A RecipeOptions reshape (#64) dissolved the uncalled-forwarder-into-constructor-slot shape, verified at the pre-fix Spinel rev 08a189c with byte-identical training. No upstream merge needed anymore.

- `lora` → compute.rb, `lora_cuda` → compute_cuda.rb (metal: honest backend-gap note, no Metal lora recipe)
- compute-surface smoke gains the **uncalled-LoRA tripwire** (PR #57's design, ported to prep/smokes/): the historical poisoning shape is baked into the gate's own C compile
- consuming-toy.md caveats → history

Gates at a699cf9: compute-surface CPU `6.14494514465332` + CUDA `6.155894756317139` (canonical), train_gate 4/4 byte-for-byte.

Closes #52. Part of #58.

🤖 Generated with [Claude Code](https://claude.com/claude-code)