### PR TITLE
docs(#27): record Mac M2 re-confirmation of SmolLM2-135M Metal row

### DIFF
--- a/docs/models.md
+++ b/docs/models.md
@@ -76,9 +76,12 @@ multi-GB models pay the copy cost — and the copy-load path has no
 QK-norm support, so QK-norm models (Qwen3, OLMoE) abort loudly on
 Metal rather than decode degenerate (#76).
 
-◇ The SmolLM2-135M Metal ✓ is Mac-gated (#27) and was not re-run in the
-2026-06-11 gx10 pass; it stands from the 2026-05-31 Mac validation
-(`9b5131a`).
+◇ The SmolLM2-135M Metal ✓ is Mac-gated (#27). Re-confirmed on
+2026-06-12 on Apple M2 (toy `d5ffbc5` / spinel `a699cf9`, pinned per
+the toy#27 brief; vendored ggml `57ea0bc`): `make
+example_inference_metal` builds + runs end-to-end (Metal kernels JIT,
+fusion/concurrency on), F32, deterministic ids — identical to the
+prior 2026-05-31 Mac validation (`9b5131a`).
 
 ## Tokenizer / RoPE coverage
 


### PR DESCRIPTION
Run 2 of the toy#27 Mac validation re-ran the SmolLM2-135M F32 Metal row on **real Apple M2 hardware**, against the brief's pinned clean toolchain (toy `d5ffbc5` / spinel `a699cf9`, fresh clone — not the shared checkout). `make example_inference_metal` builds + runs end-to-end (Metal kernels JIT, fusion/concurrency on) and emits deterministic ids identical to the 2026-05-31 baseline.

The `◇` footnote in `docs/models.md` previously said the ✓ "was not re-run in the 2026-06-11 gx10 pass" — this updates it to stamp the fresh Mac provenance.

Single-line-of-thought doc change; no code. Full run-2 results (incl. the cold-start gate, #64 device legs, and two reconciled findings) are in [#27](https://github.com/OriPekelman/toy/issues/27).

🤖 Generated with [Claude Code](https://claude.com/claude-code)