### PR TITLE
fix(#76): wire QK-norm through the CUDA loader — Qwen3 CUDA F32 token-identical to CPU

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+- **Fixed #76: Qwen3 CUDA F32 degenerate decode.** The hand-written CUDA
+  loader (`transformer_lm_cuda.rb`) never wired the detected QK-norm flags
+  into the engine — it called `realize_for_mmap` with 5 of 6 args (Spinel
+  zero-fills missing call args silently), so Qwen3's per-head Q/K RMS-norms
+  were never built on the CUDA graph. Now wired identically to the CPU
+  loader; Qwen3-0.6B/1.7B CUDA decode is token-identical to CPU and
+  `docs/models.md` rows are restored ✓. Also: `NO_QK_NORM=1` actually
+  disables the norm now (it was overwritten by `realize_for_mmap`), and
+  loading a QK-norm model through the legacy (non-`toy.ggml_native`)
+  copy-load path fails loud instead of decoding silently degenerate.
+
 - **The `toy` gem name is ours.** With huge thanks to **Ninoslav Milenović**,
   who graciously transferred ownership of the [`toy`](https://rubygems.org/gems/toy)
   gem on RubyGems. See the README acknowledgments. (Not released yet — name

--- a/docs/models.md
+++ b/docs/models.md
@@ -27,8 +27,8 @@ which backend — and the footnotes that keep the table honest.
 | Qwen2.5-1.5B       | Llama + QKV bias     | 1.5B        | ✓   | ✓    | ✓   | ✓        | ✓†      | ‡         |
 | Qwen2.5-3B         | Llama + QKV bias     | 3B          | ✓   | ✓    | ✓   | ✓        | ✓†      | ‡         |
 | Qwen2.5-7B         | Llama + QKV bias     | 7B          | ✓   | ✓    | ✓   |          | ✓       |           |
-| Qwen3-0.6B         | Qwen3 + QK-norm      | 0.6B        | ✓   |      | ✓   | ✗※       |         | ‡         |
-| Qwen3-1.7B         | Qwen3 + QK-norm      | 1.7B        | ✓   | ✓°   | ✓   | ✗※       |         | ‡         |
+| Qwen3-0.6B         | Qwen3 + QK-norm      | 0.6B        | ✓   |      | ✓   | ✓※       |         | ‡         |
+| Qwen3-1.7B         | Qwen3 + QK-norm      | 1.7B        | ✓   | ✓°   | ✓   | ✓※       |         | ‡         |
 | Qwen3-4B           | Qwen3 + QK-norm      | 4B          | ✓   |      | ✓   |          |         | ‡         |
 | OLMoE-1B-7B-Instr  | Llama + MoE + QK-norm⁂  | 7B (1B act) |     | ✓    | ✓   |          |         | ‡         |
 | Gemma 2-2b-it      | Llama + Gemma extras⁂⁂  | 2B          |     | ✓    | ✓   |          |         | ‡         |
@@ -51,15 +51,17 @@ current ggml pin (`41e7949`) that restriction no longer reproduces:
 Qwen2.5-1.5B/3B Q8 run on CUDA and decode token-identical to the CPU
 Q8 and F32 paths (re-verified 2026-06-11).
 
-※ **Qwen3 on CUDA is broken** (caught by the 2026-06-11 re-verification;
-previously over-claimed). CPU decode is coherent; the CUDA binary runs
-but decodes degenerate output (`Once upon a time Answer Answer Answer…`
-on 0.6B, `Once upon a time::::::` on 1.7B), and `toy eval --device cuda`
-returns a top-5 disjoint from CPU's. Not a spinel-pin regression — a
-main-tree binary built 2026-06-06 reproduces it. Qwen3 is the only
-QK-norm + explicit-head_dim arch in the CUDA matrix; every other
-CUDA row above passes token-identical. Reported on toy#61 (needs its
-own issue).
+※ These cells used to read ✗: Qwen3 CUDA decode was degenerate while
+CPU was coherent (caught by the 2026-06-11 re-verification, toy#76).
+Root cause was toy-side, not a ggml kernel: the hand-written CUDA
+loader (`lib/toy/models/transformer_lm_cuda.rb`) never wired the
+detected `qk_norm` flags through to `realize_for_mmap` — it passed 5
+of the 6 args and Spinel zero-fills missing call args without a
+diagnostic — so the per-head Q/K RMS-norms were never built on the
+CUDA graph. Fixed in the #76 PR; re-verified 2026-06-11 (spinel
+`a699cf9` / ggml `41e7949`, gx10): 0.6B and 1.7B greedy decode
+token-identical to CPU across prompts, `toy eval` top-5 ids identical,
+and the KV_Q8 / FLASH_ATTN opt-ins parity-hold on CUDA too.
 
 ° Qwen3-1.7B Q8 was not re-verified on 2026-06-11: no Q8 checkpoint of
 it on the bench box (re-quantizing needs an HF download we don't keep).
@@ -70,7 +72,9 @@ to CPU). Other Llama-family models should work — same FFI surface,
 same graph builder, same ggml-metal kernel coverage — but haven't been
 smoked. GPT-2-family isn't wired on Metal. Quantized weights on Metal
 are untested. The Metal path uses copy-load rather than mmap, so
-multi-GB models pay the copy cost.
+multi-GB models pay the copy cost — and the copy-load path has no
+QK-norm support, so QK-norm models (Qwen3, OLMoE) abort loudly on
+Metal rather than decode degenerate (#76).
 
 ◇ The SmolLM2-135M Metal ✓ is Mac-gated (#27) and was not re-run in the
 2026-06-11 gx10 pass; it stands from the 2026-05-31 Mac validation

--- a/lib/toy/models/transformer_lm.rb
+++ b/lib/toy/models/transformer_lm.rb
@@ -115,8 +115,13 @@ class ToyLM
     # ([d_model] per-head packed; per-head sliced gamma).
     kv.qk_norm_kind = flags.qk_norm_kind
     # NO_QK_NORM=1 turns the norm off entirely as a diagnostic.
+    # #76: the old form (kv.has_qk_norm = false) was ineffective on
+    # the mmap path — realize_for_mmap overwrites @has_qk_norm from
+    # its qk_norm parameter. Carry the override in a local instead
+    # and pass it to realize_for_mmap below.
+    qk_norm_on = flags.qk_norm
     if (ENV["NO_QK_NORM"] || "") == "1"
-      kv.has_qk_norm  = false
+      qk_norm_on = false
       kv.qk_norm_kind = 0
     end
     # #113: Gemma 2 extras. All inert by default — non-Gemma callers
@@ -140,9 +145,18 @@ class ToyLM
       # tensors stay quantized; matmul kernels read them in place.
       kv.set_weight_type(wtype)
       @gguf_handle = TinyNN.tnn_gguf_load(path)
-      kv.realize_for_mmap(@gguf_handle, cfg, @max_T, flags.untied, flags.qkv_bias, flags.qk_norm)
+      kv.realize_for_mmap(@gguf_handle, cfg, @max_T, flags.untied, flags.qkv_bias, qk_norm_on)
       kv.swa_window = flags.swa_window
     else
+      if qk_norm_on
+        # #76, fail loud (never mask): realize_for has no QK-norm
+        # support — the gamma tensors are only allocated on the mmap
+        # path, so decode here would be silently degenerate.
+        puts "ToyLM.load_cpu: " + path + " needs QK-norm but is not in " +
+             "toy.ggml_native layout; the legacy copy-load path cannot " +
+             "apply QK-norm. Re-convert with --ggml-native. Aborting."
+        exit 1
+      end
       # Legacy layout: dequantize-to-F32 on copy. The
       # tnn_gguf_copy_head_slice_to_persistent helper writes F32 bytes
       # into the dst, so dst tensors must be F32-typed — there's no

--- a/lib/toy/models/transformer_lm_cuda.rb
+++ b/lib/toy/models/transformer_lm_cuda.rb
@@ -65,11 +65,37 @@ class ToyLMCuda
     if (ENV["FLASH_ATTN"] || "") == "1"
       kv.enable_flash_attn!
     end
+    # #76 fix: wire QK-norm through to the engine, parity with
+    # load_cpu in lib/toy/models/transformer_lm.rb. This call site
+    # previously passed only 5 of realize_for_mmap's 6 args; Spinel
+    # zero-fills missing call args WITHOUT a diagnostic, so qk_norm
+    # arrived as false and Qwen3's per-head Q/K RMS-norms were never
+    # built on CUDA → degenerate decode (CPU was coherent).
+    # 1 = Qwen3-style ([d_head] shared), 2 = OLMoE/Granite-style
+    # ([d_model] packed, per-head sliced gamma). Must be set BEFORE
+    # realize_for_mmap.
+    kv.qk_norm_kind = flags.qk_norm_kind
+    qk_norm_on = flags.qk_norm
+    # NO_QK_NORM=1 turns the norm off entirely as a diagnostic
+    # (same env knob as the CPU loader).
+    if (ENV["NO_QK_NORM"] || "") == "1"
+      qk_norm_on = false
+      kv.qk_norm_kind = 0
+    end
 
     if is_native
       @gguf_handle = TinyNNCuda.tnn_gguf_load(path)
-      kv.realize_for_mmap(@gguf_handle, cfg, @max_T, flags.untied, flags.qkv_bias)
+      kv.realize_for_mmap(@gguf_handle, cfg, @max_T, flags.untied, flags.qkv_bias, qk_norm_on)
     else
+      if qk_norm_on
+        # Fail loud (never mask): the legacy copy-load path has no
+        # QK-norm support — realize_for can't allocate the gamma
+        # tensors, so decode would be silently degenerate.
+        puts "ToyLMCuda.load: " + path + " needs QK-norm but is not in " +
+             "toy.ggml_native layout; the legacy copy-load path cannot " +
+             "apply QK-norm. Re-convert with --ggml-native. Aborting."
+        exit 1
+      end
       kv.realize_for(@max_T, cfg.d_model, cfg.d_ff, cfg.n_heads, cfg.n_kv,
                      cfg.n_layers, cfg.vocab, cfg.rope_base, cfg.rms_eps,
                      flags.untied, flags.qkv_bias)

--- a/lib/toy/models/transformer_lm_metal.rb
+++ b/lib/toy/models/transformer_lm_metal.rb
@@ -68,6 +68,18 @@ class ToyLMMetal
       kv.enable_flash_attn!
     end
 
+    if flags.qk_norm
+      # #76, fail loud (never mask): Metal only has the copy-load path
+      # (realize_for), which has no QK-norm support — the gamma tensors
+      # are only allocated on the mmap path. Decoding a QK-norm model
+      # (Qwen3 / OLMoE) here would be silently degenerate, exactly the
+      # CUDA #76 failure mode. Abort until a Metal mmap/QK-norm path
+      # exists.
+      puts "ToyLMMetal.load: " + path + " needs QK-norm, which the " +
+           "Metal copy-load path cannot apply (no mmap path on Metal " +
+           "yet, issue #2). Aborting rather than decode degenerate."
+      exit 1
+    end
     kv.realize_for(@max_T, cfg.d_model, cfg.d_ff, cfg.n_heads, cfg.n_kv,
                    cfg.n_layers, cfg.vocab, cfg.rope_base, cfg.rms_eps,
                    flags.untied, flags.qkv_bias)


### PR DESCRIPTION
Fixes #76 (Qwen3 CUDA F32 degenerate decode, found by the #61 re-verification).

## Root cause — toy-side, not a ggml kernel

`ToyLMCuda#load` (`lib/toy/models/transformer_lm_cuda.rb`, hand-written, NOT a generated mirror) never wired the detected QK-norm flags into the engine:

```ruby
kv.realize_for_mmap(@gguf_handle, cfg, @max_T, flags.untied, flags.qkv_bias)   # 5 args
def realize_for_mmap(gguf_handle, cfg, max_T, untied, qkv_bias, qk_norm)       # 6 params
```

Spinel zero-fills missing call args **without any diagnostic** (verified: a full unfiltered compile of `infer_cuda.rb` emits no warning for this call), so `qk_norm` arrived as `false`. The per-head Q/K RMS-norm gamma tensors were therefore never allocated and the norm nodes never built on the CUDA graph. Qwen3 is the only QK-norm arch in the CUDA matrix — hence "only Qwen3 breaks, only on CUDA, every other row token-identical".

**Smoking gun:** force-disabling the norm on CPU reproduces the original CUDA degeneracy *exactly*:

```
$ NO_QK_NORM=1 GGUF=data/qwen3-0.6b-tok.gguf PROMPT="The capital of France is" libexec/toy-infer
text: The capital of France is Instructions Instructions Instructions Instructions ...
```
— byte-identical to what the broken CUDA binary produced.

## Fix

- **`transformer_lm_cuda.rb`** — set `kv.qk_norm_kind` from flags and pass `flags.qk_norm` as the 6th `realize_for_mmap` arg, parity with `load_cpu`. `NO_QK_NORM=1` diagnostic knob mirrored too.
- **`transformer_lm.rb`** — `NO_QK_NORM=1` was itself ineffective on the mmap path (`realize_for_mmap` overwrote `kv.has_qk_norm` from its parameter — this is what initially made the env probe look clean); the override is now carried in a local passed to `realize_for_mmap`.
- **Fail loud (never mask):** loading a QK-norm model through the legacy copy-load path (`realize_for` has no QK-norm support) now aborts with a re-convert hint instead of decoding silently degenerate — CPU, CUDA, and Metal (Metal only has copy-load, so QK-norm models abort there until a Metal mmap path exists; footnoted in models.md).
- **`docs/models.md`** — Qwen3-0.6B/1.7B CUDA F32 rows restored to ✓; ※ footnote rewritten as a fixed-by note with provenance (2026-06-11, spinel `a699cf9` / ggml `41e7949`, gx10).

## Verification (gx10, GB10, 2026-06-11)

- Qwen3-**0.6B** and Qwen3-**1.7B**: greedy decode CUDA == CPU **token-identical** across prompts at N_NEW=32.
- `toy-eval` top-5 ids identical CUDA vs CPU for both models (logprobs differ only in float text, as on every other model).
- `KV_Q8=1` and `FLASH_ATTN=1` opt-ins parity-hold on Qwen3 CUDA (KV_Q8 CUDA == KV_Q8 CPU).
- Regression: smollm2-135m, qwen25-0.5b (QKV-bias), llama-3.2-1b, mistral-7b — CUDA == CPU unchanged; `make gate-cuda` **PASS** (infer BIT-IDENTICAL ×2, eval top-k identical); CPU infer/eval gates byte-exact vs recorded baselines.

## Upstream note

No ggml issue — the kernels were never at fault. The Spinel **silent under-arity call** (fewer args than parameters compiles clean, zero-fills) is a real landmine and deserves a spinel-dev report; draft in the #76 comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)