### PR TITLE
toy#73 A.3 polish seeds — ViTTinyConfig.tiny, RunBundle provenance, per-arch run_start, lora hp_for_step

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -840,7 +840,7 @@ example_06:
 .PHONY: example_06
 
 # 07 — ViT-Tiny on the committed data/vit_smoke corpus via Recipes::VitTiny.
-examples/example_07_vit_tiny: examples/07_vit_tiny.rb lib/toy/compute.rb lib/toy/llm/engine/vit_tiny_engine.rb lib/toy/llm/recipes/vit_tiny.rb lib/toy/models/toy_vit.rb lib/toy/io/toy_image_loader.rb lib/toy/train/toy_lr_schedule.rb lib/toy/llm/adamw.rb lib/toy/llm/labels.rb lib/toy/llm/classify_batch.rb lib/toy/llm/recipe_options.rb lib/toy/ffi/tinynn.rb tinynn/libtinynn_ggml.a $(SPINEL_DEPS)
+examples/example_07_vit_tiny: examples/07_vit_tiny.rb lib/toy/compute.rb lib/toy/llm/engine/vit_tiny_engine.rb lib/toy/llm/recipes/vit_tiny.rb lib/toy/models/toy_vit.rb lib/toy/io/toy_image_loader.rb lib/toy/io/run_bundle.rb lib/toy/train/toy_lr_schedule.rb lib/toy/llm/adamw.rb lib/toy/llm/labels.rb lib/toy/llm/classify_batch.rb lib/toy/llm/recipe_options.rb lib/toy/ffi/tinynn.rb tinynn/libtinynn_ggml.a $(SPINEL_DEPS)
 	$(SPINEL) $< -o $@
 example_07: examples/example_07_vit_tiny
 .PHONY: example_07

--- a/docs/events.md
+++ b/docs/events.md
@@ -353,6 +353,11 @@ should not hand-roll the stream at all: `Toy::RunBundle`
 `events.jsonl` via `tnn_events_open_trunc` (truncate, not append), so
 re-running with the same run id replaces the bundle instead of doubling
 it; `weights_dir` returns the `runs/<id>/weights/` checkpoint home.
+Provenance (toy#73 A.3): `run_start` stamps `backend{kind}`
+automatically (`Toy::Device.name` — compile-time known); `git{sha,branch}`
+is opt-in via `bundle.git!(sha, branch)` before `run_start!` (RunBundle
+stays vendor-free, so it cannot require `SpinelKit::Git` itself — the
+file header documents the dual-layout require constraint).
 
 ## Producer guarantees
 

--- a/examples/01_train_tiny.rb
+++ b/examples/01_train_tiny.rb
@@ -79,8 +79,7 @@ adamw.lr = LR
 # Toy::RunBundle owns the dirs + the JSON + the sink, and TRUNCATES on
 # open, so a re-run with the same RUN_ID replaces the bundle.
 bundle = Toy::RunBundle.new("runs", RUN_ID)
-bundle.run_start!("llama", cfg.vocab, cfg.d_model, cfg.n_layers,
-                  cfg.ctx, STEPS, LR, SEED)
+bundle.run_start_llama!(cfg, STEPS, LR, SEED)
 
 # Train: stream context-sized windows off the corpus, one step each.
 first_loss  = 0.0

--- a/examples/07_vit_tiny.rb
+++ b/examples/07_vit_tiny.rb
@@ -20,6 +20,7 @@
 #   IMG_DIR=…     your own corpus (prep/preprocess_images.py writes one)
 #
 # THE API — Toy::LLM::Recipes::VitTiny:
+#   ViTTinyConfig.tiny                 — the model shape (no 9-arg soup)
 #   realize!(cfg, opts)                — random-init ViT + training graph
 #   step!(m_image, cls_idx, m_labels, m_hp, is_first)
 # The per-step inputs are an image Mat ([patch_flat x n_patches]) and a
@@ -32,21 +33,14 @@ STEPS   = (ENV["STEPS"] || "20").to_i
 SEED    = (ENV["SEED"]  || "0").to_i
 IMG_DIR = ENV["IMG_DIR"] || "data/vit_smoke"
 
-# The timm ViT-Tiny shape data/vit_smoke matches (224/16 -> 196 patches).
-IMAGE_SIZE  = 224
-PATCH_SIZE  = 16
-NUM_CHAN    = 3
-D_MODEL     = 192
-N_HEADS     = 3
-D_FF        = 768
-N_LAYERS    = 12
-NUM_CLASSES = 10
-
-cfg = ViTTinyConfig.new(IMAGE_SIZE, PATCH_SIZE, NUM_CHAN, D_MODEL,
-                        N_HEADS, D_FF, N_LAYERS, NUM_CLASSES, 1.0e-5)
-puts "model: image=" + IMAGE_SIZE.to_s + " patch=" + PATCH_SIZE.to_s +
-     " d=" + D_MODEL.to_s + " heads=" + N_HEADS.to_s +
-     " L=" + N_LAYERS.to_s + " classes=" + NUM_CLASSES.to_s
+# The timm ViT-Tiny shape data/vit_smoke matches (224/16 -> 196
+# patches): image 224, patch 16, 3 channels, d=192, 3 heads, d_ff 768,
+# 12 layers, 10 classes — the same factory pattern as 01's
+# SmolLM2Config.tiny.
+cfg = ViTTinyConfig.tiny
+puts "model: image=" + cfg.image_size.to_s + " patch=" + cfg.patch_size.to_s +
+     " d=" + cfg.d_model.to_s + " heads=" + cfg.n_heads.to_s +
+     " L=" + cfg.n_layers.to_s + " classes=" + cfg.num_classes.to_s
 
 opts = Toy::LLM::RecipeOptions.new
 opts.seed = SEED          # the ViT path consumes seed + init_scale only
@@ -59,8 +53,8 @@ recipe.realize!(cfg, opts)
 # a short read would otherwise silently train on zeros (never-mask).
 images_path = IMG_DIR + "/images.bin"
 labels_path = IMG_DIR + "/labels.bin"
-n_patches   = (IMAGE_SIZE / PATCH_SIZE) * (IMAGE_SIZE / PATCH_SIZE)
-patch_flat  = NUM_CHAN * PATCH_SIZE * PATCH_SIZE
+n_patches   = (cfg.image_size / cfg.patch_size) * (cfg.image_size / cfg.patch_size)
+patch_flat  = cfg.num_channels * cfg.patch_size * cfg.patch_size
 record_f    = patch_flat * n_patches
 if !File.exist?(images_path) || !File.exist?(labels_path)
   puts "07_vit_tiny: corpus missing under " + IMG_DIR +
@@ -80,7 +74,7 @@ end
 # The validating batch (the ClassifyBatch sibling of 01's
 # TrainingBatch): fill! checks the record length + label range and
 # rebuilds the image Mat + one-hot labels — a torn corpus fails loud.
-batch = Toy::LLM::ClassifyBatch.new(NUM_CLASSES, patch_flat, n_patches)
+batch = Toy::LLM::ClassifyBatch.new(cfg.num_classes, patch_flat, n_patches)
 adamw = Toy::AdamW.for_from_scratch
 
 first_loss = 0.0

--- a/examples/07_vit_tiny.rb
+++ b/examples/07_vit_tiny.rb
@@ -18,6 +18,7 @@
 #   STEPS=50      watch it actually memorize (loss -> ~0)
 #   SEED=1        a different random init
 #   IMG_DIR=…     your own corpus (prep/preprocess_images.py writes one)
+#   RUN_ID=vit-a  label the runs/<RUN_ID>/ bundle (for 06's table)
 #
 # THE API — Toy::LLM::Recipes::VitTiny:
 #   ViTTinyConfig.tiny                 — the model shape (no 9-arg soup)
@@ -25,13 +26,23 @@
 #   step!(m_image, cls_idx, m_labels, m_hp, is_first)
 # The per-step inputs are an image Mat ([patch_flat x n_patches]) and a
 # one-hot class label — where the LLM recipes take token ids and
-# shift-by-one labels. No CLI surface for ViT yet; this file is it.
+# shift-by-one labels. The run bundle rides Toy::RunBundle like 01's —
+# run_start_vit! reads the model{} block straight off the cfg (a ViT
+# has no vocab/context to feed the llama-shaped run_start!). No CLI
+# surface for ViT yet; this file is it.
 
 require_relative "../lib/toy/compute"
 
 STEPS   = (ENV["STEPS"] || "20").to_i
 SEED    = (ENV["SEED"]  || "0").to_i
 IMG_DIR = ENV["IMG_DIR"] || "data/vit_smoke"
+RUN_ID  = ENV["RUN_ID"] || "example-07-vit"
+
+# The cosine LR schedule (max, min, warmup steps) — shared between the
+# per-step ToyLR.cosine call and the run_start config{} echo.
+LR_MAX = 0.003
+LR_MIN = 0.0001
+WARMUP = 10
 
 # The timm ViT-Tiny shape data/vit_smoke matches (224/16 -> 196
 # patches): image 224, patch 16, 3 channels, d=192, 3 heads, d_ff 768,
@@ -77,11 +88,16 @@ end
 batch = Toy::LLM::ClassifyBatch.new(cfg.num_classes, patch_flat, n_patches)
 adamw = Toy::AdamW.for_from_scratch
 
+# Run bundle, the ViT way: same runs/<RUN_ID>/events.jsonl as 01, but
+# run_start_vit! stamps the image shape (no vocab/context slots to fake).
+bundle = Toy::RunBundle.new("runs", RUN_ID)
+bundle.run_start_vit!(cfg, STEPS, LR_MAX, SEED)
+
 first_loss = 0.0
 final_loss = 0.0
 step = 0
 while step < STEPS
-  adamw.lr = ToyLR.cosine(step, STEPS, 0.003, 0.0001, 10)
+  adamw.lr = ToyLR.cosine(step, STEPS, LR_MAX, LR_MIN, WARMUP)
 
   # One image per step (the smoke corpus has a single record; a real
   # corpus would advance the index).
@@ -96,12 +112,19 @@ while step < STEPS
   end
   final_loss = loss
   puts "step " + (step + 1).to_s + ": loss=" + loss.to_s
+  bundle.step!(step + 1, loss)
   step = step + 1
 end
+
+wrote_bundle = bundle.active
+bundle.run_end!(STEPS, final_loss)
 
 puts ""
 puts "vit-tiny: " + STEPS.to_s + " steps, loss " + first_loss.to_s +
      " -> " + final_loss.to_s
+if wrote_bundle
+  puts "bundle: " + bundle.events_path + "  (toy/v1 events)"
+end
 if final_loss < first_loss
   puts "VERDICT: learning"
 else

--- a/lib/toy/compute.rb
+++ b/lib/toy/compute.rb
@@ -81,11 +81,6 @@ require_relative "llm/labels"
 require_relative "llm/training_batch"
 require_relative "llm/classify_batch"
 
-# Run-bundle writer (toy#73 item 1): runs/<id>/events.jsonl in the toy/v1
-# schema + the weights/ checkpoint-dir convention. SHARED (not mirrored):
-# the events C symbols live in libtinynn_ggml.a, linked by every backend.
-require_relative "io/run_bundle"
-
 # ── Toy::Device — the device-agnostic construction seam (toy#64 item 8) ──
 #
 # DEVICE IS CHOSEN AT COMPILE TIME by which compute entry you require:
@@ -130,3 +125,11 @@ module Toy
     end
   end
 end
+
+# Run-bundle writer (toy#73 item 1): runs/<id>/events.jsonl in the toy/v1
+# schema + the weights/ checkpoint-dir convention. SHARED (not mirrored):
+# the events C symbols live in libtinynn_ggml.a, linked by every backend.
+# Required AFTER the Toy::Device module above — run_start! stamps
+# backend{kind: Toy::Device.name} (toy#73 A.3), and Spinel needs the
+# constant defined before a file referencing it compiles.
+require_relative "io/run_bundle"

--- a/lib/toy/compute_cuda.rb
+++ b/lib/toy/compute_cuda.rb
@@ -69,13 +69,6 @@ require_relative "llm/labels"
 require_relative "llm/training_batch"
 require_relative "llm/classify_batch"
 
-# Run-bundle writer (toy#73 item 1): runs/<id>/events.jsonl in the toy/v1
-# schema + the weights/ checkpoint-dir convention. SHARED (not mirrored):
-# the events C symbols live in libtinynn_ggml.a, linked by every backend
-# (the CPU TinyNN module is defined in this binary too — see the
-# checkpoint-seam note above).
-require_relative "io/run_bundle"
-
 # ── Toy::Device, CUDA arm — see the compute.rb doc block. Same
 # surface, CUDA types; user source stays device-agnostic.
 module Toy
@@ -101,3 +94,11 @@ module Toy
     end
   end
 end
+
+# Run-bundle writer (toy#73 item 1): runs/<id>/events.jsonl in the toy/v1
+# schema + the weights/ checkpoint-dir convention. SHARED (not mirrored):
+# the events C symbols live in libtinynn_ggml.a, linked by every backend
+# (the CPU TinyNN module is defined in this binary too — see the
+# checkpoint-seam note above). Required AFTER the Toy::Device module —
+# run_start! stamps backend{kind: Toy::Device.name} (toy#73 A.3).
+require_relative "io/run_bundle"

--- a/lib/toy/compute_metal.rb
+++ b/lib/toy/compute_metal.rb
@@ -64,13 +64,6 @@ require_relative "llm/labels"
 require_relative "llm/training_batch"
 require_relative "llm/classify_batch"
 
-# Run-bundle writer (toy#73 item 1): runs/<id>/events.jsonl in the toy/v1
-# schema + the weights/ checkpoint-dir convention. SHARED (not mirrored):
-# the events C symbols live in libtinynn_ggml.a, linked by every backend
-# (the CPU TinyNN module is defined in this binary too — see the
-# checkpoint-seam note above).
-require_relative "io/run_bundle"
-
 # ── Toy::Device, Metal arm — see the compute.rb doc block. NOTE: no
 # warm_start_recipe here (no Metal recipe exists); a device-agnostic
 # body that uses it will fail to compile against this entry — loudly,
@@ -94,3 +87,11 @@ module Toy
     end
   end
 end
+
+# Run-bundle writer (toy#73 item 1): runs/<id>/events.jsonl in the toy/v1
+# schema + the weights/ checkpoint-dir convention. SHARED (not mirrored):
+# the events C symbols live in libtinynn_ggml.a, linked by every backend
+# (the CPU TinyNN module is defined in this binary too — see the
+# checkpoint-seam note above). Required AFTER the Toy::Device module —
+# run_start! stamps backend{kind: Toy::Device.name} (toy#73 A.3).
+require_relative "io/run_bundle"

--- a/lib/toy/io/run_bundle.rb
+++ b/lib/toy/io/run_bundle.rb
@@ -151,11 +151,58 @@ module Toy
       s
     end
 
+    # PER-ARCH STARTS (toy#73 A.3 seed a). The generic run_start! below
+    # is llama-shaped — 8 positionals whose vocab/context slots a ViT
+    # consumer has nothing to put in. These two read the model{} block
+    # straight off the config object instead (NO default args —
+    # landmine #4; one method per arch, not a poly cfg param).
+
+    # run_start for a llama-shaped run: model{} + config{} come from
+    # the Toy::SmolLM2Config. Byte-identical to
+    # run_start!("llama", cfg.vocab, cfg.d_model, cfg.n_layers,
+    # cfg.ctx, steps, lr, seed). Returns nil.
+    def run_start_llama!(lcfg, steps, lr, seed)
+      if @rb_active
+        TinyNN.tnn_events_emit(run_start_prefix +
+          ",\"model\":{\"arch\":\"llama\"" +
+          ",\"vocab\":" + lcfg.vocab.to_s +
+          ",\"d_model\":" + lcfg.d_model.to_s +
+          ",\"n_layers\":" + lcfg.n_layers.to_s + "}" +
+          ",\"config\":{\"context\":" + lcfg.ctx.to_s +
+          ",\"steps\":" + steps.to_s +
+          ",\"lr\":" + lr.to_s +
+          ",\"seed\":" + seed.to_s + "}}")
+      end
+      nil
+    end
+
+    # run_start for a ViT run: model{} carries the image shape
+    # (image_size/patch_size/d_model/n_layers/num_classes from the
+    # ViTTinyConfig) and config{} drops the token-context key (a ViT
+    # has none — the patch count derives from the model block).
+    # Returns nil.
+    def run_start_vit!(vcfg, steps, lr, seed)
+      if @rb_active
+        TinyNN.tnn_events_emit(run_start_prefix +
+          ",\"model\":{\"arch\":\"vit\"" +
+          ",\"image_size\":" + vcfg.image_size.to_s +
+          ",\"patch_size\":" + vcfg.patch_size.to_s +
+          ",\"d_model\":" + vcfg.d_model.to_s +
+          ",\"n_layers\":" + vcfg.n_layers.to_s +
+          ",\"num_classes\":" + vcfg.num_classes.to_s + "}" +
+          ",\"config\":{\"steps\":" + steps.to_s +
+          ",\"lr\":" + lr.to_s +
+          ",\"seed\":" + seed.to_s + "}}")
+      end
+      nil
+    end
+
     # Emit the toy/v1 run_start (exactly one per bundle, first):
     # schema + t + started_at + run_id + phase:"train" + host{} +
     # backend{} + [git{} if injected] + model{arch,vocab,d_model,
     # n_layers} + config{context,steps,lr,seed}.
-    # arch is e.g. "llama" / "gpt2" / "vit". Returns nil.
+    # arch is e.g. "llama" / "gpt2" / "vit"; for llama/vit configs the
+    # per-arch starts above read these fields off the cfg for you.
     def run_start!(arch, vocab, d_model, n_layers, context, steps, lr, seed)
       if @rb_active
         TinyNN.tnn_events_emit(run_start_prefix +

--- a/lib/toy/io/run_bundle.rb
+++ b/lib/toy/io/run_bundle.rb
@@ -13,13 +13,37 @@
 #   bundle.run_end!(STEPS, final_loss)            # emits run_end + closes
 #
 # The stream is the toy/v1 schema (docs/events.md): run_start carries
-# kind/schema/t/started_at/run_id/phase/host{}/model{}/config{}, step
-# carries kind/phase/t/step/loss, run_end carries kind/t/ended_at/
-# reason/final_step/final_loss/exit_code — the same shape the train
-# runners emit (lib/toy/run/train.rb), minus the runner-only extras
-# (backend{}, git{}, lr/tokens/wall_us — all v1-optional keys; the
+# kind/schema/t/started_at/run_id/phase/host{}/backend{}/[git{}/]
+# model{}/config{}, step carries kind/phase/t/step/loss, run_end
+# carries kind/t/ended_at/reason/final_step/final_loss/exit_code — the
+# same shape the train runners emit (lib/toy/run/train.rb), minus the
+# per-step runner extras (lr/tokens/wall_us — v1-optional keys; the
 # schema is open, consumers ignore absences). Toy::RunLog reads the
 # result back (round-tripped in prep/run_log_gate.rb).
+#
+# PROVENANCE (toy#73 A.3 seed b):
+#   backend{kind} — AUTOMATIC. The device is compile-time known (you
+#     picked it by requiring compute.rb / compute_cuda.rb /
+#     compute_metal.rb), so run_start! stamps Toy::Device.name itself.
+#     This is why the compute entries require this file AFTER defining
+#     Toy::Device — Spinel needs the constant defined before a file
+#     that references it compiles.
+#   git{sha,branch} — OPT-IN via git!(sha, branch) before run_start!.
+#     It CANNOT be automatic: the reader lives in SpinelKit::Git
+#     (vendor/spinel/spinel_kit/, toy#44), and a require_relative from
+#     here cannot name it in both layouts this file ships in — in the
+#     toy repo it sits at ../../../vendor/spinel/spinel_kit/... (and
+#     only exists after `make vendor-tep`, which gates on sibling
+#     checkouts — a fresh clone must still compile example 01), while
+#     vendored into a consumer (`toy new --lib`) this file lives at
+#     vendor/spinel/toy/lib/toy/io/ and the gem sits at
+#     ../../../../spinel_kit/... — a DIFFERENT depth, and Spinel
+#     compiles a conditional require_relative to 0 (silently — see the
+#     compute.rb header). So callers that DO load SpinelKit::Git (the
+#     runners' pattern, by path) inject the two strings:
+#       gp = SpinelKit::Git.read
+#       bundle.git!(gp.sha, gp.branch)
+#     Un-injected bundles simply omit git{} (v1-optional key).
 #
 # FRESH-BUNDLE SEMANTICS: the ctor opens events.jsonl via
 # tnn_events_open_trunc (toy#73's new FFI hook) — a re-run with the
@@ -52,17 +76,20 @@
 
 module Toy
   class RunBundle
-    attr_accessor :rb_root, :rb_run_id, :rb_dir, :rb_active
+    attr_accessor :rb_root, :rb_run_id, :rb_dir, :rb_active,
+                  :rb_git_sha, :rb_git_branch
 
     # Create runs_root/ and runs_root/run_id/, then TRUNCATE-open the
     # events.jsonl sink. On open failure (rc != 0) warns loud with the
     # rc + path and continues with events disabled (active == false) —
     # compute must not die because a bundle dir is unwritable.
     def initialize(runs_root, run_id)
-      @rb_root   = runs_root
-      @rb_run_id = run_id
-      @rb_dir    = runs_root + "/" + run_id
-      @rb_active = false
+      @rb_root       = runs_root
+      @rb_run_id     = run_id
+      @rb_dir        = runs_root + "/" + run_id
+      @rb_active     = false
+      @rb_git_sha    = ""   # empty = git{} omitted from run_start
+      @rb_git_branch = ""
       TinyNN.tnn_filesystem_mkdir(runs_root)
       TinyNN.tnn_filesystem_mkdir(@rb_dir)
       rc = TinyNN.tnn_events_open_trunc(@rb_dir + "/events.jsonl")
@@ -91,13 +118,23 @@ module Toy
       d
     end
 
-    # Emit the toy/v1 run_start (exactly one per bundle, first):
-    # schema + t + started_at + run_id + phase:"train" + host{} +
-    # model{arch,vocab,d_model,n_layers} + config{context,steps,lr,seed}.
-    # arch is e.g. "llama" / "gpt2" / "vit". Returns nil.
-    def run_start!(arch, vocab, d_model, n_layers, context, steps, lr, seed)
-      if @rb_active
-        TinyNN.tnn_events_emit("{\"kind\":\"run_start\",\"schema\":\"toy/v1\"" +
+    # OPT-IN git provenance (see the header — it cannot be automatic).
+    # Call BEFORE run_start! with the two strings from SpinelKit::Git
+    # (or any sha/branch pair); run_start! then includes
+    # git{sha,branch} after backend{}. Returns nil.
+    def git!(sha, branch)
+      @rb_git_sha    = sha
+      @rb_git_branch = branch
+      nil
+    end
+
+    # The shared run_start prefix: kind/schema/t/started_at/run_id/
+    # phase:"train" + host{} + backend{kind: Toy::Device.name} +
+    # git{} when injected via git! — the same key order as the train
+    # runners' Toy::Events.add_provenance. Callers append model{} +
+    # config{} and emit.
+    def run_start_prefix
+      s = "{\"kind\":\"run_start\",\"schema\":\"toy/v1\"" +
           ",\"t\":" + TinyNN.tnn_events_now_seconds.to_s +
           ",\"started_at\":\"" + TinyNN.tnn_events_iso8601_now + "\"" +
           ",\"run_id\":\"" + RunBundle.json_escape(@rb_run_id) + "\"" +
@@ -106,6 +143,22 @@ module Toy
             RunBundle.json_escape(TinyNN.tnn_provenance_host_name) +
           "\",\"os\":\"" + TinyNN.tnn_provenance_host_os +
           "\",\"arch\":\"" + TinyNN.tnn_provenance_host_arch + "\"}" +
+          ",\"backend\":{\"kind\":\"" + Toy::Device.name + "\"}"
+      if @rb_git_sha.length > 0
+        s = s + ",\"git\":{\"sha\":\"" + RunBundle.json_escape(@rb_git_sha) +
+            "\",\"branch\":\"" + RunBundle.json_escape(@rb_git_branch) + "\"}"
+      end
+      s
+    end
+
+    # Emit the toy/v1 run_start (exactly one per bundle, first):
+    # schema + t + started_at + run_id + phase:"train" + host{} +
+    # backend{} + [git{} if injected] + model{arch,vocab,d_model,
+    # n_layers} + config{context,steps,lr,seed}.
+    # arch is e.g. "llama" / "gpt2" / "vit". Returns nil.
+    def run_start!(arch, vocab, d_model, n_layers, context, steps, lr, seed)
+      if @rb_active
+        TinyNN.tnn_events_emit(run_start_prefix +
           ",\"model\":{\"arch\":\"" + RunBundle.json_escape(arch) + "\"" +
           ",\"vocab\":" + vocab.to_s +
           ",\"d_model\":" + d_model.to_s +

--- a/lib/toy/models/toy_vit.rb
+++ b/lib/toy/models/toy_vit.rb
@@ -35,6 +35,19 @@ class ViTTinyConfig
     @num_classes  = num_classes
     @ln_eps       = ln_eps
   end
+
+  # The canonical ViT-Tiny shape (toy#73 A.3) — timm
+  # vit_tiny_patch16_224 with the 10-class smoke head: image 224,
+  # patch 16 (→ 196 patches), 3 channels, d=192, 3 heads (d_head 64
+  # derives in initialize), d_ff 768, 12 layers, ln_eps 1e-5. This is
+  # the exact shape example 07 / lib/toy/run/train_vit.rb train and
+  # the one data/vit_smoke is preprocessed for. Additive sugar over
+  # .new — byte-identical to the equivalent 9-positional call. (The
+  # vit smoke's 16/4/64-dim block is a DIFFERENT, env-driven shape —
+  # it stays on .new.)
+  def self.tiny
+    ViTTinyConfig.new(224, 16, 3, 192, 3, 768, 12, 10, 1.0e-5)
+  end
 end
 
 module ToyVit

--- a/lib/toy/run/train_lora.rb
+++ b/lib/toy/run/train_lora.rb
@@ -153,18 +153,21 @@ if EVENTS.length > 0
   end
 end
 
-# --- Training loop (1-indexed; per-step bias-corrected hp). ---
+# --- Training loop (0-indexed like every other recipe loop; hp_for_step
+# applies the lora 1-indexed bias-correction convention internally —
+# hp_for_step(k) == hp(k + 1) byte-for-byte, so the gated stdout is
+# unchanged; toy#73 A.3 seed d retired the last raw-hp(step) callers). ---
 final_loss = 0.0
-step = 1
-while step <= STEPS
+step = 0
+while step < STEPS
   step_wall_start = TinyNN.tnn_events_now_seconds
-  # 1-indexed step; bias_correct=true → slots 5/6 = 1/(1-0.9^t),
-  # 1/(1-0.999^t). Byte-identical to the historical inline `** step.to_f`.
-  m_hp = adamw_lora.hp(step)
-  loss = recipe_lora.step!(TOKENS, positions, m_labels, m_hp, step == 1)
+  # bias_correct=true → slots 5/6 = 1/(1-0.9^t), 1/(1-0.999^t) at
+  # t = step + 1. Byte-identical to the historical inline `** t.to_f`.
+  m_hp = adamw_lora.hp_for_step(step)
+  loss = recipe_lora.step!(TOKENS, positions, m_labels, m_hp, step == 0)
   final_loss = loss
-  # The byte-gated line — to STDOUT.
-  puts "step " + step.to_s + ": loss=" + loss.to_s
+  # The byte-gated line — to STDOUT (1-indexed, as recorded).
+  puts "step " + (step + 1).to_s + ": loss=" + loss.to_s
 
   if EVENTS.length > 0
     step_wall_us = ((TinyNN.tnn_events_now_seconds - step_wall_start) * 1.0e6).to_i
@@ -172,7 +175,7 @@ while step <= STEPS
     es.add_str("kind",  "step")
     es.add_str("phase", "train")
     es.add_num("t",       TinyNN.tnn_events_now_seconds)
-    es.add_num("step",    step)
+    es.add_num("step",    step + 1)
     es.add_num("loss",    loss)
     es.add_raw("lr",      "0.001")
     es.add_num("tokens",  TOKENS.length)

--- a/lib/toy/run/train_lora_cuda.rb
+++ b/lib/toy/run/train_lora_cuda.rb
@@ -162,18 +162,21 @@ if EVENTS.length > 0
   end
 end
 
-# --- Training loop (1-indexed; per-step bias-corrected hp). ---
+# --- Training loop (0-indexed like every other recipe loop; hp_for_step
+# applies the lora 1-indexed bias-correction convention internally —
+# hp_for_step(k) == hp(k + 1) byte-for-byte, so the gated stdout is
+# unchanged; toy#73 A.3 seed d retired the last raw-hp(step) callers). ---
 final_loss = 0.0
-step = 1
-while step <= STEPS
+step = 0
+while step < STEPS
   step_wall_start = TinyNNCuda.tnn_events_now_seconds
-  # 1-indexed step; bias_correct=true → slots 5/6 = 1/(1-0.9^t),
-  # 1/(1-0.999^t). Byte-identical to the historical inline `** step.to_f`.
-  m_hp = adamw_lora.hp(step)
-  loss = recipe_lora.step!(TOKENS, positions, m_labels, m_hp, step == 1)
+  # bias_correct=true → slots 5/6 = 1/(1-0.9^t), 1/(1-0.999^t) at
+  # t = step + 1. Byte-identical to the historical inline `** t.to_f`.
+  m_hp = adamw_lora.hp_for_step(step)
+  loss = recipe_lora.step!(TOKENS, positions, m_labels, m_hp, step == 0)
   final_loss = loss
-  # The byte-gated line — to STDOUT.
-  puts "step " + step.to_s + ": loss=" + loss.to_s
+  # The byte-gated line — to STDOUT (1-indexed, as recorded).
+  puts "step " + (step + 1).to_s + ": loss=" + loss.to_s
 
   if EVENTS.length > 0
     step_wall_us = ((TinyNNCuda.tnn_events_now_seconds - step_wall_start) * 1.0e6).to_i
@@ -181,7 +184,7 @@ while step <= STEPS
     es.add_str("kind",  "step")
     es.add_str("phase", "train")
     es.add_num("t",       TinyNNCuda.tnn_events_now_seconds)
-    es.add_num("step",    step)
+    es.add_num("step",    step + 1)
     es.add_num("loss",    loss)
     es.add_raw("lr",      "0.001")
     es.add_num("tokens",  TOKENS.length)

--- a/prep/run_log_gate.rb
+++ b/prep/run_log_gate.rb
@@ -170,6 +170,41 @@ else
        "round-trip not exercised (run `make example_01` first)"
 end
 
+# Per-arch run_start round-trip (toy#73 A.3): example 07 writes its
+# bundle through run_start_vit! — the model{} block is the image shape,
+# config{} has no context key. SKIPs loudly when the binary is absent.
+vit_bin = File.expand_path("../examples/example_07_vit_tiny", __dir__)
+if File.executable?(vit_bin)
+  require "open3"
+  vt_id  = "run-log-gate-vit"
+  vt_dir = File.expand_path("../runs/#{vt_id}", __dir__)
+  vt_env = { "RUN_ID" => vt_id, "STEPS" => "2" }
+  vt_root = File.expand_path("..", __dir__)
+  vt_out, vt_st = Open3.capture2e(vt_env, vit_bin, chdir: vt_root)
+  check("vit round-trip: example 07 (run_start_vit!) runs") do
+    puts vt_out unless vt_st.success?
+    vt_st.success?
+  end
+  check("vit round-trip: RunLog parses the ViT-shaped run_start") do
+    vlog = Toy::RunLog.open(vt_dir)
+    vlog.run_id == vt_id &&
+      vlog.config["schema"] == "toy/v1" &&
+      vlog.config["backend"]["kind"] == "cpu" &&
+      vlog.config["model"]["arch"] == "vit" &&
+      vlog.config["model"]["image_size"] == 224 &&
+      vlog.config["model"]["patch_size"] == 16 &&
+      vlog.config["model"]["num_classes"] == 10 &&
+      !vlog.config["config"].key?("context") &&
+      vlog.config["config"]["steps"] == 2 &&
+      vlog.loss_curve.length == 2 &&
+      vlog.final_loss.is_a?(Float)
+  end
+  FileUtils.rm_rf(vt_dir)
+else
+  puts "  SKIP: examples/example_07_vit_tiny not built — per-arch " \
+       "run_start_vit! round-trip not exercised (run `make example_07` first)"
+end
+
 # Integration sniff against real train-gate bundles, when present.
 repo_runs = File.expand_path("../runs", __dir__)
 if Dir.exist?(repo_runs) &&

--- a/prep/run_log_gate.rb
+++ b/prep/run_log_gate.rb
@@ -153,6 +153,14 @@ if File.executable?(example_bin)
       log.loss_curve.length == 3 &&
       log.final_loss.is_a?(Float)
   end
+  check("round-trip: run_start stamps backend{kind} (toy#73 A.3)") do
+    # example 01 is the CPU compute entry → Toy::Device.name == "cpu".
+    # git{} is opt-in (bundle.git! — example 01 stays vendor-free) so
+    # its absence here is the documented default.
+    cfgev = Toy::RunLog.open(rt_dir).config
+    cfgev["backend"].is_a?(Hash) && cfgev["backend"]["kind"] == "cpu" &&
+      !cfgev.key?("git")
+  end
   check("round-trip: re-run TRUNCATES (3 steps, not 6)") do
     Toy::RunLog.open(rt_dir).steps.length == 3
   end

--- a/sig/toy_compute.rbs
+++ b/sig/toy_compute.rbs
@@ -335,6 +335,9 @@ class ViTTinyConfig
                    Integer num_channels, Integer d_model, Integer n_heads,
                    Integer d_ff, Integer n_layers, Integer num_classes,
                    Float ln_eps) -> void
+  # toy#73 A.3 — the canonical timm vit_tiny_patch16_224 shape
+  # (example 07 / train_vit / data/vit_smoke).
+  def self.tiny: () -> ViTTinyConfig
 end
 
 # ============================================================================

--- a/sig/toy_compute.rbs
+++ b/sig/toy_compute.rbs
@@ -89,6 +89,11 @@ module Toy
     def weights_dir: () -> String
     def git!: (String sha, String branch) -> void
     def run_start_prefix: () -> String
+    # Per-arch starts (toy#73 A.3): model{}/config{} read off the cfg.
+    def run_start_llama!: (Toy::SmolLM2Config lcfg, Integer steps,
+                           Float lr, Integer seed) -> void
+    def run_start_vit!: (ViTTinyConfig vcfg, Integer steps,
+                         Float lr, Integer seed) -> void
     def run_start!: (String arch, Integer vocab, Integer d_model,
                      Integer n_layers, Integer context, Integer steps,
                      Float lr, Integer seed) -> void

--- a/sig/toy_compute.rbs
+++ b/sig/toy_compute.rbs
@@ -72,16 +72,23 @@ module Toy
   # ---- RunBundle (lib/toy/io/run_bundle.rb) — toy/v1 bundle writer -------
   # Truncate-opens runs/<id>/events.jsonl in the ctor; run_start!/step!/
   # run_end! emit the toy/v1 events; weights_dir is the checkpoint home.
+  # run_start stamps backend{kind: Toy::Device.name} automatically;
+  # git{sha,branch} is opt-in via git! (toy#73 A.3 — see the file header
+  # for why it cannot be automatic).
   class RunBundle
-    attr_accessor rb_root:   String
-    attr_accessor rb_run_id: String
-    attr_accessor rb_dir:    String
-    attr_accessor rb_active: bool
+    attr_accessor rb_root:       String
+    attr_accessor rb_run_id:     String
+    attr_accessor rb_dir:        String
+    attr_accessor rb_active:     bool
+    attr_accessor rb_git_sha:    String
+    attr_accessor rb_git_branch: String
 
     def initialize: (String runs_root, String run_id) -> void
     def active: () -> bool
     def events_path: () -> String
     def weights_dir: () -> String
+    def git!: (String sha, String branch) -> void
+    def run_start_prefix: () -> String
     def run_start!: (String arch, Integer vocab, Integer d_model,
                      Integer n_layers, Integer context, Integer steps,
                      Float lr, Integer seed) -> void


### PR DESCRIPTION
The four A.3 seeds noted at the end of #73, one gated commit each. Base = main @ 67cf1e3.

**Seed c — `ViTTinyConfig.tiny`** (1a13c06). The timm vit_tiny_patch16_224 shape baked as a factory, mirroring `SmolLM2Config.tiny` (#64): additive over `.new`, byte-identical cfg. Example 07 drops its 8-constant block (20-step curve diffed byte-identical before/after). The vit smoke keeps `.new` — its 16/4/64 block is a different, env-driven shape. sig lockstep.

**Seed b — RunBundle provenance** (f986a46). `backend{kind}` is AUTOMATIC: `run_start` stamps `Toy::Device.name` (compile-time known); the three compute entries now require `io/run_bundle` after defining `Toy::Device` (the require-order constraint, resolved by reordering). `git{sha,branch}` is OPT-IN via `git!(sha, branch)` — the auto-require was investigated and is genuinely stuck: `SpinelKit::Git` sits at `../../../vendor/spinel/spinel_kit/...` in the repo (vendor-tep-gated; fresh clone must still compile example 01) but `../../../../spinel_kit/...` when toy is vendored into a consumer, and Spinel compiles a conditional `require_relative` to 0. Header documents it; probed compiled (escaped `git{}` in runner key order, RunLog parses). gate-run-log grew a backend/no-git round-trip leg; docs/events.md updated.

**Seed a — per-arch run_start** (6b5d032). `run_start_llama!(cfg, steps, lr, seed)` / `run_start_vit!(cfg, steps, lr, seed)` over the extracted `run_start_prefix` seam — one method per arch (no default args, no poly cfg param); generic `run_start!` stays for other arches. Example 01 ported (event bytes unchanged); example 07 now writes a bundle at all (image-shaped `model{}`, no fake vocab/context). gate-run-log vit round-trip leg added.

**Seed d — lora runners on hp_for_step** (9913851). Shipped WITHOUT the anticipated fixture re-record: the loops go 0-indexed and `hp_for_step(k) == hp(k+1)` does the lora bias-correction internally, so the recorded 1-indexed stdout is reproduced byte-for-byte. CPU + CUDA twins changed identically against UNCHANGED fixtures.

**Gates** (gx10/GB10, spinel a699cf9, after every item): train_gate ×4 byte-for-byte; train_cuda_gate ×3 byte-identical (det 2×); gate-run-log incl. 3 new legs; gate-compute-surface (+cuda); verify-mirrors (generate == verify); gate-consumer incl. the --lib vendored leg; examples 01–05 + 07 build/run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)