### PR TITLE
fix(#77): revive bench-vs-pytorch infer leg + fail-loud checker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1624,8 +1624,13 @@ demos/smollm2_seq_qlora_cuda: demos/smollm2_seq_qlora_cuda.rb lib/toy/llm/engine
 	$(SPINEL) --cc='cc -Wl,-u,tnn_cuda_force_link' $< -o $@
 
 # Training step-time bench. MODE=lora|ft; STEPS=N; GGUF=path.
+# toy#77: the seq-engine mirror requires the primitives/blocks/archs
+# mirrors; without them in the dep list a FRESH checkout generates only
+# llama_seq_engine_cuda.rb, its require_relatives dangle (Spinel ignores
+# them with a warning), every engine type degrades to int and .new
+# returns nil — the demo then segfaults in the first attr setter.
 seq_train_bench_cuda:        demos/seq_train_bench_cuda
-demos/seq_train_bench_cuda: demos/seq_train_bench_cuda.rb lib/toy/llm/engine/llama_seq_engine_cuda.rb lib/toy/io/loaders/toy_smollm2_loader.rb lib/toy/models/transformer.rb lib/toy/models/gpt2.rb lib/toy/io/gguf_load.rb lib/toy/ffi/tinynn.rb lib/toy/ffi/tinynn_cuda.rb tinynn/libtinynn_ggml.a tinynn/libtinynn_ggml_cuda.a $(SPINEL_DEPS)
+demos/seq_train_bench_cuda: demos/seq_train_bench_cuda.rb lib/toy/llm/engine/llama_seq_engine_cuda.rb lib/toy/llm/primitives/rms_norm_cuda.rb lib/toy/llm/primitives/rope_cuda.rb lib/toy/llm/primitives/swiglu_cuda.rb lib/toy/llm/primitives/gqa_cuda.rb lib/toy/llm/blocks/transformer_block_cuda.rb lib/toy/llm/archs/llama_arch_cuda.rb lib/toy/io/loaders/toy_smollm2_loader.rb lib/toy/models/transformer.rb lib/toy/models/gpt2.rb lib/toy/io/gguf_load.rb lib/toy/ffi/tinynn.rb lib/toy/ffi/tinynn_cuda.rb tinynn/libtinynn_ggml.a tinynn/libtinynn_ggml_cuda.a $(SPINEL_DEPS)
 	$(SPINEL) --cc='cc -Wl,-u,tnn_cuda_force_link' $< -o $@
 
 # Per-phase training-step bench (CPU + CUDA). Times graph_reset /

--- a/bench/check_vs_pytorch.rb
+++ b/bench/check_vs_pytorch.rb
@@ -127,25 +127,38 @@ end
 
 ratios = heavy ? run_heavy(PT_BASE) : run_light(PT_BASE)
 
+budget = {}
+if File.exist?(BUDGET_PATH)
+  CSV.foreach(BUDGET_PATH, headers: true) do |r|
+    budget[r["metric"]] = { value: r["value"].to_f, tol: r["tolerance_pct"].to_f }
+  end
+end
+
+# toy#77 fail-loud: every budgeted metric MUST have a freshly measured
+# ratio. The old gate iterated over `ratios` only, so a leg that died
+# (e.g. the infer demo segfaulting) simply vanished from the loop and
+# the script printed "ok" — which masked a dead bench for ~10 days.
+missing = budget.keys - ratios.keys
+
 if ratios.empty?
   puts "\nFAIL: no ratios computed — a sub-bench did not produce a number (see above)."
   exit 2
 end
 
 if update
+  if missing.length > 0
+    puts "\nFAIL (--update refused): these budgeted metrics produced no measurement:"
+    missing.each { |m| puts "  SKIPPED #{m} — leg ran but yielded no parseable number (see above)" }
+    puts "Rewriting #{BUDGET_PATH} now would silently shrink the budget. Fix the"
+    puts "dead leg first (or deliberately delete its row from the CSV)."
+    exit 2
+  end
   CSV.open(BUDGET_PATH, "w", write_headers: true,
            headers: %w[metric value unit direction tolerance_pct]) do |csv|
     ratios.each { |m, v| csv << [m, sprintf("%.4f", v), "x", "lower", "25.0"] }
   end
   puts "\nwrote #{BUDGET_PATH} (#{ratios.length} ratios)"
   exit 0
-end
-
-budget = {}
-if File.exist?(BUDGET_PATH)
-  CSV.foreach(BUDGET_PATH, headers: true) do |r|
-    budget[r["metric"]] = { value: r["value"].to_f, tol: r["tolerance_pct"].to_f }
-  end
 end
 
 puts "\n== ratios (toy / PyTorch — lower is better) =="
@@ -162,7 +175,17 @@ ratios.each do |metric, v|
   puts sprintf("  %-40s = %6.3f×  (budget %.3f×, %+5.1f %%, tol +%.0f %%)  [%s]",
                metric, v, b[:value], rel, b[:tol], bad ? "REGRESS" : "ok")
 end
+missing.each do |metric|
+  puts sprintf("  %-40s = SKIPPED — no measurement (budget %.3f×)  [FAIL]",
+               metric, budget[metric][:value])
+end
 
+if missing.length > 0
+  # Loud even in --report mode: missing data is an error, not a gate
+  # judgement, so it must never exit 0.
+  puts "\nFAIL: #{missing.length} budgeted ratio(s) had no measurement — a bench leg is dead (see above)"
+  exit 3
+end
 if report
   puts "\n(report mode — not gating)"; exit 0
 end

--- a/demos/qwen25_bench_cpu.rb
+++ b/demos/qwen25_bench_cpu.rb
@@ -29,7 +29,12 @@ flags = GGUFLoad.detect_smollm2_flags(GGUF)
 t_load_0 = Time.now
 gguf = TinyNN.tnn_gguf_load(GGUF)
 kv = SmolLM2KVFFICache.new
-kv.realize_for_mmap(gguf, cfg, MAX_T, flags.untied, flags.qkv_bias)
+# toy#77: realize_for_mmap is 6-arg now (qk_norm); Spinel zero-fills
+# under-arity calls with NO diagnostic, so the old 5-arg call compiled
+# silently. Pass qk_norm explicitly + set qk_norm_kind first (same
+# call shape as lib/toy/models/transformer_lm.rb#load_cpu).
+kv.qk_norm_kind = flags.qk_norm_kind
+kv.realize_for_mmap(gguf, cfg, MAX_T, flags.untied, flags.qkv_bias, flags.qk_norm)
 t_load_ms = (Time.now - t_load_0) * 1000.0
 puts "  realize+mmap: " + t_load_ms.to_s + " ms"
 puts "  backend: " + TinyNN.tnn_backend_name(kv.sess)

--- a/demos/qwen25_bench_cuda.rb
+++ b/demos/qwen25_bench_cuda.rb
@@ -42,9 +42,19 @@ FLASH_ATTN = ENV["FLASH_ATTN"] == "1"
 BENCH_TAG = ENV["BENCH_TAG"]  || ""
 
 puts "=== Bench: " + GGUF + " ==="
+# toy#77: do NOT call .to_s on a Bool here. Spinel codegen emits
+# Bool#to_s as a raw C literal ( cond ? "true" : "false" ) WITHOUT the
+# \xff static-string GC guard byte, then registers the temp as a GC
+# root; whether the next collection segfaults in sp_gc_mark depends on
+# what the linker placed before that literal. Two Bool#to_s in this
+# one concat chain + the tinynn_cuda link layout crashed every run
+# since ~May 31 (the bench-vs-pytorch infer leg). Ternary over guarded
+# Ruby string literals sidesteps it deterministically. spinel-dev
+# issue drafted; revert to .to_s once fixed upstream.
 puts "  warmup=" + N_WARMUP.to_s + " prefill_T=" + PREFILL_T.to_s +
      " n_new=" + N_NEW.to_s + " max_T=" + MAX_T.to_s +
-     " kv_q8=" + KV_Q8.to_s + " flash=" + FLASH_ATTN.to_s
+     " kv_q8=" + (KV_Q8 ? "true" : "false") +
+     " flash=" + (FLASH_ATTN ? "true" : "false")
 
 cfg = SmolLM2ConfigLoader.read(GGUF)
 puts "  cfg: vocab=" + cfg.vocab.to_s + " d=" + cfg.d_model.to_s +
@@ -61,7 +71,15 @@ if KV_Q8
 elsif FLASH_ATTN
   kv.enable_flash_attn!
 end
-kv.realize_for_mmap(gguf, cfg, MAX_T, flags.untied, flags.qkv_bias)
+# toy#77: realize_for_mmap grew a 6th arg (qk_norm) for Qwen3/OLMoE
+# QK-norm support; this call site still passed 5. Spinel zero-fills
+# missing call args WITHOUT a diagnostic (spinel-dev#21), which left
+# the engine with a garbage qk_norm slot and crashed decode_step in
+# sp_gc_mark. Mirror the load_cuda call shape in
+# lib/toy/models/transformer_lm_cuda.rb: set qk_norm_kind BEFORE
+# realize, pass qk_norm explicitly.
+kv.qk_norm_kind = flags.qk_norm_kind
+kv.realize_for_mmap(gguf, cfg, MAX_T, flags.untied, flags.qkv_bias, flags.qk_norm)
 t_load_ms = (Time.now - t_load_0) * 1000.0
 puts "  realize+mmap: " + t_load_ms.to_s + " ms"
 puts "  backend: " + TinyNNCuda.tnn_backend_name(kv.sess)

--- a/demos/qwen25_native_mmap.rb
+++ b/demos/qwen25_native_mmap.rb
@@ -28,8 +28,11 @@ puts "config: vocab=" + cfg.vocab.to_s +
 
 flags = GGUFLoad.detect_smollm2_flags(GGUF)
 wtype = GGUFLoad.detect_weight_type(GGUF)
-puts "flags: untied=" + flags.untied.to_s +
-     " qkv_bias=" + flags.qkv_bias.to_s +
+# toy#77: ternaries, not Bool#to_s — Spinel emits Bool#to_s as a raw
+# unguarded C literal and GC-roots it; two in one concat chain can
+# segfault sp_gc_mark depending on link layout (see qwen25_bench_cuda).
+puts "flags: untied=" + (flags.untied ? "true" : "false") +
+     " qkv_bias=" + (flags.qkv_bias ? "true" : "false") +
      " weight_type=" + wtype.to_s
 
 gguf = TinyNN.tnn_gguf_load(GGUF)
@@ -38,7 +41,10 @@ kv = SmolLM2KVFFICache.new
 kv.set_weight_type(wtype)
 
 t0 = Time.now
-kv.realize_for_mmap(gguf, cfg, MAX_T, flags.untied, flags.qkv_bias)
+# toy#77: realize_for_mmap is 6-arg now (qk_norm); Spinel zero-fills
+# under-arity calls with NO diagnostic. Pass qk_norm explicitly.
+kv.qk_norm_kind = flags.qk_norm_kind
+kv.realize_for_mmap(gguf, cfg, MAX_T, flags.untied, flags.qkv_bias, flags.qk_norm)
 puts "  realized + mmap'd in " + ((Time.now - t0) * 1000.0).to_s + " ms"
 
 puts "prefilling " + ids.length.to_s + " prompt tokens..."

--- a/demos/qwen25_native_mmap_cuda.rb
+++ b/demos/qwen25_native_mmap_cuda.rb
@@ -29,14 +29,20 @@ puts "config: vocab=" + cfg.vocab.to_s +
      " L=" + cfg.n_layers.to_s
 
 flags = GGUFLoad.detect_smollm2_flags(GGUF)
-puts "flags: untied=" + flags.untied.to_s +
-     " qkv_bias=" + flags.qkv_bias.to_s
+# toy#77: ternaries, not Bool#to_s — Spinel emits Bool#to_s as a raw
+# unguarded C literal and GC-roots it; two in one concat chain can
+# segfault sp_gc_mark depending on link layout (see qwen25_bench_cuda).
+puts "flags: untied=" + (flags.untied ? "true" : "false") +
+     " qkv_bias=" + (flags.qkv_bias ? "true" : "false")
 
 gguf = TinyNNCuda.tnn_gguf_load(GGUF)
 
 kv = SmolLM2KVFFICacheCuda.new
 t0 = Time.now
-kv.realize_for_mmap(gguf, cfg, MAX_T, flags.untied, flags.qkv_bias)
+# toy#77: realize_for_mmap is 6-arg now (qk_norm); Spinel zero-fills
+# under-arity calls with NO diagnostic. Pass qk_norm explicitly.
+kv.qk_norm_kind = flags.qk_norm_kind
+kv.realize_for_mmap(gguf, cfg, MAX_T, flags.untied, flags.qkv_bias, flags.qk_norm)
 puts "  CUDA realize + mmap in " + ((Time.now - t0) * 1000.0).to_s + " ms"
 puts "  backend: " + TinyNNCuda.tnn_backend_name(kv.sess)
 

--- a/docs/bench-vs-pytorch.md
+++ b/docs/bench-vs-pytorch.md
@@ -20,32 +20,30 @@ make bench-vs-pytorch-update   # re-record the budget after an intended change
 make bench-vs-pytorch-report   # measure + print, no gate
 ```
 
-Latest GB10 (SmolLM2-135M, measured live, same session — 2026-06-11,
-toy `d605aea` / spinel `a699cf9` / ggml `41e7949`, toy#61 pass):
+Latest GB10 (SmolLM2-135M, measured live, same session — 2026-06-12,
+toy `67cf1e3`+toy#77 fix / spinel `a699cf9` / ggml `41e7949`):
 
 | Workload | toy (CUDA) | PyTorch (CUDA) | ratio toy/pt |
 | --- | --- | --- | --- |
-| Full-FT training step (T=4) | 82.05 ms | 82.48 ms | **0.995× (parity)** |
-| KV-cache decode | — see below | 98.9 tok/s | **not measurable** |
+| Full-FT training step (T=4) | 81.90 ms | 76.98 ms | **1.064×** |
+| KV-cache decode | 80.7 tok/s | 112.8 tok/s | **1.399×** |
 
-For a transformer you can read top-to-bottom, parity on the training
-step at 135M is a healthy place to be. (The CPU story is different —
-see "Caveats".)
+For a transformer you can read top-to-bottom, near-parity on the
+training step at 135M and ~1.4× on decode is a healthy place to be.
+(The CPU story is different — see "Caveats".)
 
-> **Known-broken (2026-06-11): the decode leg.** `demos/qwen25_bench_cuda`
-> segfaults at startup (`sp_gc_mark` → `sp_PtrArray_new_scan` inside
-> `SmolLM2KVCuda.decode_step`, right after `ggml_cuda_init`), so the
-> infer ratio cannot be measured at this pin. Not an `a699cf9`
-> regression — a main-tree binary built 2026-05-31 segfaults
-> identically, so the leg has been dead since shortly after the budget
-> was recorded (2026-05-24). Worse, `bench/check_vs_pytorch.rb`
-> silently skips a ratio whose inputs are missing and still prints
-> `ok` — a fail-loud violation. The last good decode numbers (~82 vs
-> ~113 tok/s, 1.38×) are RETIRED until the demo is fixed and the leg
-> re-measured; reported on toy#61.
->
-> The *CPU* decode bench (`make bench`, `bench/inference.rb`) is alive
-> and green: 85.4 tok/s vs a 64.4 baseline on 2026-06-11.
+> **Post-mortem (toy#77, fixed 2026-06-12).** The decode leg was dead
+> 2026-05-31 → 2026-06-12: Spinel compiles `Bool#to_s` to a raw C
+> string literal *without* the `\xff` static-string GC guard byte and
+> registers the temp as a GC root, so two `KV_Q8.to_s`-style calls in
+> one concat chain in `demos/qwen25_bench_cuda` made the next GC
+> collection segfault in `sp_gc_mark` — or not, depending purely on
+> link layout. Sidestepped with ternaries over guarded string
+> literals; spinel-dev issue drafted. The same window also exposed the
+> checker silently printing `ok` when a budgeted ratio had no
+> measurement — `bench/check_vs_pytorch.rb` now prints a SKIPPED line
+> per missing leg and exits non-zero (and `--update` refuses to
+> silently shrink the budget).
 
 ## What it measures
 

--- a/docs/reference/backends.md
+++ b/docs/reference/backends.md
@@ -229,12 +229,13 @@ tolerance), so there is one mental model for both. A ratio of `1.0×` is parity;
 
 ### GB10 numbers
 
-Latest GB10 light gate (SmolLM2-135M, measured live):
+Latest GB10 light gate (SmolLM2-135M, measured live 2026-06-12, toy
+`67cf1e3`+toy#77 fix / spinel `a699cf9` / ggml `41e7949`):
 
 | Workload | toy (CUDA) | PyTorch (CUDA) | ratio toy/pt |
 | --- | --- | --- | --- |
-| Full-FT training step (T=4) | ~77 ms | ~77 ms | **~1.0× (parity)** |
-| KV-cache decode | ~82 tok/s | ~113 tok/s | **~1.38×** |
+| Full-FT training step (T=4) | ~82 ms | ~77 ms | **~1.06×** |
+| KV-cache decode | ~81 tok/s | ~113 tok/s | **~1.40×** |
 
 ### Heavy mode
 


### PR DESCRIPTION
Fixes #77.

## Root cause of the segfault (verbatim evidence)

`demos/qwen25_bench_cuda` died in `sp_gc_mark ← sp_gc_mark_all ← sp_gc_collect ← sp_gc_alloc ← sp_PtrArray_new_scan ← sp_SmolLM2KVCuda_cls_decode_step` — but decode_step was innocent. Bisection (engine-path `toy-infer-cuda` passes on the same GGUF; minimal repro needs NO decode at all) landed on this line of the demo:

```ruby
puts "  warmup=" + ... + " kv_q8=" + KV_Q8.to_s + " flash=" + FLASH_ATTN.to_s
```

Spinel codegen for `Bool#to_s` (verbatim from the generated C):

```c
const char * _t2 = (lv_a ? "true" : "false");   /* raw literal, NO \xff guard */
SP_GC_ROOT(_t2);
```

Every real string literal goes through `SPL(s) = &("\xff" s)[1]`; `sp_gc_mark` reads `obj[-1]` and early-returns on the `0xff/0xfe/0xfd/0xfc` guard. The raw `"true"/"false"` literal has no guard, so marking it reads whatever .rodata byte the linker put before it — crash or silence is pure link-layout luck. `SPINEL_GC_VERIFY=1` confirms: the collector reaches the static `"false"` at a `.rodata` address with garbage header (`->scan = nil, ->size = 0x414C...` ASCII junk), rooted from two `main` stack slots. That's why it "broke since ~May 31" with no related commit, and why requiring `tinynn_cuda` flips it. Sidestepped with ternaries over guarded Ruby literals; spinel-dev issue drafted separately.

## Also swept (same demo family / same pass)

- **Stale 5-arg `realize_for_mmap`** in `qwen25_bench_{cuda,cpu}` and `qwen25_native_mmap{,_cuda}` — the engine grew a 6th `qk_norm` arg (#76); Spinel zero-fills under-arity calls with no diagnostic (spinel-dev#21). Now pass `flags.qk_norm` + set `qk_norm_kind`, parity with `transformer_lm*.rb`.
- **Makefile dep gap**: `demos/seq_train_bench_cuda` listed the seq-engine mirror but not its primitives/blocks/archs `*_cuda.rb` closure. On a fresh checkout the engine mirror's `require_relative`s dangle (Spinel ignores them with a warning), every engine type degrades to `int`, `.new` returns nil, and the demo segfaults in the first attr setter (`t_seq_token_embed=`). Main-tree builds were riding on stale generated mirrors.
- **Checker fail-loud** (`bench/check_vs_pytorch.rb`): a budgeted metric with no fresh measurement now prints `SKIPPED — no measurement … [FAIL]` and exits 3 (loud even in `--report`); `--update` refuses to rewrite a budget that would silently drop metrics (exit 2). Previously the gate loop iterated over measured ratios only, so a dead leg simply vanished and the script printed `ok` for ~10 days.

## Re-measured (GB10, live, same session, 2026-06-12)

toy `67cf1e3`+this fix / spinel `a699cf9` / ggml `41e7949`:

```
ratio_train_toy_over_pt =  1.064×  (budget 1.031×, +3.2 %, tol +25 %)  [ok]
ratio_infer_toy_over_pt =  1.399×  (budget 1.379×, +1.4 %, tol +25 %)  [ok]
ok — toy stays within budget of PyTorch
```

(toy 80.7 tok/s vs PT 112.8 tok/s decode; toy 81.9 ms vs PT 77.0 ms FT step.) Docs (`docs/bench-vs-pytorch.md`, `docs/reference/backends.md`) restored with these measured numbers + provenance. `make bench` stays green (all 10 metrics ok, CPU decode 83.4 tok/s vs 64.4 baseline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)