### PR TITLE
release: v0.8.0 — the first published version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,49 @@
 # Changelog
 
-## Unreleased
+## v0.8.0 — 2026-06-12
+
+**The first published version** (RubyGems, gem name graciously transferred
+by Ninoslav Milenović — see README acknowledgments). The release of the
+"first form right" arc (#58): toy is now a publishable dual-use framework —
+a playable CLI and a clean library — with every README claim gate-tested.
+
+Highlights of the arc (full trail: issues #58–#87):
+
+- **The experimenter API** (#64/#73): `RecipeOptions` named setters replace
+  the 8-positional `realize!`; validating `TrainingBatch` (+ objectives) and
+  `ClassifyBatch`; `AdamW.for_from_scratch`/`.for_lora` + `hp_for_step`
+  (misuse fails loud); `realize_warm!` owns donor plumbing; `Toy::RunBundle`
+  writer + `Toy::RunLog` reader (`RunLog.scan("runs")` — best run in one
+  line); config profile factories (`SmolLM2Config.tiny/.mid`,
+  `ViTTinyConfig.tiny`); ENV-driven scaffolds (one compile, many runs).
+- **Tree truth** (#65/#68): the layered stack is the whole library —
+  `lib/` is exactly `toy.rb` + `toy/`; tinynn under `toy/ffi/`, loaders
+  under `toy/io/loaders/`, KV decode + the lifted GPT-2 engines under
+  `toy/llm/engine/`; docs teach the real six layers (L4 = Engine).
+- **Compile-time devices** (#64/#70): `toy/compute` ·
+  `toy/compute_cuda` · `toy/compute_metal` entries; `toy new --lib` ships a
+  multi-arch `build.sh`; GPU vendor build-units (opt-in) validated through
+  the consumer front door (CUDA byte-exact on GB10; Metal Mac-verified).
+- **MRI dev-runs + the CRuby oracle** (#71): `require "toy/mri"` loads
+  everything under plain Ruby (teaching surface works pure-Ruby); with
+  `make libtinynn_shared`, the Fiddle arm runs the real compute path —
+  **bit-exact vs the Spinel binaries on both Linux/aarch64 and Apple
+  Silicon** (train curves and decode ids).
+- **Curated examples + tested quickstart** (#60): 7 narrated examples
+  replace the 60-entry sprawl; `make gate-consumer` proves the README
+  cold-start (app + `--lib` legs) on Linux and macOS.
+- **Coverage honesty** (#61/#76/#77): 17-model matrix re-verified with
+  provenance stamps; Qwen3 CUDA fixed (below); Qwen2.5 CUDA-Q8 footnote
+  upgraded; bench-vs-PyTorch legs restored (train 1.064×, infer 1.399×).
+- **sig/*.rbs type roots** (#69): shipped in the gem and consumed at
+  compile (`--rbs sig`) — uncalled-param poly-widening defense for toy and
+  for every consumer.
+- **lora in `toy/compute`** (#52): the exclusion dissolved with the #64
+  reshape; the compute-surface gate carries an uncalled-LoRA tripwire.
+- Upstream: eight Spinel issues filed from this arc (the silent-failure
+  cluster spinel-dev#17/#19/#20/#21/#23 among them), two fixed same-day.
+
+Itemized entries accumulated during the arc:
 
 - **#70: GPU build-units merged into `spinel-ext.json`** (spinelgems#20
   landed: `"default": "disabled"` opt-in + `--with-ext NAME` /

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <img src="toy_logo.png" alt="toy" width="240" />
 </p>
 
-**v0.7.0-pre-alpha** · not API-stable
+**v0.8.0** · first published gem · pre-1.0, not API-stable
 &nbsp;·&nbsp; [CHANGELOG](CHANGELOG.md)
 &nbsp;·&nbsp; [docs](docs/architecture.md)
 &nbsp;·&nbsp; [framework guide](docs/framework.md)

--- a/docs/consuming-toy.md
+++ b/docs/consuming-toy.md
@@ -10,6 +10,29 @@ into toy's tree.
 > which is clean and self-contained. See [`cli.md`](cli.md). This doc is the
 > *library-composition* surface.
 
+## Recommended Spinel revision (v0.8.0)
+
+toy v0.8.0 is verified against the **union of two Spinel fix branches**
+(both on [`OriPekelman/spinel`](https://github.com/OriPekelman/spinel),
+both submitted upstream):
+
+```sh
+git clone https://github.com/OriPekelman/spinel && cd spinel
+git fetch origin fix/array-literal-ctor-element-pin fix/poly-array-concrete-array-boundary
+git checkout --detach ddee073        # serve fix (spinel-dev#14)
+git merge a699cf9 --no-edit          # eval fix (spinel-dev#13); merges clean
+make deps && make
+```
+
+At that union (verified 2026-06-12, gx10/GB10, toy `f7361eb`): the full
+gate matrix passes — 26 gates, byte-exact where gated so, including serve
+(full-size binary, live HTTP) and the MRI oracle — and the compile is the
+cleanest on record (zero poly-degrade warnings). When Spinel master
+contains both fixes (matz/spinel PR 1385 + follow-ups), prefer master and
+this section will move to a plain rev pin. Known residual at any current
+rev: the `tinynn/gpt2_*` parity harnesses need `f6d5eef`
+(spinel-dev#22) — internal tooling only, no library surface affected.
+
 ## The recipe (toy#45: Gemfile + vendor — that's it)
 
 Toy ships `spinel-ext.json` **build-units** (spinelgems#14): `spinel-compat

--- a/lib/toy/version.rb
+++ b/lib/toy/version.rb
@@ -3,9 +3,9 @@
 # Spinel-only `ffi_lib` / `ffi_cflags` directives that don't load
 # under CRuby).
 module Toy
-  # Gem-canonical prerelease form of "v0.7.0-pre-alpha" (RubyGems renders
-  # dots, not dashes). Single source of truth: gemspec + `toy --version`
-  # + `toy --manifest` all read this; README/CHANGELOG display it as
-  # v0.7.0-pre-alpha.
-  VERSION = "0.7.0.pre.alpha".freeze
+  # Single source of truth: gemspec + `toy --version` + `toy --manifest`
+  # all read this; README/CHANGELOG/git tag display it as v0.8.0.
+  # v0.8.0 (2026-06-12) is the first PUBLISHED version (RubyGems).
+  # Pre-1.0: not API-stable.
+  VERSION = "0.8.0".freeze
 end


### PR DESCRIPTION
Version bump (single source `lib/toy/version.rb` → gemspec/`--version`/`--manifest`), README badge, the CHANGELOG v0.8.0 entry summarizing the #58 arc, and the recommended-Spinel-pin section in consuming-toy.md (the #13+#14 fix union — full gate matrix verified, serve live beyond f6d5eef for the first time, zero poly-degrade warnings).

After merge: tag `v0.8.0` + GitHub release + `gem build`/`push` (#62).

🤖 Generated with [Claude Code](https://claude.com/claude-code)