### PR TITLE
toy#71 Stage B — Fiddle backend: MRI runs real ggml, BIT-EXACT vs the Spinel gate curves

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,9 @@ vendor/ggml/*.build.log
 # tinynn shim build artifacts
 tinynn/*.o
 tinynn/*.a
+# toy#71 Stage B: the CRuby-oracle shared object (make libtinynn_shared)
+tinynn/*.so
+tinynn/*.dylib
 # tinynn smoke / bench binaries (all built by `make ab-smoke-*` etc.)
 tinynn/smoke
 tinynn/ab_smoke

--- a/Makefile
+++ b/Makefile
@@ -440,12 +440,15 @@ gate-mixed-precision:
 gate-run-log:
 	ruby prep/run_log_gate.rb
 
-# toy#71 Stage A — the MRI dev-run gate (plain `ruby`, NO Spinel build,
-# NO SPINEL_DIR): `require "toy/mri"` loads the full compute surface
-# under CRuby, the pure-Ruby teaching path genuinely trains (Trainer +
-# TransformerLM on the Mat path), and crossing the native boundary
-# raises the NAMED Toy::MRI::NativeCallError. Behavioral, not
-# byte-exact (MRI floats are the Ruby-libm arm).
+# toy#71 — the MRI dev-run gate, BOTH arms (plain `ruby`, NO Spinel
+# build, NO SPINEL_DIR). Stub leg (Stage A): `require "toy/mri"` loads
+# the full compute surface under CRuby, the pure-Ruby teaching path
+# genuinely trains, and crossing the native boundary raises the NAMED
+# Toy::MRI::NativeCallError. Native leg (Stage B, the CRuby oracle;
+# needs `make libtinynn_shared`, loud SKIP otherwise — MRI_GATE_STRICT=1
+# turns the skip into a failure): MRI+Fiddle reproduces the recorded
+# Spinel from-scratch gate curve BIT-EXACT (train_baseline.txt) and the
+# smollm2-135m greedy decode ids byte-equal infer_baseline.txt.
 .PHONY: gate-mri
 gate-mri:
 	ruby prep/mri_gate.rb
@@ -1198,6 +1201,37 @@ tinynn/tinynn_events.o: tinynn/tinynn_events.c tinynn/tinynn_events.h
 
 tinynn/libtinynn_ggml.a: tinynn/tinynn_ggml.o tinynn/tinynn_gguf.o tinynn/tinynn_trace.o tinynn/tinynn_events.o
 	ar $(ARFLAGS) $@ tinynn/tinynn_ggml.o tinynn/tinynn_gguf.o tinynn/tinynn_trace.o tinynn/tinynn_events.o
+
+# --- toy#71 Stage B: the CRuby-oracle shared library ------------------------
+# tinynn objects + the static CPU ggml archives linked into ONE self-
+# contained shared object that plain MRI dlopens via Fiddle (lib/toy/mri.rb
+# native arm). PIC is already on everywhere (CFLAGS -fPIC for tinynn,
+# -DCMAKE_POSITION_INDEPENDENT_CODE=ON for ggml). -Wl,-Bsymbolic binds
+# ggml's intra-library references locally — without it the aarch64 link
+# rejects adrp relocations against ggml's C++ vtables ("may bind
+# externally"); no interposition is wanted anyway. --whole-archive keeps
+# every backend-registry object alive. Link order mirrors the Spinel
+# ffi_lib list in lib/toy/ffi/tinynn.rb (stdc++/pthread, -lm TRAILING; no
+# gomp — the CPU ggml build is -DGGML_OPENMP=OFF). CPU ONLY this stage:
+# the CUDA/Metal shims stay static-archive-only (follow-up — a
+# libtinynn_ggml_cuda_shared.so would whole-archive build-cuda/ + the CUDA
+# stub libs; Metal additionally needs a Mac to verify -dynamiclib +
+# -force_load). Artifact is gitignored (rebuild: make libtinynn_shared).
+.PHONY: libtinynn_shared
+libtinynn_shared: tinynn/libtinynn_ggml_shared.so
+
+tinynn/libtinynn_ggml_shared.so: tinynn/tinynn_ggml.o tinynn/tinynn_gguf.o tinynn/tinynn_trace.o tinynn/tinynn_events.o $(GGML_DIR)/build/src/libggml.a
+ifeq ($(UNAME_S),Darwin)
+	@echo "libtinynn_shared: Linux-only this stage (toy#71 Stage B is the gx10 CPU oracle;"
+	@echo "  the macOS -dynamiclib/-force_load variant is a follow-up — needs Mac verification)"
+	@exit 1
+else
+	$(CC) -shared -Wl,-Bsymbolic -o $@ \
+	  tinynn/tinynn_ggml.o tinynn/tinynn_gguf.o tinynn/tinynn_trace.o tinynn/tinynn_events.o \
+	  -L$(GGML_DIR)/build/src \
+	  -Wl,--whole-archive -lggml -lggml-cpu -lggml-base -Wl,--no-whole-archive \
+	  -lstdc++ -lpthread -lm
+endif
 
 # --- smoke test -------------------------------------------------------------
 # Builds tinynn/smoke.rb against the CPU shim. Requires `setup-ggml` to have

--- a/docs/consuming-toy.md
+++ b/docs/consuming-toy.md
@@ -148,9 +148,10 @@ deliberately does NOT work around it in its manifest. The CUDA unit pins
 `CMAKE_CUDA_ARCHITECTURES=121` (GB10); other GPUs override the whole link
 line via the `SPINEL_EXT_<PLACEHOLDER>` escape hatch.
 
-## MRI dev-runs: `require "toy/mri"` (toy#71 Stage A)
+## MRI dev-runs: `require "toy/mri"` (toy#71)
 
-Plain CRuby can load the **whole compute surface** — no Spinel, no build:
+Plain CRuby can load — and, with one `make` target, **run** — the whole
+compute surface; no Spinel:
 
 ```sh
 ruby -Ilib -e 'require "toy/mri"'        # from a toy checkout
@@ -159,31 +160,68 @@ ruby -e 'require "toy/mri"; ...'
 ```
 
 `lib/toy/mri.rb` is the **MRI-only entry**: it gives the Spinel FFI
-intrinsics (`ffi_lib` / `ffi_func` / `ffi_cflags`) a CRuby meaning —
-declaration recorders (`Toy::MRI.declarations`) whose generated methods
-raise a named `Toy::MRI::NativeCallError` — then requires `toy/compute`
-unchanged. It is never compiled by Spinel and must never appear in a
-compiled require chain (compiled code requires `toy/compute*` directly).
+intrinsics (`ffi_lib` / `ffi_func` / `ffi_cflags`) a CRuby meaning, then
+requires `toy/compute` unchanged. It is never compiled by Spinel and
+must never appear in a compiled require chain (compiled code requires
+`toy/compute*` directly). It has **two arms**, selected once at require
+time:
 
-**The boundary, honestly:**
+- **Stub arm (Stage A — the default without a build).** `ffi_func`
+  declarations are recorded (`Toy::MRI.declarations`) and the generated
+  methods raise a named `Toy::MRI::NativeCallError` — "native call
+  `tnn_session_new` requires the Spinel-compiled binary or the fiddle
+  backend (`make libtinynn_shared`) — toy#71". Never a bare
+  `NoMethodError`, never a silent wrong answer. Pure Ruby still works
+  for real: configs (`SmolLM2Config.tiny/.mid`), `RecipeOptions`, cards,
+  `RunLog`, the Mat path, and the whole teaching stack —
+  `TransformerLM` + `Toy::Trainer` genuinely train under MRI (slowly;
+  tiny shapes). This is what livebook / `tao notebook` dev-run cells
+  use out of the box (a one-line stderr hint points at the native arm).
 
-- **Pure Ruby — works for real.** Configs (`SmolLM2Config.tiny/.mid`),
-  `RecipeOptions`, cards, `RunLog`, the Mat path, and the whole teaching
-  stack: `TransformerLM` + `Toy::Trainer` genuinely **train** under MRI
-  (slowly — pure-Ruby loops; tiny shapes only). Engine/recipe
-  *construction* also works. This is what livebook / `tao notebook`
-  dev-run cells use.
-- **Native — fails loud, by name.** Anything that reaches ggml
-  (`engine.realize_*`, KV decode, GGUF load, corpus loaders) raises
-  `Toy::MRI::NativeCallError` — "native call `tnn_session_new` requires
-  the Spinel-compiled binary or the fiddle backend — toy#71". Never a
-  bare `NoMethodError`, never a silent wrong answer.
+- **Native arm (Stage B — the CRuby oracle).** Build the shared
+  library once:
 
-Gated by `make gate-mri` (plain `ruby`; see `gating.md`). **Stage B**
-(toy#71) grows this same entry a Fiddle arm that binds the recorded
-declarations against a shared `libtinynn_ggml.so` — MRI then runs *real*
-training/inference at ggml speed, and MRI-vs-Spinel byte-comparison
-becomes a differential oracle (spinel-dev#6).
+  ```sh
+  make libtinynn_shared      # → tinynn/libtinynn_ggml_shared.so
+                             #   (needs `make setup-ggml` first;
+                             #    Linux/CPU this stage, gitignored)
+  ```
+
+  When that artifact exists, `require "toy/mri"` dlopens it via
+  **Fiddle** and every `ffi_func` declaration binds to the real C
+  function — same 186-symbol surface the Spinel binaries link. MRI then
+  runs *real* training and KV-decode inference at ggml speed:
+  `Toy::LLM::Recipes::FromScratch`, GGUF load, `ToyLM#generate`, corpus
+  loaders, the lot. `TOY_MRI_NATIVE=0` forces the stub arm back.
+  The Stage A off-state carve-outs (`tnn_null_ptr`→nil, trace
+  off-state) disappear in this arm — those functions go through Fiddle
+  like everything else.
+
+**Why "oracle":** the MRI+Fiddle arm and the Spinel-compiled binaries
+run the *same Ruby program* over the *same C library* — only the Ruby
+runtime differs. `make gate-mri`'s native leg pins this: the 5-step
+from-scratch loss curve reproduces the recorded Spinel gate curve
+**bit-exact** (`prep/fixtures/train_baseline.txt` — values *and*
+formatted strings), and smollm2-135m greedy decode ids byte-equal
+`prep/fixtures/infer_baseline.txt`. That makes any future MRI-vs-Spinel
+divergence a **differential bisection oracle for Spinel codegen bugs**
+(spinel-dev#6 phase 1): run the suspect program both ways; if MRI+Fiddle
+agrees with the recorded truth and the compiled binary doesn't, the bug
+is in compilation, by construction — no numerics argument needed.
+
+Type lowering (pinned by probing Spinel's generated C): `:ptr`→`void*`
+(integer-valued handles on the Ruby side), `:int`→`int`, `:long`→`long`,
+`:size_t`→`size_t`, `:double`→`double`, `:str`→`const char*`,
+`:int_array`→`const int64_t*`, `:float_array`→`const double*` (Spinel
+arrays store i64/f64 — *not* f32). The Fiddle arm mirrors Spinel's
+zero-copy array semantics by pack→call→unpack→`Array#replace`, so
+C-filled output arrays (`tnn_read_i32_file`, `tnn_download_to_f64_array`)
+work unchanged.
+
+Gated by `make gate-mri` (plain `ruby`; see `gating.md`): stub leg
+always; native leg when the `.so` exists (loud SKIP otherwise;
+`MRI_GATE_STRICT=1` makes the skip a failure). CUDA/Metal shared
+variants and the macOS dylib are follow-ups.
 
 ## RBS type roots ride along automatically (toy#69)
 

--- a/docs/gating.md
+++ b/docs/gating.md
@@ -110,19 +110,32 @@ to ENV), not byte-exact — numerics are `train_gate`'s job.
 
 ### MRI dev-run gate
 
-`make gate-mri` (`prep/mri_gate.rb`, toy#71 Stage A) proves the **plain-CRuby
+`make gate-mri` (`prep/mri_gate.rb`, toy#71) proves the **plain-CRuby
 entry** works with no Spinel anywhere — plain `ruby`, no `SPINEL_DIR`, no
-build step. It asserts three things: (1) `require "toy/mri"` loads the full
-compute require chain under MRI (the `ffi_lib`/`ffi_func`/`ffi_cflags`
-intrinsics resolve to the shim's declaration recorders; 194 declarations
-land in `Toy::MRI.declarations`); (2) the pure-Ruby teaching surface
-genuinely works — configs, `RecipeOptions`, engine *construction*, and a
-real `Toy::Trainer` + `TransformerLM` loop on the Mat path whose loss
-decreases; (3) crossing the native boundary fails LOUD with the named
-`Toy::MRI::NativeCallError` (never a bare `NoMethodError`), at both a
-direct `TinyNN.tnn_session_new` call and an engine realize. Behavioral,
-not byte-exact — MRI float printing is the Ruby-libm arm; numeric
-byte-equality vs the compiled binaries is Stage B's differential gate.
+Spinel build. Two subprocess legs:
+
+**Stub leg** (Stage A, forced `TOY_MRI_NATIVE=0`): (1) `require
+"toy/mri"` loads the full compute require chain under MRI (the
+`ffi_lib`/`ffi_func`/`ffi_cflags` intrinsics resolve to the shim's
+declaration recorders; 194 declarations land in `Toy::MRI.declarations`);
+(2) the pure-Ruby teaching surface genuinely works — configs,
+`RecipeOptions`, engine *construction*, and a real `Toy::Trainer` +
+`TransformerLM` loop on the Mat path whose loss decreases; (3) crossing
+the native boundary fails LOUD with the named `Toy::MRI::NativeCallError`
+(never a bare `NoMethodError`).
+
+**Native leg** (Stage B, the CRuby oracle; needs `make libtinynn_shared`
+— loud SKIP when the `.so` is absent, `MRI_GATE_STRICT=1` turns the skip
+into a failure): (4) the Fiddle arm binds and a real cpu session opens;
+(5) **differential train** — the exact from-scratch gate shape run under
+MRI+Fiddle must reproduce `prep/fixtures/train_baseline.txt` (the same
+recorded curve `train_gate` holds the Spinel runner to) with losses
+**bit-exact** (`pack("G")` comparison; formatted lines additionally
+byte-compared, string-only drift reported not failed); (6) **KV decode**
+— smollm2-135m greedy ids byte-equal `prep/fixtures/infer_baseline.txt`
+(model-gated: loud SKIP without the gitignored GGUF). One program, two
+Ruby runtimes, same C library — divergence isolates Spinel codegen
+(spinel-dev#6 phase 1).
 
 ### Model-gated regression gates
 

--- a/lib/toy/mri.rb
+++ b/lib/toy/mri.rb
@@ -1,4 +1,4 @@
-# lib/toy/mri.rb — the MRI (CRuby) dev-run entrypoint. toy#71 Stage A.
+# lib/toy/mri.rb — the MRI (CRuby) dev-run entrypoint. toy#71 Stage A+B.
 #
 #   ruby -Ilib -e 'require "toy/mri"'    # the whole compute surface loads
 #
@@ -8,10 +8,24 @@
 # compute surface) dies with NoMethodError — even though the pure-Ruby
 # teaching path (Mat, configs, RecipeOptions, RunLog, cards) never
 # executes an FFI branch. This file gives the three intrinsics an MRI
-# story: DECLARATION RECORDERS whose generated methods raise a named,
-# actionable Toy::MRI::NativeCallError. The pure-Ruby surface then works
-# end to end under MRI (livebook/tao dev-run cells, quick REPL pokes);
+# story, in TWO ARMS:
+#
+# STUB ARM (Stage A): DECLARATION RECORDERS whose generated methods raise
+# a named, actionable Toy::MRI::NativeCallError. The pure-Ruby surface
+# works end to end under MRI (livebook/tao dev-run cells, REPL pokes);
 # anything that actually needs ggml fails loud at the exact call site.
+#
+# NATIVE ARM (Stage B — the CRuby oracle): when the shared library
+# tinynn/libtinynn_ggml_shared.so exists (`make libtinynn_shared`),
+# `ffi_func` binds the declaration against it via Fiddle instead of
+# raising — the SAME toy program then runs real ggml compute under plain
+# MRI. The 186 unique declarations ARE the spec; no second surface.
+# Differential property (spinel-dev#6 phase 1): one program, two
+# runtimes (MRI+Fiddle vs the Spinel-compiled binary) over the identical
+# C library — divergence isolates a Spinel codegen bug, not a numerics
+# question. Gated by prep/mri_gate.rb's native leg (train losses vs the
+# recorded Spinel gate curve, KV-decode ids vs the infer baseline).
+# Opt out with TOY_MRI_NATIVE=0 (forces the stub arm).
 #
 # NEVER COMPILED BY SPINEL. This file must not appear in any compiled
 # require chain (lib/toy/compute*.rb, libexec runners, prep/smokes).
@@ -20,11 +34,6 @@
 # conditional require_relative to 0 — spinel-dev#20, probed a699cf9).
 # Consequently there is NO sig/ lockstep for this file: Spinel never
 # sees it, so no .rbs mirror exists or is needed.
-#
-# STAGE B (toy#71, follow-on): the registry this file keeps
-# (Toy::MRI.declarations / .libs / .cflags) is consumed by the Fiddle
-# arm — `ffi_func` declarations ARE the spec the Fiddle backend binds
-# against a shared libtinynn_ggml.so. Keep the registry shape stable.
 
 module Toy
   # MRI-side runtime support for the Spinel FFI DSL.
@@ -38,13 +47,24 @@ module Toy
     # Spinel runtime). Fail loud, never silently redefine.
     class ShimCollisionError < StandardError; end
 
-    @declarations = {}   # Module => [[name(Symbol), argtypes(Array), rettype(Symbol)], ...]
-    @libs         = {}   # Module => [libname(String), ...]
-    @cflags       = {}   # Module => [flags(String), ...]
+    # The Stage B shared library (CPU ggml + tinynn, self-contained —
+    # `make libtinynn_shared`). Repo-relative: this file lives at
+    # <root>/lib/toy/mri.rb, the artifact at <root>/tinynn/.
+    NATIVE_LIB = File.expand_path("../../tinynn/libtinynn_ggml_shared.so", __dir__)
+
+    @declarations  = {}   # Module => [[name(Symbol), argtypes(Array), rettype(Symbol)], ...]
+    @libs          = {}   # Module => [libname(String), ...]
+    @cflags        = {}   # Module => [flags(String), ...]
+    @native_handle = nil  # Fiddle::Handle when the native arm is live
 
     class << self
-      # Public registry — Stage B's Fiddle arm consumes these.
-      attr_reader :declarations, :libs, :cflags
+      # Public registry — the Fiddle arm binds against exactly these.
+      attr_reader :declarations, :libs, :cflags, :native_handle
+
+      # True when the Stage B native arm is live (shared lib dlopened).
+      def native?
+        !@native_handle.nil?
+      end
 
       def record_lib(mod, name)
         (@libs[mod] ||= []) << name
@@ -60,11 +80,125 @@ module Toy
         (@declarations[mod] ||= []) << [name.to_sym, argtypes, rettype]
         nil
       end
+
+      # ── Stage B: the Fiddle binder ──────────────────────────────────
+      # Called once at load. Honors TOY_MRI_NATIVE=0 (explicit stub-arm
+      # opt-out, silent); otherwise dlopens the shared lib when present,
+      # or hints (one stderr line) at the make target when absent.
+      def try_open_native!
+        return if ENV["TOY_MRI_NATIVE"] == "0"
+        if File.file?(NATIVE_LIB)
+          require "fiddle"
+          @native_handle = Fiddle.dlopen(NATIVE_LIB)
+        else
+          warn "toy/mri: stub arm (native calls raise) — `make libtinynn_shared` " \
+               "builds tinynn/libtinynn_ggml_shared.so for real MRI compute (toy#71)"
+        end
+      end
+
+      # Spinel's FFI lowering, pinned by probing generated C (a699cf9):
+      #   :ptr → void*            (Ruby side: integer-valued handle)
+      #   :int → int              :long → long          :size_t → size_t
+      #   :double → double        :str → const char*    :void → void
+      #   :int_array   → const int64_t* (Spinel Array<Integer> storage;
+      #                  == native long on LP64 → pack("l!*"))
+      #   :float_array → const double*  (Array<Float> storage — NOT
+      #                  float; the C side narrows where needed → pack("d*"))
+      # The tinynn headers declare exactly these widths per family
+      # (verified: int64_t*/long* for the 2 int_array sigs, double* for
+      # the 6 float_array sigs).
+      def fiddle_type(t)
+        case t
+        when :ptr, :str, :int_array, :float_array then Fiddle::TYPE_VOIDP
+        when :int    then Fiddle::TYPE_INT
+        when :long   then Fiddle::TYPE_LONG
+        when :size_t then Fiddle::TYPE_SIZE_T
+        when :double then Fiddle::TYPE_DOUBLE
+        when :void   then Fiddle::TYPE_VOID
+        else
+          raise NativeCallError,
+                "unknown FFI type #{t.inspect} in a declaration — extend " \
+                "Toy::MRI.fiddle_type in lockstep with Spinel's DSL (toy#71)"
+        end
+      end
+
+      INT_ARRAY_FMT   = "l!*"  # native long == int64_t on LP64
+      FLOAT_ARRAY_FMT = "d*"   # C double
+
+      # Build the native (Fiddle-backed) implementation for one
+      # declaration. Spinel's array specs are ZERO-COPY (the C side reads
+      # AND writes the Ruby array's storage); Fiddle can't share storage
+      # with an MRI Array, so we mirror the semantics: pack → call →
+      # unpack → Array#replace IN PLACE on the caller's array. That keeps
+      # output-array conventions (pre-sized Array filled by C, e.g.
+      # tnn_read_i32_file, tnn_download_to_f64_array) working unchanged.
+      def native_impl(mod, name, argtypes, rettype)
+        sym =
+          begin
+            @native_handle[name.to_s]
+          rescue Fiddle::DLError
+            nil
+          end
+        if sym.nil?
+          # Loud, named, at the CALL site (a require-time raise would
+          # take down the whole surface for one stale artifact).
+          return lambda do |*_args|
+            raise NativeCallError,
+                  "native call `#{name}` (declared in #{mod}) is missing from " \
+                  "#{File.basename(NATIVE_LIB)} — stale artifact? rebuild with " \
+                  "`make libtinynn_shared` (toy#71)"
+          end
+        end
+        fn = Fiddle::Function.new(sym,
+                                  argtypes.map { |t| fiddle_type(t) },
+                                  fiddle_type(rettype))
+        lambda do |*args|
+          if args.length != argtypes.length
+            raise ArgumentError,
+                  "#{mod}.#{name}: #{args.length} args for " \
+                  "#{argtypes.length}-arg native declaration"
+          end
+          arrays = nil
+          cargs = Array.new(args.length)
+          i = 0
+          while i < args.length
+            a = args[i]
+            cargs[i] =
+              case argtypes[i]
+              when :ptr then a.nil? ? 0 : a
+              when :int, :long, :size_t then Integer(a)
+              when :double then Float(a)
+              when :str then a # String buffer → const char*
+              when :int_array
+                buf = a.pack(INT_ARRAY_FMT)
+                (arrays ||= []) << [a, buf, INT_ARRAY_FMT]
+                buf
+              when :float_array
+                buf = a.pack(FLOAT_ARRAY_FMT)
+                (arrays ||= []) << [a, buf, FLOAT_ARRAY_FMT]
+                buf
+              end
+            i += 1
+          end
+          r = fn.call(*cargs)
+          arrays&.each { |orig, buf, fmt| orig.replace(buf.unpack(fmt)) }
+          case rettype
+          when :ptr  then r.to_i
+          when :str  then r.null? ? nil : r.to_s
+          when :void then nil
+          else r
+          end
+        end
+      end
     end
 
-    # The deliberate NON-RAISING declarations — every other declared
-    # function raises NativeCallError. Two families, both with an exact,
-    # documented pure-value semantic (no computation is being masked):
+    # The deliberate NON-RAISING declarations of the STUB ARM ONLY —
+    # every other declared function raises NativeCallError there. In the
+    # NATIVE arm this table is BYPASSED ENTIRELY: tnn_null_ptr and the
+    # trace family bind through Fiddle like everything else (real calls,
+    # real off-state values from tinynn_trace.c, real NULL → 0 from
+    # tnn_null_ptr). Two families, both with an exact, documented
+    # pure-value semantic (no computation is being masked):
     #
     # 1. `tnn_null_ptr` — returns a typed NULL `void *`; exists only as
     #    a Spinel type-inference workaround (`:ptr` ivars seed with it
@@ -122,23 +256,28 @@ class Module
     Toy::MRI.record_cflags(self, flags)
   end
 
-  # Records the declaration and defines a module_function `name` that
-  # raises Toy::MRI::NativeCallError. The declaring module's call shape
-  # (TinyNN.tnn_session_new(0)) thus resolves under MRI — to a loud,
-  # named failure at the exact native boundary.
+  # Records the declaration and defines a module_function `name`:
+  # NATIVE arm — a Fiddle::Function binding against the shared lib
+  # (real ggml compute under MRI); STUB arm — a loud, named
+  # Toy::MRI::NativeCallError at the exact native boundary. Either way
+  # the declaring module's call shape (TinyNN.tnn_session_new(0))
+  # resolves under MRI.
   def ffi_func(name, argtypes = [], rettype = :void)
     Toy::MRI.record_func(self, name, argtypes, rettype)
     mod  = self
     sym  = name.to_sym
     impl =
-      if Toy::MRI::OFF_STATE_NATIVES.key?(sym)
+      if Toy::MRI.native?
+        Toy::MRI.native_impl(mod, sym, argtypes, rettype)
+      elsif Toy::MRI::OFF_STATE_NATIVES.key?(sym)
         value = Toy::MRI::OFF_STATE_NATIVES[sym]
         ->(*_args) { value }
       else
         lambda do |*_args|
           raise Toy::MRI::NativeCallError,
                 "native call `#{sym}` (declared in #{mod}) requires the " \
-                "Spinel-compiled binary or the fiddle backend — toy#71"
+                "Spinel-compiled binary or the fiddle backend " \
+                "(`make libtinynn_shared`) — toy#71"
         end
       end
     define_method(sym, &impl)
@@ -152,6 +291,10 @@ class Module
     sym
   end
 end
+
+# Arm selection happens ONCE, before any declaration is processed, so
+# every ffi_func in the chain below binds consistently.
+Toy::MRI.try_open_native!
 
 # With the DSL live, the full compute surface loads under MRI.
 require_relative "compute"

--- a/prep/mri_gate.rb
+++ b/prep/mri_gate.rb
@@ -1,104 +1,268 @@
-# prep/mri_gate.rb — toy#71 Stage A gate: the MRI dev-run entrypoint.
+# prep/mri_gate.rb — toy#71 gate: the MRI dev-run entrypoint, BOTH arms.
 #
 #   make gate-mri        # plain `ruby` — NO Spinel, NO SPINEL_DIR, NO build
 #
-# Proves `require "toy/mri"` gives plain CRuby the whole compute surface:
+# Orchestrates two subprocess legs (each `require "toy/mri"` exactly once,
+# so the two arms never share a process):
 #
-#   1. LOAD  — the full compute require chain loads under MRI (no
-#      NoMethodError from the ffi_lib/ffi_func/ffi_cflags intrinsics or
-#      anything else), and the declaration registry is populated.
-#   2. PURE  — the pure-Ruby teaching surface genuinely works: configs,
-#      RecipeOptions, a real TransformerLM forward + Trainer steps on
-#      the Mat path (losses move), engine CONSTRUCTION.
-#   3. NATIVE — crossing the native boundary fails LOUD with the named
-#      Toy::MRI::NativeCallError (never a bare NoMethodError, never a
-#      silent wrong answer), at both a direct TinyNN call and an
-#      engine realize.
+#   --stub    Stage A (forced TOY_MRI_NATIVE=0):
+#             1. LOAD  — the full compute require chain loads under MRI and
+#                the declaration registry is populated.
+#             2. PURE  — the pure-Ruby teaching surface genuinely works:
+#                configs, RecipeOptions, TransformerLM forward + Trainer
+#                steps on the Mat path, engine CONSTRUCTION.
+#             3. NATIVE — crossing the native boundary fails LOUD with the
+#                named Toy::MRI::NativeCallError.
 #
-# Structural + behavioral, not byte-exact: MRI float printing is the
-# Ruby-libm arm (docs/gating.md "cross-platform"); numeric byte-equality
-# vs the Spinel binaries is Stage B's differential gate.
+#   --native  Stage B (the CRuby oracle; needs `make libtinynn_shared`):
+#             4. BIND  — the Fiddle arm is live; a real session opens on
+#                the cpu backend.
+#             5. DIFFERENTIAL TRAIN — the from-scratch gate shape (the
+#                exact lib/toy/run/train.rb compute: SmolLM2Config.mha
+#                627/64/4/128/2/32, donor_d_in=128, untied, seed 0,
+#                constant AdamW hp, first 32-token window of the PINNED
+#                prep/fixtures/ts_seqs_gate.bin) trained for 5 steps under
+#                MRI+Fiddle MUST reproduce prep/fixtures/train_baseline.txt
+#                — the same recorded curve the Spinel-compiled runner is
+#                gated on (prep/train_gate.rb). Floats compared BIT-EXACT
+#                (pack("G")); the formatted lines are additionally compared
+#                byte-wise and any string-only divergence is REPORTED (not
+#                failed — the documented MRI-Float#to_s-vs-Spinel-printing
+#                boundary; docs/gating.md "cross-platform").
+#             6. KV DECODE — greedy generate on data/smollm2-135m-f32.gguf
+#                (MODEL-GATED dev artifact: loud SKIP when absent, like
+#                gate-full-finetune) MUST byte-equal the recorded `ids:`
+#                line in prep/fixtures/infer_baseline.txt.
+#             Plus an informative perf line (steps/s, decode tok/s).
+#
+# When tinynn/libtinynn_ggml_shared.so is absent the native leg SKIPs
+# LOUDLY (exit 0) so dev boxes without a ggml build stay green; set
+# MRI_GATE_STRICT=1 to turn that skip into a failure (CI-strict mode).
+#
+# WHY THIS IS THE ORACLE (spinel-dev#6 phase 1): leg 5/6 run the SAME toy
+# program over the SAME C library as the Spinel binaries — only the Ruby
+# runtime differs. Bit-equality here means any future divergence between
+# MRI and a Spinel build isolates a Spinel codegen bug by construction.
 
-lib = File.expand_path("../lib", __dir__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require "open3"
+
+ROOT       = File.expand_path("..", __dir__)
+NATIVE_LIB = File.join(ROOT, "tinynn", "libtinynn_ggml_shared.so")
 
 def gate_fail(msg)
   warn "GATE FAIL [mri]: #{msg}"
   exit 1
 end
 
-# ── 1. LOAD ──────────────────────────────────────────────────────────
-begin
-  require "toy/mri"
-rescue StandardError, NoMethodError => e
-  gate_fail "require \"toy/mri\" raised #{e.class}: #{e.message}"
-end
+# ── Orchestrator (no toy require here) ───────────────────────────────
+if ARGV.empty?
+  stub_out, stub_st = Open3.capture2e(
+    { "TOY_MRI_NATIVE" => "0" }, RbConfig.ruby, __FILE__, "--stub"
+  )
+  print stub_out
+  gate_fail "stub leg failed" unless stub_st.success?
 
-gate_fail "Toy::MRI.declarations is empty" if Toy::MRI.declarations.empty?
-n_decl = Toy::MRI.declarations.values.sum(&:size)
-mods   = Toy::MRI.declarations.keys.map(&:to_s).sort
-gate_fail "TinyNN declarations missing" unless mods.include?("TinyNN")
-puts "load ok: #{n_decl} ffi_func declarations recorded across #{mods.join(", ")}"
-
-# ── 2. PURE-RUBY SURFACE ─────────────────────────────────────────────
-srand(0)
-
-cfg = Toy::SmolLM2Config.tiny
-gate_fail "SmolLM2Config.tiny wrong shape" unless
-  cfg.vocab == 627 && cfg.d_model == 64 && cfg.n_layers == 2
-
-opts = Toy::LLM::RecipeOptions.new
-gate_fail "RecipeOptions.new failed" unless opts.is_a?(Toy::LLM::RecipeOptions)
-
-# Engine CONSTRUCTION is pure (ivars seed with typed-NULL handles);
-# only realize crosses the native boundary (checked in part 3).
-engine = Toy::Device.llama_engine
-gate_fail "engine construction failed" unless
-  engine.is_a?(Toy::LLM::Engine::LlamaSeqEngine)
-
-# A real forward + training loop on the Mat path (the teaching stack):
-# tiny shape, 5 steps, assert the loss MOVES DOWN (behavioral, not
-# byte-pinned — see header).
-require "toy/train/toy_trainer"
-lm  = TransformerLM.new(64, 32, 64, 2, 2, 16)
-tr  = Toy::Trainer.new(lm)
-seq = (1..12).to_a
-
-logits = lm.forward(seq)
-gate_fail "forward shape: got #{logits.nrows}x#{logits.ncols}" unless
-  logits.nrows == 12 && logits.ncols == 64
-
-losses = 5.times.map { tr.step!(seq) }
-gate_fail "loss not finite: #{losses.inspect}" unless
-  losses.all? { |l| l.finite? }
-gate_fail "loss did not decrease over 5 steps: #{losses.inspect}" unless
-  losses.last < losses.first
-puts "pure ok: cfg/options/engine construct; 5 Trainer steps " \
-     "loss #{losses.first.round(4)} -> #{losses.last.round(4)}"
-
-# ── 3. NATIVE BOUNDARY FAILS LOUD + NAMED ────────────────────────────
-expect_native_error = lambda do |what, &blk|
-  begin
-    blk.call
-    gate_fail "#{what} did NOT raise"
-  rescue Toy::MRI::NativeCallError => e
-    unless e.message.include?("requires the Spinel-compiled binary") &&
-           e.message.include?("toy#71") &&
-           e.message =~ /native call `tnn_\w+`/
-      gate_fail "#{what} raised with unexpected message: #{e.message}"
-    end
-    e.message[/`(tnn_\w+)`/, 1]
-  rescue => e
-    gate_fail "#{what} raised #{e.class} (want Toy::MRI::NativeCallError): #{e.message}"
+  if File.file?(NATIVE_LIB)
+    nat_out, nat_st = Open3.capture2e(RbConfig.ruby, __FILE__, "--native")
+    print nat_out
+    gate_fail "native leg failed" unless nat_st.success?
+  elsif ENV["MRI_GATE_STRICT"] == "1"
+    gate_fail "native leg REQUIRED (MRI_GATE_STRICT=1) but " \
+              "#{NATIVE_LIB} is missing — run `make libtinynn_shared`"
+  else
+    puts "mri-gate: NATIVE LEG SKIPPED — #{NATIVE_LIB} missing; " \
+         "`make libtinynn_shared` builds it (MRI_GATE_STRICT=1 makes this a failure)"
   end
+  puts "mri-gate: ok"
+  exit 0
 end
 
-name1 = expect_native_error.call("direct TinyNN.tnn_session_new(0)") do
-  TinyNN.tnn_session_new(0)
-end
-name2 = expect_native_error.call("engine.realize_for_random_init") do
-  engine.realize_for_random_init(cfg, 32, 1, 0, false, false, 0, 1.0)
-end
-puts "native ok: `#{name1}` and `#{name2}` raise the named NativeCallError"
+lib = File.join(ROOT, "lib")
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-puts "mri-gate: ok"
+case ARGV[0]
+
+# ── The Stage A leg: stub arm ────────────────────────────────────────
+when "--stub"
+  ENV["TOY_MRI_NATIVE"] = "0"   # belt-and-braces for direct invocation
+
+  # 1. LOAD
+  begin
+    require "toy/mri"
+  rescue StandardError, NoMethodError => e
+    gate_fail "require \"toy/mri\" raised #{e.class}: #{e.message}"
+  end
+  gate_fail "native arm bound despite TOY_MRI_NATIVE=0" if Toy::MRI.native?
+  gate_fail "Toy::MRI.declarations is empty" if Toy::MRI.declarations.empty?
+  n_decl = Toy::MRI.declarations.values.sum(&:size)
+  mods   = Toy::MRI.declarations.keys.map(&:to_s).sort
+  gate_fail "TinyNN declarations missing" unless mods.include?("TinyNN")
+  puts "load ok: #{n_decl} ffi_func declarations recorded across #{mods.join(", ")}"
+
+  # 2. PURE-RUBY SURFACE
+  srand(0)
+  cfg = Toy::SmolLM2Config.tiny
+  gate_fail "SmolLM2Config.tiny wrong shape" unless
+    cfg.vocab == 627 && cfg.d_model == 64 && cfg.n_layers == 2
+  opts = Toy::LLM::RecipeOptions.new
+  gate_fail "RecipeOptions.new failed" unless opts.is_a?(Toy::LLM::RecipeOptions)
+  engine = Toy::Device.llama_engine
+  gate_fail "engine construction failed" unless
+    engine.is_a?(Toy::LLM::Engine::LlamaSeqEngine)
+
+  require "toy/train/toy_trainer"
+  lm  = TransformerLM.new(64, 32, 64, 2, 2, 16)
+  tr  = Toy::Trainer.new(lm)
+  seq = (1..12).to_a
+  logits = lm.forward(seq)
+  gate_fail "forward shape: got #{logits.nrows}x#{logits.ncols}" unless
+    logits.nrows == 12 && logits.ncols == 64
+  losses = 5.times.map { tr.step!(seq) }
+  gate_fail "loss not finite: #{losses.inspect}" unless
+    losses.all? { |l| l.finite? }
+  gate_fail "loss did not decrease over 5 steps: #{losses.inspect}" unless
+    losses.last < losses.first
+  puts "pure ok: cfg/options/engine construct; 5 Trainer steps " \
+       "loss #{losses.first.round(4)} -> #{losses.last.round(4)}"
+
+  # 3. NATIVE BOUNDARY FAILS LOUD + NAMED
+  expect_native_error = lambda do |what, &blk|
+    begin
+      blk.call
+      gate_fail "#{what} did NOT raise"
+    rescue Toy::MRI::NativeCallError => e
+      unless e.message.include?("requires the Spinel-compiled binary") &&
+             e.message.include?("toy#71") &&
+             e.message =~ /native call `tnn_\w+`/
+        gate_fail "#{what} raised with unexpected message: #{e.message}"
+      end
+      e.message[/`(tnn_\w+)`/, 1]
+    rescue => e
+      gate_fail "#{what} raised #{e.class} (want Toy::MRI::NativeCallError): #{e.message}"
+    end
+  end
+  name1 = expect_native_error.call("direct TinyNN.tnn_session_new(0)") do
+    TinyNN.tnn_session_new(0)
+  end
+  name2 = expect_native_error.call("engine.realize_for_random_init") do
+    engine.realize_for_random_init(cfg, 32, 1, 0, false, false, 0, 1.0)
+  end
+  puts "native ok: `#{name1}` and `#{name2}` raise the named NativeCallError"
+
+# ── The Stage B leg: native arm (the CRuby oracle) ───────────────────
+when "--native"
+  gate_fail "native leg invoked but #{NATIVE_LIB} is missing" unless
+    File.file?(NATIVE_LIB)
+  gate_fail "native leg needs TOY_MRI_NATIVE unset/non-0" if
+    ENV["TOY_MRI_NATIVE"] == "0"
+
+  begin
+    require "toy/mri"
+  rescue StandardError, NoMethodError => e
+    gate_fail "require \"toy/mri\" (native arm) raised #{e.class}: #{e.message}"
+  end
+  gate_fail "Fiddle arm did not bind (Toy::MRI.native? false)" unless
+    Toy::MRI.native?
+
+  # 4. BIND — a real session round-trip on the cpu backend.
+  sess = TinyNN.tnn_session_new(0)
+  gate_fail "tnn_session_new returned #{sess.inspect}" unless
+    sess.is_a?(Integer) && sess != 0
+  backend = TinyNN.tnn_backend_name(sess)
+  gate_fail "backend #{backend.inspect}, want \"cpu\"" unless backend == "cpu"
+  TinyNN.tnn_session_free(sess)
+  puts "bind ok: Fiddle arm live (#{File.basename(NATIVE_LIB)}, backend cpu)"
+
+  # 5. DIFFERENTIAL TRAIN — vs the recorded Spinel gate curve.
+  baseline_path = File.join(ROOT, "prep", "fixtures", "train_baseline.txt")
+  expected = File.readlines(baseline_path).filter_map do |line|
+    l = line.chomp
+    next if l.empty? || l.start_with?("#")
+    m = l.match(/\Astep (\d+): loss=(.+)\z/)
+    gate_fail "unparseable baseline line: #{l.inspect}" unless m
+    [l, Float(m[2])]
+  end
+  gate_fail "train_baseline.txt held no step lines" if expected.empty?
+
+  cfg = Toy::SmolLM2Config.mha(627, 64, 4, 128, 2, 32, 10000.0, 1.0e-5)
+  cfg.donor_d_in = 128
+  opts = Toy::LLM::RecipeOptions.new
+  opts.t_seq  = 32
+  opts.untied = true
+  opts.seed   = 0
+  recipe = Toy::LLM::Recipes::FromScratch.new
+  recipe.realize!(cfg, opts)
+
+  # PINNED corpus (cross-platform gate rule): its first 32-token window
+  # equals data/ts_seqs.txt line 1, the runner's from-scratch input.
+  seq_ids   = ToyCorpusLoader.read_seq(
+    File.join(ROOT, "prep", "fixtures", "ts_seqs_gate.bin"), 0, 32)
+  positions = (0...32).to_a
+  m_labels  = Toy::Labels.next_token(seq_ids, 627, 32, 1)
+  m_hp      = Toy::AdamW.for_from_scratch.hp(0)
+
+  t0 = Time.now
+  got = expected.each_index.map do |step|
+    loss = recipe.step!(seq_ids, positions, m_labels, m_hp, step.zero?)
+    ["step #{step + 1}: loss=#{loss}", loss]
+  end
+  train_secs = Time.now - t0
+
+  string_drift = []
+  expected.zip(got).each_with_index do |((want_line, want_f), (got_line, got_f)), i|
+    unless [want_f].pack("G") == [got_f].pack("G")
+      gate_fail "differential train step #{i + 1}: MRI+Fiddle loss #{got_f} " \
+                "(bits #{[got_f].pack("G").unpack1("H*")}) != Spinel gate curve " \
+                "#{want_f} (bits #{[want_f].pack("G").unpack1("H*")})"
+    end
+    string_drift << [want_line, got_line] if want_line != got_line
+  end
+  if string_drift.empty?
+    puts "differential ok: #{expected.size} train losses BIT-EXACT vs " \
+         "train_baseline.txt (formatted lines byte-equal too)"
+  else
+    # Values bit-equal, formatting differs: the documented fallback arm.
+    string_drift.each do |want, gotl|
+      puts "  format-only drift: spinel=#{want.inspect} mri=#{gotl.inspect}"
+    end
+    puts "differential ok: #{expected.size} train losses BIT-EXACT vs " \
+         "train_baseline.txt (#{string_drift.size} format-only drifts above)"
+  end
+
+  # 6. KV DECODE — vs the recorded infer baseline (model-gated).
+  gguf = File.join(ROOT, "data", "smollm2-135m-f32.gguf")
+  if File.exist?(gguf)
+    infer_baseline = File.join(ROOT, "prep", "fixtures", "infer_baseline.txt")
+    want_line = nil
+    File.foreach(infer_baseline) do |line|
+      next if line.strip.empty? || line.start_with?("#")
+      key, val = line.chomp.split("\t", 2)
+      want_line = val if key == "smollm2-135m-f32.gguf"
+    end
+    gate_fail "no smollm2-135m-f32.gguf entry in infer_baseline.txt" unless want_line
+
+    require "toy/models/transformer_lm"
+    arch = Arch.load_or_fail(gguf, "mri_gate")
+    lm = ToyLM.new(arch, :cpu)
+    lm.load(gguf)
+    prompt_ids = [6403, 1980, 253, 655, 28]   # infer_gate's PROMPT_IDS
+    t1 = Time.now
+    out_ids = lm.generate(prompt_ids, 8)
+    decode_secs = Time.now - t1
+    got_line = "ids: " + out_ids.join(" ")
+    gate_fail "KV decode ids diverge:\n  want #{want_line.inspect}\n  got  #{got_line.inspect}" unless
+      got_line == want_line
+    puts "kv-decode ok: greedy ids byte-equal infer_baseline.txt " \
+         "(smollm2-135m-f32, prompt 5 ids + 8 new)"
+    puts format("perf (informative): %.1f train steps/s; %.1f decode tok/s — MRI+Fiddle, CPU",
+                expected.size / train_secs, 8 / decode_secs)
+  else
+    puts "kv-decode SKIPPED — #{gguf} missing (gitignored dev model, " \
+         "same gating as gate-full-finetune); train differential above still binding"
+    puts format("perf (informative): %.1f train steps/s — MRI+Fiddle, CPU",
+                expected.size / train_secs)
+  end
+
+else
+  gate_fail "unknown argument #{ARGV[0].inspect} (use --stub / --native / no args)"
+end

--- a/tinynn/Makefile
+++ b/tinynn/Makefile
@@ -12,6 +12,21 @@ OBJS := tinynn_ggml.o tinynn_gguf.o tinynn_trace.o tinynn_events.o
 libtinynn_ggml.a: $(OBJS)
 	ar rcs $@ $(OBJS)
 
+# toy#71 Stage B — the CRuby-oracle shared object (MRI dlopens it via
+# Fiddle; see lib/toy/mri.rb). Self-contained: tinynn objects + the static
+# CPU ggml archives, -Wl,-Bsymbolic for the aarch64 vtable relocations,
+# --whole-archive so the backend registry survives, -lm trailing. Linux/
+# CPU only this stage (macOS dylib + CUDA/Metal variants are follow-ups).
+# Mirrors the root Makefile's libtinynn_shared rule — keep both in sync.
+shared: libtinynn_ggml_shared.so
+.PHONY: shared
+
+libtinynn_ggml_shared.so: $(OBJS)
+	$(CC) -shared -Wl,-Bsymbolic -o $@ $(OBJS) \
+	  -L../vendor/ggml/build/src \
+	  -Wl,--whole-archive -lggml -lggml-cpu -lggml-base -Wl,--no-whole-archive \
+	  -lstdc++ -lpthread -lm
+
 # Optional backend shims (toy#45 Phase 3). NOT in the default target —
 # they are separate build-unit targets ("targets": ["cuda"] / ["metal"]
 # in spinel-ext.json's default-disabled cuda-shim / metal-shim entries),


### PR DESCRIPTION
## toy#71 Stage B — the Fiddle backend / CRuby oracle

Same entrypoint (`lib/toy/mri.rb`), new arm: when `tinynn/libtinynn_ggml_shared.so` exists, every `ffi_func` declaration binds through Fiddle and the SAME toy program runs real ggml compute under plain CRuby. The 186 unique declarations are the spec — no second surface.

### What's here
- **`make libtinynn_shared`** → `tinynn/libtinynn_ggml_shared.so` (gitignored): tinynn objects + the static CPU ggml archives, `-Wl,-Bsymbolic` (aarch64 vtable relocs), `--whole-archive`, ffi_lib-mirroring link order (`-lm` trailing, no gomp — CPU ggml is OPENMP=OFF). Mirrored in `tinynn/Makefile` (`make -C tinynn shared`). Linux/CPU this stage; macOS dylib + CUDA/Metal = follow-ups.
- **The Fiddle arm** in `lib/toy/mri.rb`: auto-detect at the repo-relative path, `TOY_MRI_NATIVE=0` opt-out, absence = Stage A stub + one-line hint. OFF_STATE carve-outs bypassed in native mode (real calls). Missing symbol → named `NativeCallError` at the call site.
- **`make gate-mri` native leg** (`prep/mri_gate.rb --native`; loud SKIP without the .so, `MRI_GATE_STRICT=1` fails instead): differential train + KV decode + perf line.
- Docs: `consuming-toy.md` MRI section (two arms, build instructions, the oracle framing, lowering table), `gating.md`.

### Differential verdict: BIT-EXACT
- **Train**: the from-scratch gate shape (exact `lib/toy/run/train.rb` compute, pinned `ts_seqs_gate.bin` window, 5 steps) under MRI+Fiddle reproduces `prep/fixtures/train_baseline.txt` — parsed floats bit-equal (`pack("G")`) AND the formatted `step N: loss=…` lines byte-equal. No libm/float-printing boundary surfaced; the exact-on-values fallback is implemented but was not needed.
- **KV decode**: smollm2-135m-f32 greedy ids byte-equal `prep/fixtures/infer_baseline.txt` (`ids: 6403 1980 253 655 28 665 436 253 1838 8180 3365 14176 30`).

### Type ground truth (probed `spinel -c` at a699cf9 + tinynn headers)
`:ptr`→`void*` (integer handles Ruby-side), `:int`→`int`, `:long`→`long`, `:size_t`→`size_t`, `:double`→`double`, `:str`→`const char*` (NULL→nil on return), `:int_array`→`const int64_t*` (`pack("l!*")`), `:float_array`→`const double*` (`pack("d*")` — Spinel arrays store f64, NOT f32; the C side narrows). Zero-copy array semantics mirrored by pack→call→unpack→`Array#replace`, so pre-sized output arrays (`tnn_read_i32_file`, `tnn_download_to_f64_array`) work unchanged.

### Perf (informative, gx10 CPU)
- Tiny from-scratch train: MRI+Fiddle ~660 steps/s vs compiled toy-train ~915 steps/s (≈0.7×; graph compute dominates at this shape).
- smollm2-135m decode: MRI ~8.5 tok/s vs compiled ~85 tok/s (≈10×; per-token 49k-vocab logits download pays the pack/unpack + Ruby argmax toll). Fine for an oracle; not a serving path.

### Spinel-side safety (SPINEL_DIR=/tmp/spinel-a699cf9-serve, gx10)
gate-compute-surface PASS · gate-compute-surface-cuda PASS · train_gate 4/4 byte-exact PASS · gate-consumer PASS (incl. --lib leg) · gate-mri both legs PASS. Nothing compiled changed (the diff touches no compiled require chain; tinynn/Makefile only gains a target).

Closes the Stage B half of #71.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
