### PR TITLE
build(#71): macOS variant for libtinynn_shared — Stage B CRuby oracle Mac-verified

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1222,9 +1222,18 @@ libtinynn_shared: tinynn/libtinynn_ggml_shared.so
 
 tinynn/libtinynn_ggml_shared.so: tinynn/tinynn_ggml.o tinynn/tinynn_gguf.o tinynn/tinynn_trace.o tinynn/tinynn_events.o $(GGML_DIR)/build/src/libggml.a
 ifeq ($(UNAME_S),Darwin)
-	@echo "libtinynn_shared: Linux-only this stage (toy#71 Stage B is the gx10 CPU oracle;"
-	@echo "  the macOS -dynamiclib/-force_load variant is a follow-up — needs Mac verification)"
-	@exit 1
+	# macOS variant (toy#71 Stage B follow-up, Mac-verified 2026-06-12):
+	# -dynamiclib for -shared; -force_load per archive for GNU ld's
+	# --whole-archive (pulls every ggml object so the Fiddle backend
+	# resolves all tnn_* symbols); -lc++ for libc++ (not libstdc++); no
+	# -Bsymbolic (macOS two-level namespace already binds internally).
+	# Output keeps the .so name the gate/Fiddle loader expects.
+	$(CC) -dynamiclib -o $@ \
+	  tinynn/tinynn_ggml.o tinynn/tinynn_gguf.o tinynn/tinynn_trace.o tinynn/tinynn_events.o \
+	  -Wl,-force_load,$(GGML_DIR)/build/src/libggml.a \
+	  -Wl,-force_load,$(GGML_DIR)/build/src/libggml-cpu.a \
+	  -Wl,-force_load,$(GGML_DIR)/build/src/libggml-base.a \
+	  -lc++ -lpthread -lm
 else
 	$(CC) -shared -Wl,-Bsymbolic -o $@ \
 	  tinynn/tinynn_ggml.o tinynn/tinynn_gguf.o tinynn/tinynn_trace.o tinynn/tinynn_events.o \


### PR DESCRIPTION
The `libtinynn_shared` rule's Darwin branch was a stub that `exit 1`'d with *"the macOS -dynamiclib/-force_load variant is a follow-up — needs Mac verification"*. This implements and **verifies it on Apple M2** (toy#27 run 4, toy `73af46a`).

### The translation (GNU ld → macOS ld)
| Linux | macOS |
|-------|-------|
| `-shared` | `-dynamiclib` |
| `-Wl,--whole-archive … --no-whole-archive` | `-Wl,-force_load,<archive>` per ggml `.a` |
| `-lstdc++` | `-lc++` (libc++) |
| `-Wl,-Bsymbolic` | dropped (macOS two-level namespace binds internally) |

Output keeps the `.so` name the Fiddle loader / `gate-mri` expect (Fiddle dlopen's a Mach-O dylib by path regardless of extension).

### Verified on Apple M2
- `make libtinynn_shared` → `Mach-O 64-bit dynamically linked shared library arm64`.
- `MRI_GATE_STRICT=1 make gate-mri` → **full Stage B CRuby oracle passes**:
  - `differential ok`: 5 from-scratch train losses **BIT-EXACT** vs `prep/fixtures/train_baseline.txt` (formatted lines byte-equal too)
  - `kv-decode ok`: smollm2-135m greedy ids **byte-equal** `prep/fixtures/infer_baseline.txt`
  - perf: ~431 train steps/s, ~3.1 decode tok/s (MRI+Fiddle, CPU)

So the bit-exact CRuby oracle now runs on Apple Silicon, not just the gx10 Linux box. Linux branch untouched.

Full run-4 results: [#27](https://github.com/OriPekelman/toy/issues/27).

🤖 Generated with [Claude Code](https://claude.com/claude-code)