### PR TITLE
toy#71 Stage A — lib/toy/mri.rb: the MRI dev-run DSL shim

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -440,6 +440,16 @@ gate-mixed-precision:
 gate-run-log:
 	ruby prep/run_log_gate.rb
 
+# toy#71 Stage A — the MRI dev-run gate (plain `ruby`, NO Spinel build,
+# NO SPINEL_DIR): `require "toy/mri"` loads the full compute surface
+# under CRuby, the pure-Ruby teaching path genuinely trains (Trainer +
+# TransformerLM on the Mat path), and crossing the native boundary
+# raises the NAMED Toy::MRI::NativeCallError. Behavioral, not
+# byte-exact (MRI floats are the Ruby-libm arm).
+.PHONY: gate-mri
+gate-mri:
+	ruby prep/mri_gate.rb
+
 # toy#60 item 4 — the COLD-START consumer gate: `toy new` scaffold →
 # hello.rb compiles + runs (default ENV, then D_MODEL override without
 # recompiling) → `toy train` prints losses + writes runs/<id>/ → the

--- a/docs/consuming-toy.md
+++ b/docs/consuming-toy.md
@@ -148,6 +148,43 @@ deliberately does NOT work around it in its manifest. The CUDA unit pins
 `CMAKE_CUDA_ARCHITECTURES=121` (GB10); other GPUs override the whole link
 line via the `SPINEL_EXT_<PLACEHOLDER>` escape hatch.
 
+## MRI dev-runs: `require "toy/mri"` (toy#71 Stage A)
+
+Plain CRuby can load the **whole compute surface** — no Spinel, no build:
+
+```sh
+ruby -Ilib -e 'require "toy/mri"'        # from a toy checkout
+# or, in a consumer with toy on the load path:
+ruby -e 'require "toy/mri"; ...'
+```
+
+`lib/toy/mri.rb` is the **MRI-only entry**: it gives the Spinel FFI
+intrinsics (`ffi_lib` / `ffi_func` / `ffi_cflags`) a CRuby meaning —
+declaration recorders (`Toy::MRI.declarations`) whose generated methods
+raise a named `Toy::MRI::NativeCallError` — then requires `toy/compute`
+unchanged. It is never compiled by Spinel and must never appear in a
+compiled require chain (compiled code requires `toy/compute*` directly).
+
+**The boundary, honestly:**
+
+- **Pure Ruby — works for real.** Configs (`SmolLM2Config.tiny/.mid`),
+  `RecipeOptions`, cards, `RunLog`, the Mat path, and the whole teaching
+  stack: `TransformerLM` + `Toy::Trainer` genuinely **train** under MRI
+  (slowly — pure-Ruby loops; tiny shapes only). Engine/recipe
+  *construction* also works. This is what livebook / `tao notebook`
+  dev-run cells use.
+- **Native — fails loud, by name.** Anything that reaches ggml
+  (`engine.realize_*`, KV decode, GGUF load, corpus loaders) raises
+  `Toy::MRI::NativeCallError` — "native call `tnn_session_new` requires
+  the Spinel-compiled binary or the fiddle backend — toy#71". Never a
+  bare `NoMethodError`, never a silent wrong answer.
+
+Gated by `make gate-mri` (plain `ruby`; see `gating.md`). **Stage B**
+(toy#71) grows this same entry a Fiddle arm that binds the recorded
+declarations against a shared `libtinynn_ggml.so` — MRI then runs *real*
+training/inference at ggml speed, and MRI-vs-Spinel byte-comparison
+becomes a differential oracle (spinel-dev#6).
+
 ## RBS type roots ride along automatically (toy#69)
 
 Toy ships `sig/*.rbs` covering its public surface — the pure-Ruby

--- a/docs/framework.md
+++ b/docs/framework.md
@@ -41,6 +41,12 @@ the recipes, the GGUF loader and tokenizer, AdamW and label helpers.
 It is the entry point for **library consumers** — anything that isn't
 the toy CLI itself.
 
+For **MRI dev-runs** (notebook cells, REPL pokes — no Spinel build),
+`require "toy/mri"` loads the same surface under plain CRuby: pure-Ruby
+paths (configs, Mat, `TransformerLM` + `Toy::Trainer`) work for real;
+native calls raise a named `Toy::MRI::NativeCallError` instead of dying
+in a `NoMethodError`. See `consuming-toy.md` § MRI dev-runs (toy#71).
+
 ## A training run in one screen
 
 The recipe surface is deliberately flat: `realize!` builds the whole

--- a/docs/gating.md
+++ b/docs/gating.md
@@ -108,6 +108,22 @@ leg (`toy new gatelib --lib` → `bundle lock` → `spinel-compat vendor` →
 absent. Structural assertions (files exist, losses finite, curves react
 to ENV), not byte-exact — numerics are `train_gate`'s job.
 
+### MRI dev-run gate
+
+`make gate-mri` (`prep/mri_gate.rb`, toy#71 Stage A) proves the **plain-CRuby
+entry** works with no Spinel anywhere — plain `ruby`, no `SPINEL_DIR`, no
+build step. It asserts three things: (1) `require "toy/mri"` loads the full
+compute require chain under MRI (the `ffi_lib`/`ffi_func`/`ffi_cflags`
+intrinsics resolve to the shim's declaration recorders; 194 declarations
+land in `Toy::MRI.declarations`); (2) the pure-Ruby teaching surface
+genuinely works — configs, `RecipeOptions`, engine *construction*, and a
+real `Toy::Trainer` + `TransformerLM` loop on the Mat path whose loss
+decreases; (3) crossing the native boundary fails LOUD with the named
+`Toy::MRI::NativeCallError` (never a bare `NoMethodError`), at both a
+direct `TinyNN.tnn_session_new` call and an engine realize. Behavioral,
+not byte-exact — MRI float printing is the Ruby-libm arm; numeric
+byte-equality vs the compiled binaries is Stage B's differential gate.
+
 ### Model-gated regression gates
 
 Some gates exercise a REAL model whose GGUF is a gitignored multi-GB dev

--- a/lib/toy/mri.rb
+++ b/lib/toy/mri.rb
@@ -1,0 +1,157 @@
+# lib/toy/mri.rb — the MRI (CRuby) dev-run entrypoint. toy#71 Stage A.
+#
+#   ruby -Ilib -e 'require "toy/mri"'    # the whole compute surface loads
+#
+# WHY THIS EXISTS. `ffi_lib` / `ffi_func` / `ffi_cflags` are Spinel
+# COMPILE-TIME intrinsics with no CRuby counterpart, so under plain MRI
+# every `require` that transits lib/toy/ffi/tinynn.rb (i.e. the whole
+# compute surface) dies with NoMethodError — even though the pure-Ruby
+# teaching path (Mat, configs, RecipeOptions, RunLog, cards) never
+# executes an FFI branch. This file gives the three intrinsics an MRI
+# story: DECLARATION RECORDERS whose generated methods raise a named,
+# actionable Toy::MRI::NativeCallError. The pure-Ruby surface then works
+# end to end under MRI (livebook/tao dev-run cells, quick REPL pokes);
+# anything that actually needs ggml fails loud at the exact call site.
+#
+# NEVER COMPILED BY SPINEL. This file must not appear in any compiled
+# require chain (lib/toy/compute*.rb, libexec runners, prep/smokes).
+# It is the CRuby side of the seam, like lib/toy/core/ — a SEPARATE
+# entry file, NOT a conditional require (Spinel silently compiles
+# conditional require_relative to 0 — spinel-dev#20, probed a699cf9).
+# Consequently there is NO sig/ lockstep for this file: Spinel never
+# sees it, so no .rbs mirror exists or is needed.
+#
+# STAGE B (toy#71, follow-on): the registry this file keeps
+# (Toy::MRI.declarations / .libs / .cflags) is consumed by the Fiddle
+# arm — `ffi_func` declarations ARE the spec the Fiddle backend binds
+# against a shared libtinynn_ggml.so. Keep the registry shape stable.
+
+module Toy
+  # MRI-side runtime support for the Spinel FFI DSL.
+  module MRI
+    # Raised when MRI code calls a declared-but-unbound native function.
+    # Named (not NoMethodError) so callers/tests can rescue it precisely.
+    class NativeCallError < StandardError; end
+
+    # Raised when the DSL shim would clobber an existing definition
+    # (double-load, a foreign stub like tao's, or — impossibly — a
+    # Spinel runtime). Fail loud, never silently redefine.
+    class ShimCollisionError < StandardError; end
+
+    @declarations = {}   # Module => [[name(Symbol), argtypes(Array), rettype(Symbol)], ...]
+    @libs         = {}   # Module => [libname(String), ...]
+    @cflags       = {}   # Module => [flags(String), ...]
+
+    class << self
+      # Public registry — Stage B's Fiddle arm consumes these.
+      attr_reader :declarations, :libs, :cflags
+
+      def record_lib(mod, name)
+        (@libs[mod] ||= []) << name
+        nil
+      end
+
+      def record_cflags(mod, flags)
+        (@cflags[mod] ||= []) << flags
+        nil
+      end
+
+      def record_func(mod, name, argtypes, rettype)
+        (@declarations[mod] ||= []) << [name.to_sym, argtypes, rettype]
+        nil
+      end
+    end
+
+    # The deliberate NON-RAISING declarations — every other declared
+    # function raises NativeCallError. Two families, both with an exact,
+    # documented pure-value semantic (no computation is being masked):
+    #
+    # 1. `tnn_null_ptr` — returns a typed NULL `void *`; exists only as
+    #    a Spinel type-inference workaround (`:ptr` ivars seed with it
+    #    instead of `nil`, else post-85a4670 inference boxes them as
+    #    sp_RbVal — see lib/toy/ffi/tinynn.rb FFNFFICache#initialize).
+    #    Under MRI the honest equivalent of a typed NULL handle is
+    #    `nil`. Without this, `TransformerLM.new` — the PURE-RUBY
+    #    teaching model, the whole point of Stage A — raises at
+    #    construction despite never executing an FFI branch.
+    #
+    # 2. The trace OFF-state (tinynn/tinynn_trace.c): until
+    #    `tnn_trace_open` succeeds, natively begin→0, end/mark→nothing,
+    #    active→0, op_capture_active→0. Under MRI tracing can never
+    #    open (`tnn_trace_open` RAISES — a state change we cannot
+    #    honor, so it fails loud, as does tnn_trace_set_op_capture),
+    #    so the off-state values ARE the native semantics, forever.
+    #    Without this, every Mat op raises — Mat#matmul et al. are
+    #    unconditionally instrumented with tnn_trace_begin/end.
+    OFF_STATE_NATIVES = {
+      tnn_null_ptr:                nil,
+      tnn_trace_begin:             0,
+      tnn_trace_end:               nil,
+      tnn_trace_mark:              nil,
+      tnn_trace_active:            0,
+      tnn_trace_op_capture_active: 0,
+    }.freeze
+  end
+end
+
+# ── The DSL shim ──────────────────────────────────────────────────────
+# Guard FIRST: if any of the three is already a method on Module, some
+# other definition got there before us (loaded twice? tao's interim
+# stub? the ffi gem in the same process?). Silently clobbering would
+# mask which semantics are live — fail loud instead.
+%i[ffi_lib ffi_func ffi_cflags].each do |dsl|
+  if Module.method_defined?(dsl) || Module.private_method_defined?(dsl)
+    raise Toy::MRI::ShimCollisionError,
+          "Module##{dsl} is already defined — refusing to clobber. " \
+          "toy/mri must be the FIRST and ONLY provider of the FFI DSL " \
+          "in this process (did it get required twice, or after a " \
+          "foreign stub / the ffi gem?) — toy#71"
+  end
+end
+
+class Module
+  private
+
+  # Records the library name; linking is a Spinel-build concern.
+  def ffi_lib(name)
+    Toy::MRI.record_lib(self, name)
+  end
+
+  # Records the flags; compiling is a Spinel-build concern.
+  def ffi_cflags(flags)
+    Toy::MRI.record_cflags(self, flags)
+  end
+
+  # Records the declaration and defines a module_function `name` that
+  # raises Toy::MRI::NativeCallError. The declaring module's call shape
+  # (TinyNN.tnn_session_new(0)) thus resolves under MRI — to a loud,
+  # named failure at the exact native boundary.
+  def ffi_func(name, argtypes = [], rettype = :void)
+    Toy::MRI.record_func(self, name, argtypes, rettype)
+    mod  = self
+    sym  = name.to_sym
+    impl =
+      if Toy::MRI::OFF_STATE_NATIVES.key?(sym)
+        value = Toy::MRI::OFF_STATE_NATIVES[sym]
+        ->(*_args) { value }
+      else
+        lambda do |*_args|
+          raise Toy::MRI::NativeCallError,
+                "native call `#{sym}` (declared in #{mod}) requires the " \
+                "Spinel-compiled binary or the fiddle backend — toy#71"
+        end
+      end
+    define_method(sym, &impl)
+    if instance_of?(Module)
+      module_function(sym)
+    else
+      # Defensive: every current declaration site is a module, but if a
+      # class ever declares one, give it the same singleton call shape.
+      singleton_class.define_method(sym, &impl)
+    end
+    sym
+  end
+end
+
+# With the DSL live, the full compute surface loads under MRI.
+require_relative "compute"

--- a/prep/mri_gate.rb
+++ b/prep/mri_gate.rb
@@ -1,0 +1,104 @@
+# prep/mri_gate.rb — toy#71 Stage A gate: the MRI dev-run entrypoint.
+#
+#   make gate-mri        # plain `ruby` — NO Spinel, NO SPINEL_DIR, NO build
+#
+# Proves `require "toy/mri"` gives plain CRuby the whole compute surface:
+#
+#   1. LOAD  — the full compute require chain loads under MRI (no
+#      NoMethodError from the ffi_lib/ffi_func/ffi_cflags intrinsics or
+#      anything else), and the declaration registry is populated.
+#   2. PURE  — the pure-Ruby teaching surface genuinely works: configs,
+#      RecipeOptions, a real TransformerLM forward + Trainer steps on
+#      the Mat path (losses move), engine CONSTRUCTION.
+#   3. NATIVE — crossing the native boundary fails LOUD with the named
+#      Toy::MRI::NativeCallError (never a bare NoMethodError, never a
+#      silent wrong answer), at both a direct TinyNN call and an
+#      engine realize.
+#
+# Structural + behavioral, not byte-exact: MRI float printing is the
+# Ruby-libm arm (docs/gating.md "cross-platform"); numeric byte-equality
+# vs the Spinel binaries is Stage B's differential gate.
+
+lib = File.expand_path("../lib", __dir__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+
+def gate_fail(msg)
+  warn "GATE FAIL [mri]: #{msg}"
+  exit 1
+end
+
+# ── 1. LOAD ──────────────────────────────────────────────────────────
+begin
+  require "toy/mri"
+rescue StandardError, NoMethodError => e
+  gate_fail "require \"toy/mri\" raised #{e.class}: #{e.message}"
+end
+
+gate_fail "Toy::MRI.declarations is empty" if Toy::MRI.declarations.empty?
+n_decl = Toy::MRI.declarations.values.sum(&:size)
+mods   = Toy::MRI.declarations.keys.map(&:to_s).sort
+gate_fail "TinyNN declarations missing" unless mods.include?("TinyNN")
+puts "load ok: #{n_decl} ffi_func declarations recorded across #{mods.join(", ")}"
+
+# ── 2. PURE-RUBY SURFACE ─────────────────────────────────────────────
+srand(0)
+
+cfg = Toy::SmolLM2Config.tiny
+gate_fail "SmolLM2Config.tiny wrong shape" unless
+  cfg.vocab == 627 && cfg.d_model == 64 && cfg.n_layers == 2
+
+opts = Toy::LLM::RecipeOptions.new
+gate_fail "RecipeOptions.new failed" unless opts.is_a?(Toy::LLM::RecipeOptions)
+
+# Engine CONSTRUCTION is pure (ivars seed with typed-NULL handles);
+# only realize crosses the native boundary (checked in part 3).
+engine = Toy::Device.llama_engine
+gate_fail "engine construction failed" unless
+  engine.is_a?(Toy::LLM::Engine::LlamaSeqEngine)
+
+# A real forward + training loop on the Mat path (the teaching stack):
+# tiny shape, 5 steps, assert the loss MOVES DOWN (behavioral, not
+# byte-pinned — see header).
+require "toy/train/toy_trainer"
+lm  = TransformerLM.new(64, 32, 64, 2, 2, 16)
+tr  = Toy::Trainer.new(lm)
+seq = (1..12).to_a
+
+logits = lm.forward(seq)
+gate_fail "forward shape: got #{logits.nrows}x#{logits.ncols}" unless
+  logits.nrows == 12 && logits.ncols == 64
+
+losses = 5.times.map { tr.step!(seq) }
+gate_fail "loss not finite: #{losses.inspect}" unless
+  losses.all? { |l| l.finite? }
+gate_fail "loss did not decrease over 5 steps: #{losses.inspect}" unless
+  losses.last < losses.first
+puts "pure ok: cfg/options/engine construct; 5 Trainer steps " \
+     "loss #{losses.first.round(4)} -> #{losses.last.round(4)}"
+
+# ── 3. NATIVE BOUNDARY FAILS LOUD + NAMED ────────────────────────────
+expect_native_error = lambda do |what, &blk|
+  begin
+    blk.call
+    gate_fail "#{what} did NOT raise"
+  rescue Toy::MRI::NativeCallError => e
+    unless e.message.include?("requires the Spinel-compiled binary") &&
+           e.message.include?("toy#71") &&
+           e.message =~ /native call `tnn_\w+`/
+      gate_fail "#{what} raised with unexpected message: #{e.message}"
+    end
+    e.message[/`(tnn_\w+)`/, 1]
+  rescue => e
+    gate_fail "#{what} raised #{e.class} (want Toy::MRI::NativeCallError): #{e.message}"
+  end
+end
+
+name1 = expect_native_error.call("direct TinyNN.tnn_session_new(0)") do
+  TinyNN.tnn_session_new(0)
+end
+name2 = expect_native_error.call("engine.realize_for_random_init") do
+  engine.realize_for_random_init(cfg, 32, 1, 0, false, false, 0, 1.0)
+end
+puts "native ok: `#{name1}` and `#{name2}` raise the named NativeCallError"
+
+puts "mri-gate: ok"


### PR DESCRIPTION
Closes nothing yet (Stage B remains on #71). Implements the approved Stage A design from #71's design comment.

## What

`lib/toy/mri.rb` — a **never-compiled MRI-only entry**: `require "toy/mri"` loads the full compute surface under plain CRuby (no Spinel, no build). It defines the three Spinel FFI intrinsics on `Module` as declaration recorders:

- `ffi_lib` / `ffi_cflags` — record + no-op (`Toy::MRI.libs` / `.cflags`).
- `ffi_func` — records into the **public** `Toy::MRI.declarations` registry (Stage B's Fiddle arm consumes it) and defines a `module_function` raising the named `Toy::MRI::NativeCallError`:
  > native call `tnn_session_new` (declared in TinyNN) requires the Spinel-compiled binary or the fiddle backend — toy#71
- Collision guard — `ShimCollisionError` if any `ffi_*` is already defined (double-load, foreign stub): fail loud, never clobber.

Then `require_relative "compute"` — one MRI entry, surface unchanged.

Two documented **off-state carve-outs** (exact native semantics; nothing computed is masked):
1. `tnn_null_ptr → nil` — the typed-NULL handle seed (`TransformerLM.new` touches it even with `USE_FFI_MATMUL=false`).
2. The trace family's documented closed-state (`tnn_trace_begin→0`, `end`/`mark`→nop, `active`/`op_capture_active→0`) — Mat ops are unconditionally instrumented with `tnn_trace_begin/end`; `tnn_trace_open` itself (a state change MRI can't honor) still raises.

## Proven under MRI

- `require "toy/mri"` loads clean; 194 declarations recorded (TinyNN + GgufKV).
- Pure-Ruby teaching stack trains for real: `Toy::Trainer` + `TransformerLM`, loss decreasing; the **original #71 repro** (`examples/legacy/02_train_custom_gpt.rb`) runs end-to-end with `ruby -Ilib -r toy/mri …` (1 epoch, 21s, generates text).
- `SmolLM2Config.tiny`, `RecipeOptions`, engine **construction** all work; `realize_*` / direct TinyNN calls raise the named error.

## Gate

`make gate-mri` (`prep/mri_gate.rb`, plain `ruby`, no `SPINEL_DIR`): load + registry, loss-decreasing 5-step Trainer run, named-error assertions at both boundaries. Wired into `docs/gating.md`; consumption documented in `docs/consuming-toy.md` § MRI dev-runs + a pointer in `docs/framework.md`.

## Spinel-side safety (SPINEL_DIR=/tmp/spinel-a699cf9-serve, gx10)

- grep proves NO compiled file requires `toy/mri` (compiled chains use `toy/compute*` only; no sig lockstep needed — Spinel never sees the file).
- `gate-compute-surface` PASS, `gate-compute-surface-cuda` PASS, `prep/train_gate.rb` PASS (all 4 recipes byte-exact), `gate-consumer` PASS (incl. `--lib` leg).

🤖 Generated with [Claude Code](https://claude.com/claude-code)