### PR TITLE
toy#73 — Phase A.2 API polish: RunBundle, compute completeness, batch objectives, donor plumbing, hp_for_step

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -809,14 +809,14 @@ example_01: examples/example_01_train_tiny
 
 # 02 — warm-start fine-tune: donor token_embd from a real GGUF through
 # Toy::LLM::Recipes::WarmStart (realize_scratch! → realize_warm! → build!).
-examples/example_02_finetune_warm_start: examples/02_finetune_warm_start.rb lib/toy.rb lib/toy/models/toy_smollm2.rb lib/toy/llm/engine/llama_seq_engine.rb lib/toy/io/toy_corpus_loader.rb lib/toy/train/toy_lr_schedule.rb lib/toy/llm/adamw.rb lib/toy/llm/labels.rb lib/toy/llm/training_batch.rb lib/toy/llm/recipe_options.rb lib/toy/llm/recipes/warm_start.rb lib/toy/ffi/tinynn.rb lib/toy/models/transformer.rb tinynn/libtinynn_ggml.a $(SPINEL_DEPS)
+examples/example_02_finetune_warm_start: examples/02_finetune_warm_start.rb lib/toy/compute.rb lib/toy/llm/engine/llama_seq_engine.rb lib/toy/io/toy_corpus_loader.rb lib/toy/train/toy_lr_schedule.rb lib/toy/llm/adamw.rb lib/toy/llm/labels.rb lib/toy/llm/training_batch.rb lib/toy/llm/recipe_options.rb lib/toy/llm/recipes/warm_start.rb lib/toy/ffi/tinynn.rb tinynn/libtinynn_ggml.a $(SPINEL_DEPS)
 	$(SPINEL) $< -o $@
 example_02: examples/example_02_finetune_warm_start
 .PHONY: example_02
 
-# 03 — LoRA adapters over a frozen mmap'd base GGUF. Requires the lora
-# recipe DIRECTLY (not via toy/compute — spinel-dev#12 / toy#52).
-examples/example_03_lora: examples/03_lora.rb lib/toy.rb lib/toy/models/toy_smollm2.rb lib/toy/io/loaders/toy_smollm2_loader.rb lib/toy/llm/engine/llama_seq_engine.rb lib/toy/models/transformer.rb lib/toy/models/gpt2.rb lib/toy/io/gguf_load.rb lib/toy/ffi/tinynn.rb lib/toy/llm/adamw.rb lib/toy/llm/recipe_options.rb lib/toy/llm/recipes/lora.rb tinynn/libtinynn_ggml.a $(SPINEL_DEPS)
+# 03 — LoRA adapters over a frozen mmap'd base GGUF, via the one-require
+# compute surface (lora re-added to it by toy#52).
+examples/example_03_lora: examples/03_lora.rb lib/toy/compute.rb lib/toy/io/loaders/toy_smollm2_loader.rb lib/toy/llm/engine/llama_seq_engine.rb lib/toy/io/gguf_load.rb lib/toy/ffi/tinynn.rb lib/toy/llm/adamw.rb lib/toy/llm/recipe_options.rb lib/toy/llm/recipes/lora.rb tinynn/libtinynn_ggml.a $(SPINEL_DEPS)
 	$(SPINEL) $< -o $@
 example_03: examples/example_03_lora
 .PHONY: example_03
@@ -840,7 +840,7 @@ example_06:
 .PHONY: example_06
 
 # 07 — ViT-Tiny on the committed data/vit_smoke corpus via Recipes::VitTiny.
-examples/example_07_vit_tiny: examples/07_vit_tiny.rb lib/toy/llm/engine/vit_tiny_engine.rb lib/toy/llm/recipes/vit_tiny.rb lib/toy/models/toy_vit.rb lib/toy/models/toy_smollm2.rb lib/toy/io/toy_image_loader.rb lib/toy/train/toy_lr_schedule.rb lib/toy/llm/adamw.rb lib/toy/llm/recipe_options.rb lib/toy/models/transformer.rb lib/toy/ffi/tinynn.rb tinynn/libtinynn_ggml.a $(SPINEL_DEPS)
+examples/example_07_vit_tiny: examples/07_vit_tiny.rb lib/toy/compute.rb lib/toy/llm/engine/vit_tiny_engine.rb lib/toy/llm/recipes/vit_tiny.rb lib/toy/models/toy_vit.rb lib/toy/io/toy_image_loader.rb lib/toy/train/toy_lr_schedule.rb lib/toy/llm/adamw.rb lib/toy/llm/recipe_options.rb lib/toy/ffi/tinynn.rb tinynn/libtinynn_ggml.a $(SPINEL_DEPS)
 	$(SPINEL) $< -o $@
 example_07: examples/example_07_vit_tiny
 .PHONY: example_07

--- a/Makefile
+++ b/Makefile
@@ -802,7 +802,7 @@ example_train_from_scratch_blessed: examples/example_train_from_scratch_blessed
 # 01 — from-scratch on the bundled tiny corpus via the one-require
 # compute surface + the named value objects. THE showcase; the example
 # in docs/framework.md must stay truthful to this file.
-examples/example_01_train_tiny: examples/01_train_tiny.rb lib/toy/compute.rb lib/toy/io/toy_corpus_loader.rb lib/toy/llm/training_batch.rb lib/toy/llm/recipe_options.rb tinynn/libtinynn_ggml.a $(SPINEL_DEPS)
+examples/example_01_train_tiny: examples/01_train_tiny.rb lib/toy/compute.rb lib/toy/io/toy_corpus_loader.rb lib/toy/io/run_bundle.rb lib/toy/llm/training_batch.rb lib/toy/llm/recipe_options.rb tinynn/libtinynn_ggml.a $(SPINEL_DEPS)
 	$(SPINEL) $< -o $@
 example_01: examples/example_01_train_tiny
 .PHONY: example_01

--- a/Makefile
+++ b/Makefile
@@ -816,7 +816,7 @@ example_02: examples/example_02_finetune_warm_start
 
 # 03 — LoRA adapters over a frozen mmap'd base GGUF, via the one-require
 # compute surface (lora re-added to it by toy#52).
-examples/example_03_lora: examples/03_lora.rb lib/toy/compute.rb lib/toy/io/loaders/toy_smollm2_loader.rb lib/toy/llm/engine/llama_seq_engine.rb lib/toy/io/gguf_load.rb lib/toy/ffi/tinynn.rb lib/toy/llm/adamw.rb lib/toy/llm/recipe_options.rb lib/toy/llm/recipes/lora.rb tinynn/libtinynn_ggml.a $(SPINEL_DEPS)
+examples/example_03_lora: examples/03_lora.rb lib/toy/compute.rb lib/toy/io/loaders/toy_smollm2_loader.rb lib/toy/llm/engine/llama_seq_engine.rb lib/toy/io/gguf_load.rb lib/toy/ffi/tinynn.rb lib/toy/llm/adamw.rb lib/toy/llm/labels.rb lib/toy/llm/training_batch.rb lib/toy/llm/recipe_options.rb lib/toy/llm/recipes/lora.rb tinynn/libtinynn_ggml.a $(SPINEL_DEPS)
 	$(SPINEL) $< -o $@
 example_03: examples/example_03_lora
 .PHONY: example_03
@@ -840,7 +840,7 @@ example_06:
 .PHONY: example_06
 
 # 07 — ViT-Tiny on the committed data/vit_smoke corpus via Recipes::VitTiny.
-examples/example_07_vit_tiny: examples/07_vit_tiny.rb lib/toy/compute.rb lib/toy/llm/engine/vit_tiny_engine.rb lib/toy/llm/recipes/vit_tiny.rb lib/toy/models/toy_vit.rb lib/toy/io/toy_image_loader.rb lib/toy/train/toy_lr_schedule.rb lib/toy/llm/adamw.rb lib/toy/llm/recipe_options.rb lib/toy/ffi/tinynn.rb tinynn/libtinynn_ggml.a $(SPINEL_DEPS)
+examples/example_07_vit_tiny: examples/07_vit_tiny.rb lib/toy/compute.rb lib/toy/llm/engine/vit_tiny_engine.rb lib/toy/llm/recipes/vit_tiny.rb lib/toy/models/toy_vit.rb lib/toy/io/toy_image_loader.rb lib/toy/train/toy_lr_schedule.rb lib/toy/llm/adamw.rb lib/toy/llm/labels.rb lib/toy/llm/classify_batch.rb lib/toy/llm/recipe_options.rb lib/toy/ffi/tinynn.rb tinynn/libtinynn_ggml.a $(SPINEL_DEPS)
 	$(SPINEL) $< -o $@
 example_07: examples/example_07_vit_tiny
 .PHONY: example_07

--- a/docs/events.md
+++ b/docs/events.md
@@ -346,11 +346,21 @@ shared `run_start` provenance — `host{}` + `backend{}` + `git{}` — is one ca
 object (`adamw.hp(step)`), not a hand-filled `Mat(1,7)`. All four are pure-Ruby
 (no FFI), Spinel-compiled, and shared across the CPU/CUDA/Metal runners.
 
+Compiled **library consumers** (anything riding `lib/toy/compute*.rb`)
+should not hand-roll the stream at all: `Toy::RunBundle`
+(`lib/toy/io/run_bundle.rb`, toy#73) owns the run-dir creation, the
+`run_start`/`step`/`run_end` JSON, and the sink. Its ctor opens
+`events.jsonl` via `tnn_events_open_trunc` (truncate, not append), so
+re-running with the same run id replaces the bundle instead of doubling
+it; `weights_dir` returns the `runs/<id>/weights/` checkpoint home.
+
 ## Producer guarantees
 
 1. `run_start` is written before any other event and flushed before
    compute begins.
-2. The file is opened `O_APPEND`. One run, one writer — concurrent
+2. The file is opened `O_APPEND` by the runners (`tnn_events_open`);
+   `Toy::RunBundle` opens with truncate (`tnn_events_open_trunc`) for
+   re-runnable consumer bundles. One run, one writer — concurrent
    writers to the same file are not supported.
 3. Each event is a complete line ending in `\n`; newlines inside strings
    are JSON-escaped.

--- a/examples/01_train_tiny.rb
+++ b/examples/01_train_tiny.rb
@@ -26,11 +26,10 @@
 #   Toy::AdamW.for_from_scratch  — the optimizer hyper-params, named
 #   Toy::RunBundle               — the runs/<id>/events.jsonl writer
 #
-# Everything compute rides ONE require (lib/toy/compute.rb). The corpus
-# streamer is the one extra: it lives outside the compute surface.
+# Everything — compute, loaders, schedules, the run bundle — rides ONE
+# require (lib/toy/compute.rb).
 
 require_relative "../lib/toy/compute"
-require_relative "../lib/toy/io/toy_corpus_loader"
 
 STEPS  = (ENV["STEPS"]  || "30").to_i
 SEED   = (ENV["SEED"]   || "0").to_i

--- a/examples/01_train_tiny.rb
+++ b/examples/01_train_tiny.rb
@@ -18,12 +18,13 @@
 #   SEED=1            a different random init
 #   RUN_ID=lr-01      label the runs/<RUN_ID>/ bundle (for 06's table)
 #
-# THE API (the whole story is five named objects — docs/framework.md):
+# THE API (the whole story is six named objects — docs/framework.md):
 #   Toy::SmolLM2Config.tiny      — the model shape (no 9-arg soup)
 #   Toy::LLM::RecipeOptions      — named realize-time options
 #   Toy::LLM::Recipes::FromScratch — realize!(cfg, opts) once, step! per step
 #   Toy::LLM::TrainingBatch      — validates each step's ids + labels
 #   Toy::AdamW.for_from_scratch  — the optimizer hyper-params, named
+#   Toy::RunBundle               — the runs/<id>/events.jsonl writer
 #
 # Everything compute rides ONE require (lib/toy/compute.rb). The corpus
 # streamer is the one extra: it lives outside the compute surface.
@@ -76,32 +77,11 @@ adamw.lr = LR
 
 # Run bundle: runs/<RUN_ID>/events.jsonl in the toy/v1 schema, the same
 # stream `toy train` writes — Toy::RunLog reads it back (06_runlog_compare).
-# Hand-rolled JSON lines: the SpinelKit JSON builder lives in vendor/
-# (a `make vendor-tep` artifact), and a tutorial should run on a fresh
-# clone — so we emit the three event kinds by string concat.
-TinyNN.tnn_filesystem_mkdir("runs")
-RUN_DIR = "runs/" + RUN_ID
-TinyNN.tnn_filesystem_mkdir(RUN_DIR)
-# The events sink APPENDS (and the FFI surface has no truncate), so a
-# re-run with the same RUN_ID would double the bundle — warn loud.
-if File.exist?(RUN_DIR + "/events.jsonl")
-  puts "warn: " + RUN_DIR + "/events.jsonl already exists — appending."
-  puts "      rm -r " + RUN_DIR + " (or set RUN_ID=) for a fresh bundle."
-end
-events_on = TinyNN.tnn_events_open(RUN_DIR + "/events.jsonl") == 0
-if events_on
-  TinyNN.tnn_events_emit("{\"kind\":\"run_start\",\"schema\":\"toy/v1\"," +
-    "\"run_id\":\"" + RUN_ID + "\",\"phase\":\"train\"," +
-    "\"model\":{\"arch\":\"llama\",\"vocab\":" + cfg.vocab.to_s +
-    ",\"d_model\":" + cfg.d_model.to_s +
-    ",\"n_layers\":" + cfg.n_layers.to_s + "}," +
-    "\"config\":{\"context\":" + cfg.ctx.to_s +
-    ",\"steps\":" + STEPS.to_s +
-    ",\"lr\":" + LR.to_s +
-    ",\"seed\":" + SEED.to_s + "}}")
-else
-  puts "warn: could not open " + RUN_DIR + "/events.jsonl (run bundle disabled)"
-end
+# Toy::RunBundle owns the dirs + the JSON + the sink, and TRUNCATES on
+# open, so a re-run with the same RUN_ID replaces the bundle.
+bundle = Toy::RunBundle.new("runs", RUN_ID)
+bundle.run_start!("llama", cfg.vocab, cfg.d_model, cfg.n_layers,
+                  cfg.ctx, STEPS, LR, SEED)
 
 # Train: stream context-sized windows off the corpus, one step each.
 first_loss  = 0.0
@@ -122,25 +102,19 @@ while step < STEPS
   end
   final_loss = loss
   puts "step " + (step + 1).to_s + ": loss=" + loss.to_s
-  if events_on
-    TinyNN.tnn_events_emit("{\"kind\":\"step\",\"step\":" + (step + 1).to_s +
-                           ",\"loss\":" + loss.to_s + "}")
-  end
+  bundle.step!(step + 1, loss)
   step = step + 1
 end
 
-if events_on
-  TinyNN.tnn_events_emit("{\"kind\":\"run_end\",\"reason\":\"completed\"," +
-    "\"final_step\":" + STEPS.to_s + ",\"final_loss\":" + final_loss.to_s + "}")
-  TinyNN.tnn_events_close
-end
+wrote_bundle = bundle.active
+bundle.run_end!(STEPS, final_loss)
 
 # The run-log summary.
 puts ""
 puts "run " + RUN_ID + ": " + STEPS.to_s + " steps, loss " +
      first_loss.to_s + " -> " + final_loss.to_s
-if events_on
-  puts "bundle: " + RUN_DIR + "/events.jsonl  (toy/v1 events)"
+if wrote_bundle
+  puts "bundle: " + bundle.events_path + "  (toy/v1 events)"
   puts "inspect from plain Ruby:  ruby examples/06_runlog_compare.rb"
 end
 if final_loss < first_loss

--- a/examples/01_train_tiny.rb
+++ b/examples/01_train_tiny.rb
@@ -92,7 +92,7 @@ while step < STEPS
   byte_offset = byte_offset + cfg.ctx * 4              # packed i32
 
   batch.fill!(seq_ids)                                  # validate + labels
-  batch.hp = adamw.hp(step)
+  batch.hp = adamw.hp_for_step(step)
 
   loss = recipe.step!(batch.seq_ids, batch.positions, batch.labels,
                       batch.hp, step == 0)

--- a/examples/02_finetune_warm_start.rb
+++ b/examples/02_finetune_warm_start.rb
@@ -22,13 +22,12 @@
 #                  — diff the loss curves to see what the donor buys
 #
 # THE API — Toy::LLM::Recipes::WarmStart splits realize into a window:
+#   donor_embed_width(gguf)       read the donor's width for the cfg
 #   realize_scratch!(cfg, opts)   build the random-init graph, window OPEN
-#   realize_warm!(buf, n)         upload donor embeddings into the graph
+#   realize_warm!(gguf, cfg)      read + dim-check + upload the donor
+#                                 embeddings (fails loud on mismatch)
 #   build!                        bake forward+loss+backward+AdamW, CLOSED
 #   step!(…)                      same per-step contract as FromScratch
-#
-# The donor read itself is plain GGUF plumbing (open, read one tensor,
-# free) — the recipe deliberately only owns the upload mechanism.
 
 require_relative "../lib/toy/compute"
 
@@ -56,18 +55,10 @@ if !File.exist?(CORPUS)
   exit 1
 end
 
-# Open the donor and read its embedding width — the projection lens is
-# sized donor_d_in × d_model, so the cfg must know the donor's width.
-ggh = TinyNN.tnn_gguf_load(DONOR_GGUF)
-if ggh == nil || ggh == TinyNN.tnn_null_ptr
-  puts "02_finetune_warm_start: failed to open " + DONOR_GGUF + " (not a GGUF?)"
-  exit 1
-end
-donor_d = TinyNN.tnn_gguf_get_u32(ggh, "llama.embedding_length")
-if donor_d <= 0
-  puts "02_finetune_warm_start: donor has no llama.embedding_length key — not llama-family?"
-  exit 1
-end
+# Read the donor's embedding width — the projection lens is sized
+# donor_d_in × d_model, so the cfg must know the donor's width before
+# realize. (Fails loud if the donor is not llama-family.)
+donor_d = Toy::LLM::Recipes::WarmStart.donor_embed_width(DONOR_GGUF)
 
 cfg = Toy::SmolLM2Config.tiny
 cfg.donor_d_in = donor_d        # embed table becomes vocab × donor_d
@@ -83,29 +74,18 @@ opts.seed   = SEED
 recipe = Toy::LLM::Recipes::WarmStart.new
 recipe.realize_scratch!(cfg, opts)
 
-# Read the first VOCAB rows of the donor's token_embd.weight and upload
-# them while the warm window is open. (The donor's vocab is much larger;
-# rows align when the corpus is tokenized with the donor's tokenizer —
-# for this tiny demo the POINT is the mechanism, not token alignment.)
+# Warm the embed table from the donor while the window is open:
+# realize_warm! owns the read (open, dim-check vs cfg.donor_d_in, read
+# the first VOCAB rows of token_embd.weight, upload, free) and fails
+# loud on any mismatch. (The donor's vocab is much larger; rows align
+# when the corpus is tokenized with the donor's tokenizer — for this
+# tiny demo the POINT is the mechanism, not token alignment.)
 if INIT == "warm"
-  te_idx = TinyNN.tnn_gguf_find_index(ggh, "token_embd.weight")
-  if te_idx < 0
-    puts "02_finetune_warm_start: donor has no token_embd.weight tensor"
-    exit 1
-  end
-  n_floats = VOCAB * donor_d
-  te_buf = Mat.new(1, n_floats)
-  rc = TinyNN.tnn_gguf_read_f32_to_doubles(ggh, te_idx, te_buf.flat, n_floats)
-  if rc != 0
-    puts "02_finetune_warm_start: token_embd.weight read failed rc=" + rc.to_s
-    exit 1
-  end
-  recipe.realize_warm!(te_buf.flat, n_floats)
-  puts "warm: loaded " + n_floats.to_s + " donor embedding floats"
+  recipe.realize_warm!(DONOR_GGUF, cfg)
+  puts "warm: loaded " + (VOCAB * donor_d).to_s + " donor embedding floats"
 else
   puts "warm: SKIPPED (INIT=" + INIT + " — random embeddings, same graph)"
 end
-TinyNN.tnn_gguf_free(ggh)
 
 recipe.build!                   # bake the graph; window closed
 

--- a/examples/02_finetune_warm_start.rb
+++ b/examples/02_finetune_warm_start.rb
@@ -30,14 +30,7 @@
 # The donor read itself is plain GGUF plumbing (open, read one tensor,
 # free) — the recipe deliberately only owns the upload mechanism.
 
-require_relative "../lib/toy"
-require_relative "../lib/toy/models/toy_smollm2"
-require_relative "../lib/toy/llm/engine/llama_seq_engine"
-require_relative "../lib/toy/io/toy_corpus_loader"
-require_relative "../lib/toy/train/toy_lr_schedule"
-require_relative "../lib/toy/llm/adamw"
-require_relative "../lib/toy/llm/training_batch"
-require_relative "../lib/toy/llm/recipes/warm_start"
+require_relative "../lib/toy/compute"
 
 STEPS      = (ENV["STEPS"] || "20").to_i
 SEED       = (ENV["SEED"]  || "0").to_i

--- a/examples/02_finetune_warm_start.rb
+++ b/examples/02_finetune_warm_start.rb
@@ -123,7 +123,7 @@ while step < STEPS
   byte_offset = byte_offset + CONTEXT * 4
 
   batch.fill!(seq_ids)
-  batch.hp = adamw.hp(step)
+  batch.hp = adamw.hp_for_step(step)
   loss = recipe.step!(batch.seq_ids, batch.positions, batch.labels,
                       batch.hp, step == 0)
   if step == 0

--- a/examples/03_lora.rb
+++ b/examples/03_lora.rb
@@ -24,16 +24,11 @@
 # THE API — Toy::LLM::Recipes::LoRA:
 #   realize!(gguf, cfg, rank, opts)  — mmap base + attach rank-R adapters
 #   step!(ids, pos, labels, hp, is_first) — same contract as the siblings
-# NOTE: LoRA is required DIRECTLY (not part of the one-require
-# toy/compute surface yet — Spinel constructor-slot inference, toy#52).
+# LoRA rides the one-require compute surface like its siblings (re-added
+# by toy#52 once the toy#64 reshape dissolved the spinel-dev#12 facet).
 # The CLI form of this example is `toy train lora`.
 
-require_relative "../lib/toy"
-require_relative "../lib/toy/models/toy_smollm2"
-require_relative "../lib/toy/io/loaders/toy_smollm2_loader"
-require_relative "../lib/toy/llm/engine/llama_seq_engine"
-require_relative "../lib/toy/llm/adamw"
-require_relative "../lib/toy/llm/recipes/lora"
+require_relative "../lib/toy/compute"
 
 GGUF      = ENV["GGUF"]  || "data/smollm2-135m-native.gguf"
 RANK      = (ENV["RANK"]  || "8").to_i

--- a/examples/03_lora.rb
+++ b/examples/03_lora.rb
@@ -74,20 +74,11 @@ opts.init_scale = 0.01
 recipe.realize!(gguf, cfg, RANK, opts)
 puts "realize OK (base mmap'd, adapters attached)"
 
-# One-hot labels: every position targets TARGET_ID. (A custom objective
-# like this is hand-built — Toy::Labels/TrainingBatch model the
-# next-token objective only.)
-m_labels = Mat.new(TOKENS.length, cfg.vocab)
-i = 0
-while i < TOKENS.length * cfg.vocab
-  m_labels.flat[i] = 0.0
-  i = i + 1
-end
-ti = 0
-while ti < TOKENS.length
-  m_labels.flat[ti * cfg.vocab + TARGET_ID] = 1.0
-  ti = ti + 1
-end
+# The validating batch, fixed-target objective: every position targets
+# TARGET_ID (out-of-vocab ids or target fail loud, not mid-graph). The
+# prompt is constant, so one fill before the loop covers every step.
+batch = Toy::LLM::TrainingBatch.new(cfg.vocab, TOKENS.length, 1)
+batch.fill_fixed_target!(TOKENS, TARGET_ID)
 
 # LoRA's AdamW convention differs from from-scratch: beta2=0.999 and
 # PER-STEP bias correction. hp_for_step knows that: it takes the plain
@@ -95,13 +86,11 @@ end
 adamw = Toy::AdamW.for_lora
 adamw.lr = LR
 
-positions = [0, 1, 2, 3]
-
 first_loss = 0.0
 final_loss = 0.0
 step = 0
 while step < STEPS
-  loss = recipe.step!(TOKENS, positions, m_labels,
+  loss = recipe.step!(batch.seq_ids, batch.positions, batch.labels,
                       adamw.hp_for_step(step), step == 0)
   if step == 0
     first_loss = loss

--- a/examples/03_lora.rb
+++ b/examples/03_lora.rb
@@ -90,8 +90,8 @@ while ti < TOKENS.length
 end
 
 # LoRA's AdamW convention differs from from-scratch: beta2=0.999 and
-# PER-STEP bias correction (slots 5/6 of hp carry the correction
-# denominators, not the betas) — hence hp is rebuilt every step.
+# PER-STEP bias correction. hp_for_step knows that: it takes the plain
+# 0-indexed loop step and applies the lora 1-indexed t internally.
 adamw = Toy::AdamW.for_lora
 adamw.lr = LR
 
@@ -99,15 +99,15 @@ positions = [0, 1, 2, 3]
 
 first_loss = 0.0
 final_loss = 0.0
-step = 1
-while step <= STEPS
-  m_hp = adamw.hp(step)                  # 1-indexed for bias correction
-  loss = recipe.step!(TOKENS, positions, m_labels, m_hp, step == 1)
-  if step == 1
+step = 0
+while step < STEPS
+  loss = recipe.step!(TOKENS, positions, m_labels,
+                      adamw.hp_for_step(step), step == 0)
+  if step == 0
     first_loss = loss
   end
   final_loss = loss
-  puts "step " + step.to_s + ": loss=" + loss.to_s
+  puts "step " + (step + 1).to_s + ": loss=" + loss.to_s
   step = step + 1
 end
 

--- a/examples/07_vit_tiny.rb
+++ b/examples/07_vit_tiny.rb
@@ -77,10 +77,11 @@ if got != record_f
   exit 1
 end
 
-m_image  = Mat.new(patch_flat, n_patches)
-m_labels = Mat.new(1, NUM_CLASSES)
-cls_idx  = [0]                       # read the class token at position 0
-adamw    = Toy::AdamW.for_from_scratch
+# The validating batch (the ClassifyBatch sibling of 01's
+# TrainingBatch): fill! checks the record length + label range and
+# rebuilds the image Mat + one-hot labels — a torn corpus fails loud.
+batch = Toy::LLM::ClassifyBatch.new(NUM_CLASSES, patch_flat, n_patches)
+adamw = Toy::AdamW.for_from_scratch
 
 first_loss = 0.0
 final_loss = 0.0
@@ -92,18 +93,10 @@ while step < STEPS
   # corpus would advance the index).
   patches = ToyImageLoader.read_image(images_path, 0, record_f)
   label   = ToyImageLoader.read_label(labels_path, 0)
-  i = 0
-  while i < record_f
-    m_image.flat[i] = patches[i]
-    i = i + 1
-  end
-  j = 0
-  while j < NUM_CLASSES
-    m_labels.flat[j] = j == label ? 1.0 : 0.0
-    j = j + 1
-  end
+  batch.fill!(patches, label)
 
-  loss = recipe.step!(m_image, cls_idx, m_labels, adamw.hp_for_step(step), step == 0)
+  loss = recipe.step!(batch.image, batch.cls_idx, batch.labels,
+                      adamw.hp_for_step(step), step == 0)
   if step == 0
     first_loss = loss
   end

--- a/examples/07_vit_tiny.rb
+++ b/examples/07_vit_tiny.rb
@@ -26,12 +26,7 @@
 # one-hot class label — where the LLM recipes take token ids and
 # shift-by-one labels. No CLI surface for ViT yet; this file is it.
 
-require_relative "../lib/toy/models/toy_vit"
-require_relative "../lib/toy/llm/engine/vit_tiny_engine"
-require_relative "../lib/toy/io/toy_image_loader"
-require_relative "../lib/toy/train/toy_lr_schedule"
-require_relative "../lib/toy/llm/recipes/vit_tiny"
-require_relative "../lib/toy/llm/adamw"
+require_relative "../lib/toy/compute"
 
 STEPS   = (ENV["STEPS"] || "20").to_i
 SEED    = (ENV["SEED"]  || "0").to_i

--- a/examples/07_vit_tiny.rb
+++ b/examples/07_vit_tiny.rb
@@ -103,7 +103,7 @@ while step < STEPS
     j = j + 1
   end
 
-  loss = recipe.step!(m_image, cls_idx, m_labels, adamw.hp(step), step == 0)
+  loss = recipe.step!(m_image, cls_idx, m_labels, adamw.hp_for_step(step), step == 0)
   if step == 0
     first_loss = loss
   end

--- a/lib/toy/compute.rb
+++ b/lib/toy/compute.rb
@@ -79,6 +79,7 @@ require_relative "train/toy_lr_schedule"
 require_relative "llm/adamw"
 require_relative "llm/labels"
 require_relative "llm/training_batch"
+require_relative "llm/classify_batch"
 
 # Run-bundle writer (toy#73 item 1): runs/<id>/events.jsonl in the toy/v1
 # schema + the weights/ checkpoint-dir convention. SHARED (not mirrored):

--- a/lib/toy/compute.rb
+++ b/lib/toy/compute.rb
@@ -65,6 +65,15 @@ require_relative "llm/recipes/vit_tiny"
 require_relative "io/gguf_load"
 require_relative "io/tokenizer"
 
+# Training I/O + schedule (toy#73 item 2): the streaming token-corpus
+# loader, the ViT image/label loader, and the cosine LR schedule. The
+# loaders are plain file I/O through C helpers in libtinynn_ggml.a
+# (backend-agnostic; every backend links it) and ToyLR is pure Ruby, so
+# all three are SHARED across the CPU/CUDA/Metal entries — no mirrors.
+require_relative "io/toy_corpus_loader"
+require_relative "io/toy_image_loader"
+require_relative "train/toy_lr_schedule"
+
 # AdamW hyper-parameter value object + training labels (used when driving
 # build_training_step directly) + the validating per-step batch wrapper.
 require_relative "llm/adamw"

--- a/lib/toy/compute.rb
+++ b/lib/toy/compute.rb
@@ -71,6 +71,11 @@ require_relative "llm/adamw"
 require_relative "llm/labels"
 require_relative "llm/training_batch"
 
+# Run-bundle writer (toy#73 item 1): runs/<id>/events.jsonl in the toy/v1
+# schema + the weights/ checkpoint-dir convention. SHARED (not mirrored):
+# the events C symbols live in libtinynn_ggml.a, linked by every backend.
+require_relative "io/run_bundle"
+
 # ── Toy::Device — the device-agnostic construction seam (toy#64 item 8) ──
 #
 # DEVICE IS CHOSEN AT COMPILE TIME by which compute entry you require:

--- a/lib/toy/compute_cuda.rb
+++ b/lib/toy/compute_cuda.rb
@@ -54,6 +54,15 @@ require_relative "llm/recipes/lora_cuda"
 require_relative "io/gguf_load"
 require_relative "io/tokenizer"
 
+# Training I/O + schedule (toy#73 item 2): corpus loader + image loader +
+# cosine LR schedule. SHARED with the CPU entry (file I/O through C helpers
+# in libtinynn_ggml.a + pure Ruby) — see compute.rb's note. The image
+# loader rides along even though vit training stays CPU-only this arc
+# (the loader is backend-free; the missing piece is the engine/recipe).
+require_relative "io/toy_corpus_loader"
+require_relative "io/toy_image_loader"
+require_relative "train/toy_lr_schedule"
+
 # AdamW + labels + the validating batch wrapper (shared, pure Ruby).
 require_relative "llm/adamw"
 require_relative "llm/labels"

--- a/lib/toy/compute_cuda.rb
+++ b/lib/toy/compute_cuda.rb
@@ -59,6 +59,13 @@ require_relative "llm/adamw"
 require_relative "llm/labels"
 require_relative "llm/training_batch"
 
+# Run-bundle writer (toy#73 item 1): runs/<id>/events.jsonl in the toy/v1
+# schema + the weights/ checkpoint-dir convention. SHARED (not mirrored):
+# the events C symbols live in libtinynn_ggml.a, linked by every backend
+# (the CPU TinyNN module is defined in this binary too — see the
+# checkpoint-seam note above).
+require_relative "io/run_bundle"
+
 # ── Toy::Device, CUDA arm — see the compute.rb doc block. Same
 # surface, CUDA types; user source stays device-agnostic.
 module Toy

--- a/lib/toy/compute_cuda.rb
+++ b/lib/toy/compute_cuda.rb
@@ -67,6 +67,7 @@ require_relative "train/toy_lr_schedule"
 require_relative "llm/adamw"
 require_relative "llm/labels"
 require_relative "llm/training_batch"
+require_relative "llm/classify_batch"
 
 # Run-bundle writer (toy#73 item 1): runs/<id>/events.jsonl in the toy/v1
 # schema + the weights/ checkpoint-dir convention. SHARED (not mirrored):

--- a/lib/toy/compute_metal.rb
+++ b/lib/toy/compute_metal.rb
@@ -62,6 +62,7 @@ require_relative "train/toy_lr_schedule"
 require_relative "llm/adamw"
 require_relative "llm/labels"
 require_relative "llm/training_batch"
+require_relative "llm/classify_batch"
 
 # Run-bundle writer (toy#73 item 1): runs/<id>/events.jsonl in the toy/v1
 # schema + the weights/ checkpoint-dir convention. SHARED (not mirrored):

--- a/lib/toy/compute_metal.rb
+++ b/lib/toy/compute_metal.rb
@@ -54,6 +54,13 @@ require_relative "llm/adamw"
 require_relative "llm/labels"
 require_relative "llm/training_batch"
 
+# Run-bundle writer (toy#73 item 1): runs/<id>/events.jsonl in the toy/v1
+# schema + the weights/ checkpoint-dir convention. SHARED (not mirrored):
+# the events C symbols live in libtinynn_ggml.a, linked by every backend
+# (the CPU TinyNN module is defined in this binary too — see the
+# checkpoint-seam note above).
+require_relative "io/run_bundle"
+
 # ── Toy::Device, Metal arm — see the compute.rb doc block. NOTE: no
 # warm_start_recipe here (no Metal recipe exists); a device-agnostic
 # body that uses it will fail to compile against this entry — loudly,

--- a/lib/toy/compute_metal.rb
+++ b/lib/toy/compute_metal.rb
@@ -49,6 +49,15 @@ require_relative "llm/recipes/from_scratch_metal"
 require_relative "io/gguf_load"
 require_relative "io/tokenizer"
 
+# Training I/O + schedule (toy#73 item 2): corpus loader + image loader +
+# cosine LR schedule. SHARED with the CPU entry (file I/O through C helpers
+# in libtinynn_ggml.a + pure Ruby) — see compute.rb's note. The image
+# loader rides along even though vit training stays CPU-only this arc
+# (the loader is backend-free; the missing piece is the engine/recipe).
+require_relative "io/toy_corpus_loader"
+require_relative "io/toy_image_loader"
+require_relative "train/toy_lr_schedule"
+
 # AdamW + labels + the validating batch wrapper (shared, pure Ruby).
 require_relative "llm/adamw"
 require_relative "llm/labels"

--- a/lib/toy/ffi/tinynn.rb
+++ b/lib/toy/ffi/tinynn.rb
@@ -451,6 +451,9 @@ module TinyNN
   # docs/events-schema.md. One file per run, line-buffered, opt-in
   # via the caller passing a path (typically from ENV["TOY_EVENTS"]).
   ffi_func :tnn_events_open,          [:str],                   :int
+  # Truncate-open ("w" not "a"): the fresh-bundle opener (Toy::RunBundle,
+  # toy#73) — a re-run with the same run_id replaces the bundle.
+  ffi_func :tnn_events_open_trunc,    [:str],                   :int
   ffi_func :tnn_events_emit,          [:str],                   :void
   ffi_func :tnn_events_close,         [],                       :void
   ffi_func :tnn_events_active,        [],                       :int

--- a/lib/toy/ffi/tinynn_cuda.rb
+++ b/lib/toy/ffi/tinynn_cuda.rb
@@ -190,6 +190,9 @@ module TinyNNCuda
   ffi_func :tnn_trace_op_capture_active, [],                        :int
   # JSON Lines event stream. See tinynn/tinynn_events.h.
   ffi_func :tnn_events_open,          [:str],                       :int
+  # Truncate-open ("w" not "a"): the fresh-bundle opener (Toy::RunBundle,
+  # toy#73) — a re-run with the same run_id replaces the bundle.
+  ffi_func :tnn_events_open_trunc,    [:str],                       :int
   ffi_func :tnn_events_emit,          [:str],                       :void
   ffi_func :tnn_events_close,         [],                           :void
   ffi_func :tnn_events_active,        [],                           :int

--- a/lib/toy/ffi/tinynn_metal.rb
+++ b/lib/toy/ffi/tinynn_metal.rb
@@ -179,6 +179,9 @@ module TinyNNMetal
   # train_metal.rb's events/provenance + run_start/step/run_end stream needs
   # all nine. (cuda twin: lib/toy/ffi/tinynn_cuda.rb:188-197.)
   ffi_func :tnn_events_open,          [:str],                       :int
+  # Truncate-open ("w" not "a"): the fresh-bundle opener (Toy::RunBundle,
+  # toy#73) — a re-run with the same run_id replaces the bundle.
+  ffi_func :tnn_events_open_trunc,    [:str],                       :int
   ffi_func :tnn_events_emit,          [:str],                       :void
   ffi_func :tnn_events_close,         [],                           :void
   ffi_func :tnn_events_active,        [],                           :int

--- a/lib/toy/io/run_bundle.rb
+++ b/lib/toy/io/run_bundle.rb
@@ -1,0 +1,180 @@
+# lib/toy/io/run_bundle.rb — Toy::RunBundle: the runs/<id>/ event-bundle
+# WRITER for compiled consumers (toy#73 item 1).
+#
+# Before this class, a compiled consumer that wanted the toy/v1 bundle
+# hand-rolled JSON lines against the raw tnn_events_* FFI (example 01
+# burned ~15 lines on it), and the append-only sink meant a re-run with
+# the same run id DOUBLED the bundle. RunBundle owns the whole story:
+#
+#   bundle = Toy::RunBundle.new("runs", RUN_ID)   # mkdir + TRUNCATE-open
+#   bundle.run_start!("llama", cfg.vocab, cfg.d_model, cfg.n_layers,
+#                     cfg.ctx, STEPS, LR, SEED)
+#   bundle.step!(step + 1, loss)                  # one per step
+#   bundle.run_end!(STEPS, final_loss)            # emits run_end + closes
+#
+# The stream is the toy/v1 schema (docs/events.md): run_start carries
+# kind/schema/t/started_at/run_id/phase/host{}/model{}/config{}, step
+# carries kind/phase/t/step/loss, run_end carries kind/t/ended_at/
+# reason/final_step/final_loss/exit_code — the same shape the train
+# runners emit (lib/toy/run/train.rb), minus the runner-only extras
+# (backend{}, git{}, lr/tokens/wall_us — all v1-optional keys; the
+# schema is open, consumers ignore absences). Toy::RunLog reads the
+# result back (round-tripped in prep/run_log_gate.rb).
+#
+# FRESH-BUNDLE SEMANTICS: the ctor opens events.jsonl via
+# tnn_events_open_trunc (toy#73's new FFI hook) — a re-run with the
+# same run id REPLACES the bundle instead of doubling it. The runners'
+# append-only tnn_events_open stays untouched (the CLI creates a fresh
+# run dir per run, so append is correct there).
+#
+# CHECKPOINT-DIR CONVENTION: weights_dir creates + returns
+# runs/<id>/weights — the documented checkpoint home (docs/events.md
+# "Run directory layout") — so consumers put GGUF snapshots where
+# `toy infer` and the bundle tooling expect them.
+#
+# JSON: self-contained minimal escaper (same escape table as
+# SpinelKit::Json::Builder) — NO vendor/spinel/spinel_kit require, so a
+# fresh clone compiles the examples without `make vendor-tep`. Values
+# here are run ids / arch names + numbers; control bytes beyond
+# \" \\ \n \r \t pass through (don't put binary in a run id).
+#
+# BACKEND COUPLING: none in practice — the tnn_events_* / mkdir C
+# symbols live in libtinynn_ggml.a, which EVERY backend links, and the
+# CPU TinyNN module is defined in every compiled binary (transformer.rb
+# requires ffi/tinynn). So this file is SHARED across the CPU / CUDA /
+# Metal compute entries (like ToyCorpusLoader), NOT mirrored.
+#
+# Spinel hygiene: PLAIN class (no Struct.new — landmine #16), explicit
+# ctor with NO default args (landmine #4), while-loops, NO #{}
+# interpolation, uniquely rb_-prefixed ivars, FFI :str calls only
+# inside method bodies (step_bind :str landmine 2026-05-28). Warns
+# loud + disables on open failure (never silently swallows events).
+
+module Toy
+  class RunBundle
+    attr_accessor :rb_root, :rb_run_id, :rb_dir, :rb_active
+
+    # Create runs_root/ and runs_root/run_id/, then TRUNCATE-open the
+    # events.jsonl sink. On open failure (rc != 0) warns loud with the
+    # rc + path and continues with events disabled (active == false) —
+    # compute must not die because a bundle dir is unwritable.
+    def initialize(runs_root, run_id)
+      @rb_root   = runs_root
+      @rb_run_id = run_id
+      @rb_dir    = runs_root + "/" + run_id
+      @rb_active = false
+      TinyNN.tnn_filesystem_mkdir(runs_root)
+      TinyNN.tnn_filesystem_mkdir(@rb_dir)
+      rc = TinyNN.tnn_events_open_trunc(@rb_dir + "/events.jsonl")
+      if rc == 0
+        @rb_active = true
+      else
+        puts "warn: Toy::RunBundle could not open " + @rb_dir +
+             "/events.jsonl (rc=" + rc.to_s + ") — run bundle disabled"
+      end
+    end
+
+    def active
+      @rb_active
+    end
+
+    def events_path
+      @rb_dir + "/events.jsonl"
+    end
+
+    # The checkpoint-dir convention: runs/<id>/weights/, created on
+    # first ask. Pass the returned path to ToyGGUFWriter.write_step (or
+    # any GGUF writer) so the bundle layout matches docs/events.md.
+    def weights_dir
+      d = @rb_dir + "/weights"
+      TinyNN.tnn_filesystem_mkdir(d)
+      d
+    end
+
+    # Emit the toy/v1 run_start (exactly one per bundle, first):
+    # schema + t + started_at + run_id + phase:"train" + host{} +
+    # model{arch,vocab,d_model,n_layers} + config{context,steps,lr,seed}.
+    # arch is e.g. "llama" / "gpt2" / "vit". Returns nil.
+    def run_start!(arch, vocab, d_model, n_layers, context, steps, lr, seed)
+      if @rb_active
+        TinyNN.tnn_events_emit("{\"kind\":\"run_start\",\"schema\":\"toy/v1\"" +
+          ",\"t\":" + TinyNN.tnn_events_now_seconds.to_s +
+          ",\"started_at\":\"" + TinyNN.tnn_events_iso8601_now + "\"" +
+          ",\"run_id\":\"" + RunBundle.json_escape(@rb_run_id) + "\"" +
+          ",\"phase\":\"train\"" +
+          ",\"host\":{\"name\":\"" +
+            RunBundle.json_escape(TinyNN.tnn_provenance_host_name) +
+          "\",\"os\":\"" + TinyNN.tnn_provenance_host_os +
+          "\",\"arch\":\"" + TinyNN.tnn_provenance_host_arch + "\"}" +
+          ",\"model\":{\"arch\":\"" + RunBundle.json_escape(arch) + "\"" +
+          ",\"vocab\":" + vocab.to_s +
+          ",\"d_model\":" + d_model.to_s +
+          ",\"n_layers\":" + n_layers.to_s + "}" +
+          ",\"config\":{\"context\":" + context.to_s +
+          ",\"steps\":" + steps.to_s +
+          ",\"lr\":" + lr.to_s +
+          ",\"seed\":" + seed.to_s + "}}")
+      end
+      nil
+    end
+
+    # Emit one toy/v1 step event. `step` is the 1-indexed step number
+    # (matches the runners' "step N: loss=" stdout line). Returns nil.
+    def step!(step, loss)
+      if @rb_active
+        TinyNN.tnn_events_emit("{\"kind\":\"step\",\"phase\":\"train\"" +
+          ",\"t\":" + TinyNN.tnn_events_now_seconds.to_s +
+          ",\"step\":" + step.to_s +
+          ",\"loss\":" + loss.to_s + "}")
+      end
+      nil
+    end
+
+    # Emit the toy/v1 run_end (exactly one, last) and CLOSE the sink.
+    # reason:"completed" / exit_code:0 — RunBundle is for runs that ran
+    # to completion; a crashed run just leaves the bundle without a
+    # run_end (the documented torn-bundle case consumers handle).
+    # Returns nil.
+    def run_end!(final_step, final_loss)
+      if @rb_active
+        TinyNN.tnn_events_emit("{\"kind\":\"run_end\"" +
+          ",\"t\":" + TinyNN.tnn_events_now_seconds.to_s +
+          ",\"ended_at\":\"" + TinyNN.tnn_events_iso8601_now + "\"" +
+          ",\"reason\":\"completed\"" +
+          ",\"final_step\":" + final_step.to_s +
+          ",\"final_loss\":" + final_loss.to_s +
+          ",\"exit_code\":0}")
+        TinyNN.tnn_events_close
+        @rb_active = false
+      end
+      nil
+    end
+
+    # Minimal JSON string-body escaper (same table as
+    # SpinelKit::Json::Builder.escape, minus the \u00XX arm — run ids
+    # and arch names are ASCII-clean by construction).
+    def self.json_escape(s)
+      out = ""
+      i = 0
+      n = s.length
+      while i < n
+        c = s[i]
+        if c == "\""
+          out = out + "\\\""
+        elsif c == "\\"
+          out = out + "\\\\"
+        elsif c == "\n"
+          out = out + "\\n"
+        elsif c == "\r"
+          out = out + "\\r"
+        elsif c == "\t"
+          out = out + "\\t"
+        else
+          out = out + c
+        end
+        i = i + 1
+      end
+      out
+    end
+  end
+end

--- a/lib/toy/llm/adamw.rb
+++ b/lib/toy/llm/adamw.rb
@@ -144,5 +144,26 @@ module Toy
       end
       m
     end
+
+    # MODE-AWARE per-step hp builder (toy#73 item 5): takes the CALLER's
+    # 0-INDEXED loop step (the convention every recipe loop already uses
+    # for its `step == 0` is_first branch) and applies the mode's step
+    # convention internally:
+    #
+    #   MODE_FROM_SCRATCH — step-agnostic (slots 5/6 = constant betas);
+    #                       hp_for_step(k) == hp(k).
+    #   MODE_LORA         — the lora-family graphs want a 1-INDEXED t in
+    #                       1/(1-beta^t); hp_for_step(k) == hp(k + 1).
+    #
+    # This removes the lora paths' off-by-one ceremony (a 1-indexed loop
+    # carried solely to feed hp(step)). Byte-identical to the hp calls it
+    # replaces. The #64 mode guard STAYS: both arms delegate to hp, so
+    # mode-unset / mode-vs-bias_correct mismatch still fail loud.
+    def hp_for_step(step)
+      if @mode == MODE_LORA
+        return hp(step + 1)
+      end
+      hp(step)
+    end
   end
 end

--- a/lib/toy/llm/classify_batch.rb
+++ b/lib/toy/llm/classify_batch.rb
@@ -1,0 +1,88 @@
+# lib/toy/llm/classify_batch.rb — Toy::LLM::ClassifyBatch: the
+# image-classification SIBLING of TrainingBatch (toy#73 item 3).
+#
+# The ViT recipe's step! quartet is (m_image, cls_idx, m_labels, m_hp)
+# where the LLM recipes take (seq_ids, positions, labels, hp). Before
+# this class the ViT example hand-filled the image Mat and the class
+# one-hot with raw loops and NO validation — a short patches array
+# silently trained on stale/zero pixels, an out-of-range label
+# silently scattered off the row. ClassifyBatch fails LOUD instead:
+#
+#   batch = Toy::LLM::ClassifyBatch.new(NUM_CLASSES, patch_flat, n_patches)
+#   batch.fill!(patches, label)        # validates + rebuilds both
+#   batch.hp = adamw.hp_for_step(step) # caller-owned (optimizer knob)
+#   recipe.step!(batch.image, batch.cls_idx, batch.labels,
+#                batch.hp, step == 0)
+#
+# The ctor pins the record shape (patch_flat x n_patches — what
+# ViTTinyEngine's t_image expects) and builds the cls_idx vector ([0]:
+# the class token lives at position 0 in every current ViT graph).
+# fill! validates the patches length and the label range, copies the
+# patches into the image Mat, and rebuilds the one-hot labels via
+# Toy::Labels.one_hot_class — byte-identical to the hand loops it
+# replaces. ToyImageLoader.read_label returns -1 on a short read, so a
+# torn labels.bin fails loud in fill!, not as a silent all-zero row.
+#
+# Pure-Ruby: NO TinyNN / FFI calls — only Mat (via Toy::Labels) — so it
+# is SHARED (not mirrored) across CPU / CUDA / Metal, like
+# TrainingBatch / AdamW / Labels. (ViT training itself is CPU-only
+# this arc; the batch object is backend-free.)
+#
+# Spinel hygiene: PLAIN class (NO Struct.new — landmine #16), explicit
+# ctor with NO default args (landmine #4), while-loops, NO #{}
+# interpolation, uniquely cb_-prefixed scalar ivars.
+
+require_relative "labels"
+
+module Toy; module LLM
+  class ClassifyBatch
+    attr_accessor :cb_classes, :cb_patch_flat, :cb_n_patches,
+                  :image, :cls_idx, :labels, :hp
+
+    def initialize(num_classes, patch_flat, n_patches)
+      if num_classes <= 0
+        raise "ClassifyBatch: num_classes must be positive, got " +
+              num_classes.to_s
+      end
+      if patch_flat <= 0 || n_patches <= 0
+        raise "ClassifyBatch: patch_flat/n_patches must be positive, got " +
+              patch_flat.to_s + "/" + n_patches.to_s
+      end
+      @cb_classes    = num_classes
+      @cb_patch_flat = patch_flat
+      @cb_n_patches  = n_patches
+
+      # The image Mat at the engine's expected shape; zero until fill!.
+      @image = Mat.new(patch_flat, n_patches)
+
+      # The class-token read position: 0 in every current ViT graph.
+      @cls_idx = [0]
+
+      # Zero labels at the final shape until fill!; hp is caller-owned
+      # (Mat(1,7) from Toy::AdamW) — zero placeholder pins the type.
+      @labels = Mat.new(1, num_classes)
+      @hp     = Mat.new(1, 7)
+    end
+
+    # Validate + load one (image, label) record. `patches` is the flat
+    # f32 record from ToyImageLoader.read_image (length must be exactly
+    # patch_flat * n_patches); `label` is the class index from
+    # read_label (0...num_classes — read_label's -1 short-read sentinel
+    # fails the range check loud). Returns nil.
+    def fill!(patches, label)
+      record_f = @cb_patch_flat * @cb_n_patches
+      if patches.length != record_f
+        raise "ClassifyBatch#fill!: patches length " +
+              patches.length.to_s + " != patch_flat*n_patches " +
+              record_f.to_s
+      end
+      i = 0
+      while i < record_f
+        @image.flat[i] = patches[i]
+        i = i + 1
+      end
+      @labels = Toy::Labels.one_hot_class(@cb_classes, label)
+      nil
+    end
+  end
+end; end

--- a/lib/toy/llm/labels.rb
+++ b/lib/toy/llm/labels.rb
@@ -16,10 +16,14 @@
 #   next_token          — UNGUARDED  (from-scratch: known-good seq_ids)
 #   next_token_guarded  — in-vocab guarded (warm-start: streamed corpus)
 #
-# OUT OF SCOPE (deliberately NOT routed through here, they are NOT
-# shift-by-one): lora's constant-TARGET_ID one-hot (every row targets
-# the same id) and vit's single-class one-hot stay as inline builds in
-# their runners.
+# Since toy#73 item 3 the two NON-shift-by-one objectives also live
+# here (they used to be inline hand fills in the lora/vit fixtures):
+#   fixed_target   — every position targets ONE id (the lora smoke
+#                    objective; consumed by TrainingBatch#fill_fixed_target!)
+#   one_hot_class  — single-row class one-hot (the ViT objective;
+#                    consumed by ClassifyBatch#fill!)
+# Both FAIL LOUD on an out-of-range target/label — the unguarded
+# scatter would silently write outside the row otherwise.
 
 module Toy
   module Labels
@@ -86,6 +90,51 @@ module Toy
           m.flat[k * vocab + target] = 1.0
         end
         k = k + 1
+      end
+      m
+    end
+
+    # FIXED-TARGET one-hot (toy#73 item 3): every one of the `context`
+    # positions targets the SAME id — the lora-smoke objective
+    # (examples/03_lora.rb: push every position of a fixed prompt
+    # toward one token). Reproduces the example's hand fill VERBATIM
+    # (zero the Mat, then scatter 1.0 at row*vocab + target_id).
+    # FAILS LOUD on an out-of-vocab target.
+    def self.fixed_target(vocab, context, target_id)
+      if target_id < 0 || target_id >= vocab
+        raise "Toy::Labels.fixed_target: target_id " + target_id.to_s +
+              " out of vocab 0..." + vocab.to_s
+      end
+      m = Mat.new(context, vocab)
+      j = 0
+      while j < context * vocab
+        m.flat[j] = 0.0
+        j = j + 1
+      end
+      k = 0
+      while k < context
+        m.flat[k * vocab + target_id] = 1.0
+        k = k + 1
+      end
+      m
+    end
+
+    # SINGLE-ROW CLASS one-hot (toy#73 item 3): Mat(1, num_classes)
+    # with 1.0 at `label` — the ViT classification objective
+    # (examples/07_vit_tiny.rb's hand loop, byte-identical). FAILS
+    # LOUD on an out-of-range label (ToyImageLoader.read_label returns
+    # -1 on a short read, so a torn labels.bin fails here, not as a
+    # silent all-zero label row).
+    def self.one_hot_class(num_classes, label)
+      if label < 0 || label >= num_classes
+        raise "Toy::Labels.one_hot_class: label " + label.to_s +
+              " out of range 0..." + num_classes.to_s
+      end
+      m = Mat.new(1, num_classes)
+      j = 0
+      while j < num_classes
+        m.flat[j] = j == label ? 1.0 : 0.0
+        j = j + 1
       end
       m
     end

--- a/lib/toy/llm/recipes/warm_start.rb
+++ b/lib/toy/llm/recipes/warm_start.rb
@@ -23,18 +23,20 @@
 # INIT=scratch (09's default) skips it entirely and trains from the
 # random init, which is what reproduces 09's scratch loss curve.
 #
-# Experiment concerns stay in the FIXTURE (lib-vs-example scope): the
-# GGUF open / dim-check / find_index / read / free (09 L151-181) and the
-# PCA-lens W_proj read+upload (09 L188-229) are experiment-specific. The
-# recipe exposes @ws_cache.sess + the t_seq_token_embed / t_seq_w_proj
-# public delegators (llama_seq_forward_ffi.rb:81-88) for the fixture to
-# upload through; realize_warm! is the mechanism ONLY — it takes the
-# ALREADY-READ donor float buffer + its length and performs the single
-# tnn_upload_from_float_array (mirrors 09 L180). The cosine LR schedule
-# and corpus streaming likewise live in the fixture; the per-step LR
-# enters ONLY via the caller mutating m_hp.flat[0] before step! — there
-# is deliberately NO lr param on step! (would diverge from the siblings
-# and move schedule logic into the recipe).
+# Since toy#73 item 4 realize_warm! OWNS the donor plumbing (the GGUF
+# open / width dim-check / find_index / read / upload / free that every
+# consumer hand-rolled, ~25 lines each): realize_warm!(path, cfg) does
+# the whole read and fails NAMED+LOUD on every mismatch; the class
+# method donor_embed_width(path) is the pre-realize half (cfg.donor_d_in
+# must carry the donor width BEFORE realize_scratch! sizes the lens).
+# The raw upload mechanism survives as upload_donor!(buf, n) for
+# already-read buffers. Still caller-side (lib-vs-example scope): the
+# PCA-lens W_proj read+upload (09 L188-229) through @ws_cache.sess +
+# the t_seq_w_proj delegator, the cosine LR schedule, and the corpus
+# streaming; the per-step LR enters ONLY via the caller mutating
+# m_hp.flat[0] before step! — there is deliberately NO lr param on
+# step! (would diverge from the siblings and move schedule logic into
+# the recipe).
 #
 # Spinel hygiene: NEVER Struct.new (landmine #16 / matz/spinel#1043) —
 # hand-written plain class, explicit no-arg ctor, NO default-arg ctor
@@ -91,17 +93,98 @@ module Toy; module LLM; module Recipes
       nil
     end
 
-    # OPTIONAL: upload an already-read donor embedding into the realize'd
-    # token_embed table. Mechanism ONLY — mirrors 09 L180. The caller
-    # (fixture) owns the GGUF open / dim-check / find_index / read / free
-    # (09 L151-181) and passes the resulting flat float buffer + its
-    # length. Must be called AFTER realize_scratch! (the tensor exists)
-    # and BEFORE build! (else we train through the random init). The PCA
-    # lens W_proj upload (09 L188-229) is performed by the fixture
-    # directly through @ws_cache.sess + the t_seq_w_proj delegator — the
-    # recipe does not wrap it (same lib-vs-example rationale). INIT=scratch
-    # skips this method entirely (matches 09 default). Returns nil.
-    def realize_warm!(donor_buf_flat, n_floats)
+    # Read the donor's embedding width (llama.embedding_length) from a
+    # GGUF path — the value the caller must put in cfg.donor_d_in
+    # BEFORE realize_scratch! (the projection lens is sized
+    # donor_d_in x d_model at realize time, so the recipe cannot learn
+    # it later). FAILS LOUD on a missing/corrupt donor or a
+    # non-llama-family GGUF. (toy#73 item 4 — the read half of the
+    # donor plumbing realize_warm! owns.)
+    def self.donor_embed_width(donor_gguf_path)
+      if !File.exist?(donor_gguf_path)
+        raise "WarmStart.donor_embed_width: donor GGUF not found: " +
+              donor_gguf_path
+      end
+      ggh = TinyNN.tnn_gguf_load(donor_gguf_path)
+      if ggh == nil || ggh == TinyNN.tnn_null_ptr
+        raise "WarmStart.donor_embed_width: failed to open " +
+              donor_gguf_path + " (not a GGUF?)"
+      end
+      donor_d = TinyNN.tnn_gguf_get_u32(ggh, "llama.embedding_length")
+      TinyNN.tnn_gguf_free(ggh)
+      if donor_d <= 0
+        raise "WarmStart.donor_embed_width: donor has no " +
+              "llama.embedding_length key — not llama-family? (" +
+              donor_gguf_path + ")"
+      end
+      donor_d
+    end
+
+    # OPTIONAL: warm the realize'd embed table from a donor GGUF. Owns
+    # the WHOLE donor read (toy#73 item 4 — was ~25 lines of bare GGUF
+    # plumbing in every consumer): open, re-read llama.embedding_length
+    # and DIM-CHECK it against cfg.donor_d_in (the width the lens was
+    # realized at — a mismatch would silently upload garbage through
+    # the wrong stride), find token_embd.weight, read the first
+    # cfg.vocab rows, upload through upload_donor!, free. Every failure
+    # raises NAMED + LOUD (which tensor, expected vs got, which path).
+    # Must be called AFTER realize_scratch! (the tensor exists) and
+    # BEFORE build! (else we train through the random init).
+    # INIT=scratch flows skip this method entirely. Returns nil.
+    def realize_warm!(donor_gguf_path, cfg)
+      if !File.exist?(donor_gguf_path)
+        raise "WarmStart#realize_warm!: donor GGUF not found: " +
+              donor_gguf_path
+      end
+      ggh = TinyNN.tnn_gguf_load(donor_gguf_path)
+      if ggh == nil || ggh == TinyNN.tnn_null_ptr
+        raise "WarmStart#realize_warm!: failed to open " +
+              donor_gguf_path + " (not a GGUF?)"
+      end
+      donor_d = TinyNN.tnn_gguf_get_u32(ggh, "llama.embedding_length")
+      if donor_d <= 0
+        TinyNN.tnn_gguf_free(ggh)
+        raise "WarmStart#realize_warm!: donor has no " +
+              "llama.embedding_length key — not llama-family? (" +
+              donor_gguf_path + ")"
+      end
+      if donor_d != cfg.donor_d_in
+        TinyNN.tnn_gguf_free(ggh)
+        raise "WarmStart#realize_warm!: token_embd.weight width " +
+              "mismatch: expected donor_d_in=" + cfg.donor_d_in.to_s +
+              " (the width realize_scratch! sized the lens at) but " +
+              "donor llama.embedding_length=" + donor_d.to_s + " (" +
+              donor_gguf_path + ")"
+      end
+      te_idx = TinyNN.tnn_gguf_find_index(ggh, "token_embd.weight")
+      if te_idx < 0
+        TinyNN.tnn_gguf_free(ggh)
+        raise "WarmStart#realize_warm!: donor has no " +
+              "token_embd.weight tensor (" + donor_gguf_path + ")"
+      end
+      n_floats = cfg.vocab * donor_d
+      te_buf = Mat.new(1, n_floats)
+      rc = TinyNN.tnn_gguf_read_f32_to_doubles(ggh, te_idx,
+                                               te_buf.flat, n_floats)
+      if rc != 0
+        TinyNN.tnn_gguf_free(ggh)
+        raise "WarmStart#realize_warm!: token_embd.weight read failed " +
+              "rc=" + rc.to_s + " — wanted " + n_floats.to_s +
+              " floats (vocab " + cfg.vocab.to_s + " x donor_d " +
+              donor_d.to_s + ") from " + donor_gguf_path
+      end
+      upload_donor!(te_buf.flat, n_floats)
+      TinyNN.tnn_gguf_free(ggh)
+      nil
+    end
+
+    # The raw upload MECHANISM realize_warm! rides (and the seam for
+    # already-read buffers — e.g. the legacy PCA-lens flow): one
+    # tnn_upload_from_float_array into the realize'd token_embed table
+    # (mirrors 09 L180). Same window rules as realize_warm!. The PCA
+    # lens W_proj upload (09 L188-229) stays caller-side through
+    # @ws_cache.sess + the t_seq_w_proj delegator. Returns nil.
+    def upload_donor!(donor_buf_flat, n_floats)
       TinyNN.tnn_upload_from_float_array(@ws_cache.sess,
                                          @ws_cache.t_seq_token_embed,
                                          donor_buf_flat, n_floats)

--- a/lib/toy/llm/training_batch.rb
+++ b/lib/toy/llm/training_batch.rb
@@ -17,8 +17,12 @@
 # only shape every current graph accepts); fill! validates the sequence
 # (length == context, every id in 0...vocab) and rebuilds the labels
 # Mat via Toy::Labels.next_token — byte-identical to the hand loops it
-# replaces. hp stays a plain accessor: which AdamW convention applies
-# is the caller's choice (see the slot-5/6 finding in adamw.rb).
+# replaces. fill_fixed_target! (toy#73 item 3) is the second objective:
+# same sequence validation, labels target ONE fixed id at every
+# position (the lora-smoke shape). hp stays a plain accessor: which
+# AdamW convention applies is the caller's choice (see the slot-5/6
+# finding in adamw.rb). The image-classification sibling is
+# Toy::LLM::ClassifyBatch (classify_batch.rb).
 #
 # batch_size must be 1: batched training is deferred (the Labels
 # builders do not multiply batch into the row count — see labels.rb);
@@ -98,6 +102,31 @@ module Toy; module LLM
       end
       @seq_ids = new_seq_ids
       @labels  = Toy::Labels.next_token(new_seq_ids, @vocab, @context, @batch)
+      nil
+    end
+
+    # FIXED-TARGET objective (toy#73 item 3): validate the sequence the
+    # same way fill! does, but build labels where EVERY position
+    # targets `target_id` (the lora-smoke objective — push the whole
+    # prompt toward one token). Same loud guarantees: length mismatch,
+    # out-of-vocab id, and out-of-vocab target all raise (via
+    # Toy::Labels.fixed_target for the target). Returns nil.
+    def fill_fixed_target!(new_seq_ids, target_id)
+      if new_seq_ids.length != @context
+        raise "TrainingBatch#fill_fixed_target!: seq_ids length " +
+              new_seq_ids.length.to_s + " != context " + @context.to_s
+      end
+      k = 0
+      while k < @context
+        id = new_seq_ids[k]
+        if id < 0 || id >= @vocab
+          raise "TrainingBatch#fill_fixed_target!: seq_ids[" + k.to_s +
+                "] = " + id.to_s + " out of vocab 0..." + @vocab.to_s
+        end
+        k = k + 1
+      end
+      @seq_ids = new_seq_ids
+      @labels  = Toy::Labels.fixed_target(@vocab, @context, target_id)
       nil
     end
   end

--- a/prep/run_log_gate.rb
+++ b/prep/run_log_gate.rb
@@ -123,6 +123,45 @@ Dir.mktmpdir("toy_run_log_gate") do |root|
   end
 end
 
+# Toy::RunBundle round-trip (toy#73 item 1): run the compiled example 01
+# (which writes its bundle through Toy::RunBundle) twice with the same
+# RUN_ID and assert (a) RunLog parses the bundle, (b) the second run
+# REPLACED the first (tnn_events_open_trunc — no doubled events). Needs
+# the Spinel-built binary; SKIPs loudly when absent (CRuby-only envs).
+example_bin = File.expand_path("../examples/example_01_train_tiny", __dir__)
+if File.executable?(example_bin)
+  require "open3"
+  rt_id  = "run-log-gate-roundtrip"
+  rt_dir = File.expand_path("../runs/#{rt_id}", __dir__)
+  rt_env = { "RUN_ID" => rt_id, "STEPS" => "3" }
+  root   = File.expand_path("..", __dir__)
+  out1, st1 = Open3.capture2e(rt_env, example_bin, chdir: root)
+  out2, st2 = Open3.capture2e(rt_env, example_bin, chdir: root)
+  check("round-trip: example 01 (RunBundle) runs") do
+    unless st1.success? && st2.success?
+      puts out1 unless st1.success?
+      puts out2 unless st2.success?
+    end
+    st1.success? && st2.success?
+  end
+  check("round-trip: RunLog parses the RunBundle bundle") do
+    log = Toy::RunLog.open(rt_dir)
+    log.run_id == rt_id &&
+      log.config["schema"] == "toy/v1" &&
+      log.config["model"]["arch"] == "llama" &&
+      log.config["config"]["steps"] == 3 &&
+      log.loss_curve.length == 3 &&
+      log.final_loss.is_a?(Float)
+  end
+  check("round-trip: re-run TRUNCATES (3 steps, not 6)") do
+    Toy::RunLog.open(rt_dir).steps.length == 3
+  end
+  FileUtils.rm_rf(rt_dir)
+else
+  puts "  SKIP: examples/example_01_train_tiny not built — RunBundle " \
+       "round-trip not exercised (run `make example_01` first)"
+end
+
 # Integration sniff against real train-gate bundles, when present.
 repo_runs = File.expand_path("../runs", __dir__)
 if Dir.exist?(repo_runs) &&

--- a/prep/smokes/smoke_recipe_lora.rb
+++ b/prep/smokes/smoke_recipe_lora.rb
@@ -89,21 +89,22 @@ end
 # denominators 1/(1-beta^t) — NOT constant betas (see the loud finding in
 # lib/toy/llm/adamw.rb: the lora FFI graph reads slots 5/6 DIFFERENTLY
 # from the from-scratch/warm/vit graphs). lr comes from ENV (default
-# 0.001). m_hp is rebuilt per step below.
+# 0.001). hp_for_step (toy#73 item 5) is mode-aware: it takes the
+# 0-indexed loop step and applies lora's 1-indexed t internally —
+# hp_for_step(k) == hp(k + 1), byte-identical to 03_finetune_lora.rb's
+# inline 1/(1-beta^t) at t = k + 1.
 adamw = Toy::AdamW.for_lora   # beta2=0.999 + per-step bias correction
 adamw.lr = LR
 
 positions = [0, 1, 2, 3]
 
 losses = [0.0]; losses.pop
-step = 1
-while step <= STEPS
-  # 1-indexed step; bias_correct=true → slots5/6 = 1/(1-0.9^t),
-  # 1/(1-0.999^t). Byte-identical to 03_finetune_lora.rb:177-178.
-  m_hp = adamw.hp(step)
-  loss = recipe.step!(TOKENS, positions, m_labels, m_hp, step == 1)
+step = 0
+while step < STEPS
+  m_hp = adamw.hp_for_step(step)
+  loss = recipe.step!(TOKENS, positions, m_labels, m_hp, step == 0)
   losses.push(loss)
-  puts "step " + step.to_s + ": loss=" + loss.to_s
+  puts "step " + (step + 1).to_s + ": loss=" + loss.to_s
   step = step + 1
 end
 

--- a/sig/toy_compute.rbs
+++ b/sig/toy_compute.rbs
@@ -57,12 +57,16 @@ module Toy
     def hp_for_step: (Integer step) -> Mat
   end
 
-  # ---- Labels (lib/toy/llm/labels.rb) — shift-by-one one-hot builders ----
+  # ---- Labels (lib/toy/llm/labels.rb) — one-hot label builders -----------
   module Labels
     def self.next_token:         (Array[Integer] seq_ids, Integer vocab,
                                   Integer context, Integer batch) -> Mat
     def self.next_token_guarded: (Array[Integer] seq_ids, Integer vocab,
                                   Integer context, Integer batch) -> Mat
+    # toy#73 item 3 — the two non-shift-by-one objectives.
+    def self.fixed_target:  (Integer vocab, Integer context,
+                             Integer target_id) -> Mat
+    def self.one_hot_class: (Integer num_classes, Integer label) -> Mat
   end
 
   # ---- RunBundle (lib/toy/io/run_bundle.rb) — toy/v1 bundle writer -------
@@ -133,6 +137,27 @@ module Toy
 
       def initialize: (Integer vocab, Integer context, Integer batch_size) -> void
       def fill!: (Array[Integer] new_seq_ids) -> void
+      # toy#73 item 3 — fixed-target objective (every position targets
+      # target_id; the lora-smoke shape).
+      def fill_fixed_target!: (Array[Integer] new_seq_ids,
+                               Integer target_id) -> void
+    end
+
+    # ---- ClassifyBatch (lib/toy/llm/classify_batch.rb) -------------------
+    # Image-classification sibling of TrainingBatch (toy#73 item 3):
+    # validates one (patches, label) record per fill!.
+    class ClassifyBatch
+      attr_accessor cb_classes:    Integer
+      attr_accessor cb_patch_flat: Integer
+      attr_accessor cb_n_patches:  Integer
+      attr_accessor image:         Mat
+      attr_accessor cls_idx:       Array[Integer]
+      attr_accessor labels:        Mat
+      attr_accessor hp:            Mat
+
+      def initialize: (Integer num_classes, Integer patch_flat,
+                       Integer n_patches) -> void
+      def fill!: (Array[Float] patches, Integer label) -> void
     end
 
     # ======================================================================

--- a/sig/toy_compute.rbs
+++ b/sig/toy_compute.rbs
@@ -185,9 +185,14 @@ module Toy
         attr_accessor ws_step_index: Integer
 
         def initialize: () -> void
+        # The pre-realize half of the donor plumbing (toy#73 item 4):
+        # the width cfg.donor_d_in must carry before realize_scratch!.
+        def self.donor_embed_width: (String donor_gguf_path) -> Integer
         def realize_scratch!: (Toy::SmolLM2Config cfg, Toy::LLM::RecipeOptions opts) -> void
-        # donor_buf_flat is the ALREADY-READ flat donor embedding.
-        def realize_warm!: (Array[Float] donor_buf_flat, Integer n_floats) -> void
+        # Owns the donor GGUF read + dim-check + upload (toy#73 item 4).
+        def realize_warm!: (String donor_gguf_path, Toy::SmolLM2Config cfg) -> void
+        # The raw upload seam for ALREADY-READ buffers (PCA-lens flow).
+        def upload_donor!: (Array[Float] donor_buf_flat, Integer n_floats) -> void
         def build!: () -> void
         def step!: (Array[Integer] seq_ids, Array[Integer] positions,
                     Mat m_labels, Mat m_hp, bool is_first) -> Float

--- a/sig/toy_compute.rbs
+++ b/sig/toy_compute.rbs
@@ -52,6 +52,9 @@ module Toy
     # step is the caller's 1-indexed step; ignored when bias_correct
     # is false. Returns the Mat(1,7) handed to the recipes' step!.
     def hp: (Integer step) -> Mat
+    # Mode-aware builder: takes the 0-INDEXED loop step; applies lora's
+    # 1-indexed t internally (hp_for_step(k) == hp(k+1) in MODE_LORA).
+    def hp_for_step: (Integer step) -> Mat
   end
 
   # ---- Labels (lib/toy/llm/labels.rb) — shift-by-one one-hot builders ----

--- a/sig/toy_compute.rbs
+++ b/sig/toy_compute.rbs
@@ -62,6 +62,27 @@ module Toy
                                   Integer context, Integer batch) -> Mat
   end
 
+  # ---- RunBundle (lib/toy/io/run_bundle.rb) — toy/v1 bundle writer -------
+  # Truncate-opens runs/<id>/events.jsonl in the ctor; run_start!/step!/
+  # run_end! emit the toy/v1 events; weights_dir is the checkpoint home.
+  class RunBundle
+    attr_accessor rb_root:   String
+    attr_accessor rb_run_id: String
+    attr_accessor rb_dir:    String
+    attr_accessor rb_active: bool
+
+    def initialize: (String runs_root, String run_id) -> void
+    def active: () -> bool
+    def events_path: () -> String
+    def weights_dir: () -> String
+    def run_start!: (String arch, Integer vocab, Integer d_model,
+                     Integer n_layers, Integer context, Integer steps,
+                     Float lr, Integer seed) -> void
+    def step!: (Integer step, Float loss) -> void
+    def run_end!: (Integer final_step, Float final_loss) -> void
+    def self.json_escape: (String s) -> String
+  end
+
   # ---- Device (lib/toy/compute{,_cuda,_metal}.rb) ------------------------
   # The device-agnostic construction seam. ONLY `name` is declared:
   # the factory methods (llama_engine, gpt2_engine, from_scratch_recipe,

--- a/sig/toy_compute.rbs
+++ b/sig/toy_compute.rbs
@@ -376,3 +376,27 @@ module GGUFLoad
   def self.detect_smollm2_flags: (String path) -> GGUFLoad::SmolLM2Flags
   def self.detect_weight_type: (String path) -> Integer
 end
+
+# ============================================================================
+# Training I/O + LR schedule (toy#73 item 2) — folded into the compute
+# entries; top-level modules, ptr-free.
+# ============================================================================
+# ---- ToyLR (lib/toy/train/toy_lr_schedule.rb) ------------------------------
+module ToyLR
+  def self.cosine: (Integer step, Integer n_steps, Float lr_max,
+                    Float lr_min, Integer warmup_steps) -> Float
+  def self.constant: (Integer step, Float lr) -> Float
+end
+
+# ---- ToyCorpusLoader (lib/toy/io/toy_corpus_loader.rb) ---------------------
+module ToyCorpusLoader
+  def self.read_seq: (String path, Integer byte_offset,
+                      Integer n_tokens) -> Array[Integer]
+end
+
+# ---- ToyImageLoader (lib/toy/io/toy_image_loader.rb) -----------------------
+module ToyImageLoader
+  def self.read_image: (String images_path, Integer image_idx,
+                        Integer record_floats) -> Array[Float]
+  def self.read_label: (String labels_path, Integer image_idx) -> Integer
+end

--- a/tinynn/tinynn_events.c
+++ b/tinynn/tinynn_events.c
@@ -19,16 +19,24 @@ static double monotonic_seconds(void) {
     return (double)ts.tv_sec + (double)ts.tv_nsec / 1.0e9;
 }
 
-int tnn_events_open(const char *path) {
+static int events_open_mode(const char *path, const char *mode) {
     if (g_evt.out) return -1;
     if (!path)     return -2;
-    g_evt.out = fopen(path, "a");
+    g_evt.out = fopen(path, mode);
     if (!g_evt.out) return -3;
     /* Line-buffered so consumers tailing the file see new events
      * promptly — no waiting on a 4 KB stdio block boundary. */
     setvbuf(g_evt.out, NULL, _IOLBF, 0);
     g_evt.epoch_sec = monotonic_seconds();
     return 0;
+}
+
+int tnn_events_open(const char *path) {
+    return events_open_mode(path, "a");
+}
+
+int tnn_events_open_trunc(const char *path) {
+    return events_open_mode(path, "w");
 }
 
 void tnn_events_emit(const char *json_obj) {

--- a/tinynn/tinynn_events.h
+++ b/tinynn/tinynn_events.h
@@ -42,6 +42,12 @@ extern "C" {
  * on failure (-1 already open, -2 null path, -3 fopen failed). */
 int     tnn_events_open(const char *path);
 
+/* Same as tnn_events_open but TRUNCATES an existing file ("w" vs
+ * "a"). The fresh-bundle opener for re-runnable run dirs
+ * (Toy::RunBundle, toy#73): re-running with the same run_id replaces
+ * the bundle instead of doubling it. Same return codes as open. */
+int     tnn_events_open_trunc(const char *path);
+
 /* Append a single JSON event followed by `\n`. The string MUST be a
  * complete, well-formed JSON object — we do not validate. When the
  * file isn't open, this is a single load + branch (no-op). */


### PR DESCRIPTION
Implements all 5 ranked items of #73, one gated commit each. Byte-gates green after every item: train_gate x4 recipes, gate-compute-surface(+cuda), gate-run-log (incl. the new round-trip leg), gate-consumer, verify-mirrors; curated examples 01-07 all build + run.

## Items

1. **`Toy::RunBundle`** (069d2a8) — toy/v1 `run_start`/`step`/`run_end` writer for compiled consumers + `runs/<id>/weights/` checkpoint-dir convention. New FFI hook `tnn_events_open_trunc` (least-invasive: shared static opener in `tinynn_events.c`, `"w"` vs `"a"`), bound in all three HAND-maintained tinynn FFI twins in lockstep. RunBundle is SHARED (not mirrored) — the events C symbols live in `libtinynn_ggml.a`, which every backend links. `gate-run-log` round-trips: example 01 run twice with one RUN_ID → RunLog parses, re-run truncates (3 steps, not 6).
2. **toy/compute completeness** (c0964da) — `ToyCorpusLoader` + `ToyImageLoader` + `ToyLR` folded into all three compute entries (shared, no mirrors; per-backend engine/recipe gaps unchanged). Examples 02/03/07 drop the require dance for the one require (8→1, 6→1, 6→1). Compile time/size flat: ~45-60 s, ~1.7 MB per example — nothing exploded.
3. **TrainingBatch custom objectives** (e89cd10) — `Labels.fixed_target` + `Labels.one_hot_class`, `TrainingBatch#fill_fixed_target!` (setter form — same quartet, different labels), and the `Toy::LLM::ClassifyBatch` sibling for the ViT quartet (different shape entirely). A torn `labels.bin` (read_label's -1) now fails loud instead of training on an all-zero label row. Examples 03/07 ported, curves byte-identical.
4. **WarmStart donor plumbing** (725173c) — `realize_warm!(gguf, cfg)` owns open/dim-check/read/upload/free with NAMED loud errors (which tensor, expected vs got, which path; verified compiled: non-GGUF donor aborts nonzero). `WarmStart.donor_embed_width(path)` is the pre-realize half; `upload_donor!(buf, n)` keeps the raw seam (PCA-lens flow). Example 02 ported; warm-arm curve byte-identical.
5. **`AdamW#hp_for_step(step)`** (bb9a229) — mode-aware: takes the 0-indexed loop step, applies lora's 1-indexed `1/(1-beta^t)` internally (`hp_for_step(k) == hp(k+1)` in lora mode, provably byte-identical). Example 03's 1-indexed-loop-for-hp ceremony gone; examples 01/02/07 + smoke_recipe_lora ported uniformly. The #64 mode guard stays (both arms delegate to `hp`). Byte-gated lora runners keep raw `hp(step)` (their 1-indexed stdout is the gate).

## The cuteness metric (example line counts)

| example | before | after | Δ |
|---|---|---|---|
| 01_train_tiny | 151 | 123 | −28 |
| 02_finetune_warm_start | 152 | 124 | −28 |
| 03_lora | 127 | 110 | −17 |
| 07_vit_tiny | 128 | 115 | −13 |

`sig/toy_compute.rbs` updated in lockstep with every added/changed signature (exact arity). docs/events.md documents the truncate-open producer path.

Part of #58; closes #73.

🤖 Generated with [Claude Code](https://claude.com/claude-code)