### PR TITLE
spike(#30): tep OpenAI Backend — Bug B gone at the union pin, collapse blocked on ids/text shape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## Unreleased
+
+- **toy#30 spike — tep OpenAI Backend adoption (SPIKE ONLY, not collapsed):**
+  Verified at the toy-v0.8.0 union Spinel pin (`fbb9beb`, the #13+#14 union)
+  whether `Tep::Llm::OpenAI::Server.use(ToyBackend.new) + serve!` produces
+  correct JSON. **Result: the "Bug B" JSON-key blanking
+  (`Tep::Json.encode_pair_str` → `{"":"","":""}`) NO LONGER reproduces at this
+  pin** — `/v1/models`, `/v1/completions`, `/v1/embeddings` all encode
+  byte-correct keys+values, and the cross-repo `Server.use` dispatch into a
+  `ToyBackend` authored in toy's compilation unit works live (embeddings
+  vector byte-identical to the hand-rolled handler). Bug B was a Spinel
+  regression cleared by the union, not a tep defect (tep#205 clean at this pin).
+  **The collapse did NOT ship:** tep's battery `CompletionsHandler` emits a
+  `text` field, but `prep/serve_gate.rb` + `prep/serve_events_gate.rb`
+  hard-require `choices[0].ids` (toy speaks token IDs, not text). The battery
+  has no `ids` field and the vendored tep is generated (no hand-edits), so a
+  straight `Server.use + serve!` swap would change the wire bytes and fail both
+  serve gates — which the "never change serve JSON" rule forbids. Toy keeps its
+  hand-rolled handlers. Spike harness: `prep/serve_spike_tepbackend.rb`. Next
+  step is tep-side: a battery completion shape that can carry `ids` (or a
+  toy-owned `CompletionsHandler` override on top of the Backend), tracked on
+  toy#30.
+
 ## v0.8.0 — 2026-06-12
 
 **The first published version** (RubyGems, gem name graciously transferred

--- a/prep/serve_spike_tepbackend.rb
+++ b/prep/serve_spike_tepbackend.rb
@@ -1,0 +1,132 @@
+# prep/serve_spike_tepbackend.rb -- PHASE 1 SPIKE for toy#30.
+#
+# NOT a shipped runner. Verifies, at the toy-v0.8.0 union Spinel pin,
+# whether the tep OpenAI Backend battery (Tep::Llm::OpenAI::Server.use +
+# serve! + the battery's ModelsHandler/CompletionsHandler/EmbeddingsHandler)
+# produces CORRECT JSON when a Backend subclass authored in TOY's
+# compilation unit dispatches through APP.openai_backend.
+#
+# DECISION GATE: if the battery JSON is byte-correct (no blank keys, no
+# pointer-ints) -> proceed to the collapse. If "Bug B" (Tep::Json.escape
+# poly-degradation blanking keys/values) reproduces -> STOP, stay on toy's
+# hand-rolled handlers. See toy#30 / tep#205.
+#
+# Loads toy's FULL serve surface (model load via server.rb's STATE +
+# api_generate_ids + the embeddings lookup) so sched_fibers stays concrete
+# (a minimal surface degrades it -> matz/spinel#1369 boot crash).
+
+require_relative "../lib/toy/llm/engine/llama_kv_engine"
+require_relative "../vendor/spinel/spinel_kit/lib/spinel_kit/json_builder"
+require_relative "../lib/toy/io/toy_events"
+require_relative "../lib/toy/io/loaders/toy_smollm2_loader"
+require_relative "../vendor/spinel/deps"
+# server.rb defines STATE (model loaded at require time), MODEL_NAME,
+# api_generate_ids, api_now_unix. Reused verbatim -- the spike does not
+# duplicate the loader/decode logic.
+require_relative "../lib/toy/serve/openai/server"
+
+# ToyBackend authored HERE (toy's compilation unit), subclassing the
+# vendored tep Backend. Overrides the three model-specific surfaces.
+class ToyBackend < Tep::Llm::OpenAI::Backend
+  def list_models
+    out = [""]
+    out.delete_at(0)
+    out.push(STATE.model_name)
+    out
+  end
+
+  def device_kind
+    "cpu"
+  end
+
+  # token-level greedy generation -> Tep::Llm::OpenAI::Completion.
+  # Reuses server.rb's api_generate_ids (deterministic argmax). The tep
+  # CompletionsHandler emits `text` (not toy's `ids`); for the SPIKE we
+  # only care that the JSON ENVELOPE encodes correctly, so text carries
+  # a deterministic string of the decoded ids.
+  def generate_from_tokens(model, token_ids, sampling)
+    n_new = sampling.max_tokens
+    if n_new <= 0
+      n_new = 16
+    end
+    if n_new > 256
+      n_new = 256
+    end
+    new_ids = api_generate_ids(token_ids, n_new)
+    comp = Tep::Llm::OpenAI::Completion.new
+    txt = ""
+    i = 0
+    while i < new_ids.length
+      if i > 0
+        txt = txt + ","
+      end
+      txt = txt + new_ids[i].to_s
+      i = i + 1
+    end
+    comp.text              = txt
+    comp.prompt_tokens     = token_ids.length
+    comp.completion_tokens = new_ids.length
+    comp
+  end
+
+  def supports_embeddings?
+    true
+  end
+
+  # mean-pooled embedding -> Array[Float] of length d_model.
+  # The lookup + pooling moves here from EmbeddingsHandler#handle.
+  def generate_embeddings(model, token_ids)
+    d_model = STATE.cfg.d_model
+    sess    = STATE.kv.sess
+    t_embed = STATE.kv.t_token_embed
+
+    sum_buf = [0.0]; sum_buf.pop
+    j0 = 0
+    while j0 < d_model
+      sum_buf.push(0.0)
+      j0 = j0 + 1
+    end
+    tok_buf = [0.0]; tok_buf.pop
+    j1 = 0
+    while j1 < d_model
+      tok_buf.push(0.0)
+      j1 = j1 + 1
+    end
+
+    i = 0
+    while i < token_ids.length
+      rc = TinyNN.tnn_embed_lookup_to_doubles(sess, t_embed, token_ids[i], tok_buf, d_model)
+      k = 0
+      while k < d_model
+        sum_buf[k] = sum_buf[k] + tok_buf[k]
+        k = k + 1
+      end
+      i = i + 1
+    end
+
+    inv_n = 1.0 / token_ids.length.to_f
+    out = [0.0]; out.pop
+    kk = 0
+    while kk < d_model
+      out.push(sum_buf[kk] * inv_n)
+      kk = kk + 1
+    end
+    out
+  end
+end
+
+SERVE_PORT = (ENV["PORT"] || "4567").to_i
+
+# Pin api_gen_id's `prefix` param to String so co-loading tep's battery
+# doesn't widen the (otherwise-uncalled) helper to poly -> char* (the
+# 2026-06-08 spike artifact; server.rb:108). A String-literal call keeps
+# the param concrete. The real collapse keeps a String call site too.
+_pin_gen_id = api_gen_id("cmpl")
+puts "[spike] api_gen_id pin: " + _pin_gen_id
+
+# The collapse shape: register the backend, mount the battery routes.
+Tep::Llm::OpenAI::Server.use(ToyBackend.new)
+Tep::Llm::OpenAI::Server.serve!("")
+
+puts "[spike] tep battery mounted; serving on " + SERVE_PORT.to_s
+Tep.run!(SERVE_PORT, 1, false)


### PR DESCRIPTION
## toy#30 — adopt tep's `Tep::Llm::OpenAI::Backend` — SPIKE verdict

**DRAFT.** Phase 1 (the deciding spike) ran; Phase 2 (the collapse) is blocked on a wire-shape mismatch, so toy keeps its hand-rolled handlers.

### Phase 1 — JSON-correctness at the union pin: PASS (Bug B is gone)

Built at `SPINEL_DIR=/tmp/spinel-union-1414` (the verified #13+#14 union `fbb9beb`, the toy-v0.8.0 pin tree):

- A `ToyBackend < Tep::Llm::OpenAI::Backend` authored in **toy's own** compilation unit (`prep/serve_spike_tepbackend.rb`), overriding `list_models` / `generate_from_tokens` / `generate_embeddings` / `supports_embeddings?`, dispatched via `Tep::Llm::OpenAI::Server.use(ToyBackend.new) + serve!` + `Tep.run!`, loaded with toy's **full** serve surface (`server.rb` STATE + model load).
- Byte-diffed the battery JSON against the **current hand-rolled serve built at the same pin** (the proven-correct oracle, the binary `serve_gate` passes against).

| endpoint | battery output | verdict |
|---|---|---|
| `GET /v1/models` | `{"object":"list","data":[{"id":"test","object":"model","owned_by":"tep"}]}` | keys+values correct |
| `POST /v1/completions` | `{"id":"cmpl-tep","object":"text_completion","created":...,"model":"test","choices":[{"index":0,"text":"198,198,504,808,2775,288,536,314","finish_reason":"stop"}],"usage":{...}}` | keys+values correct; dispatched into `ToyBackend#generate_from_tokens` (same ids as oracle) |
| `POST /v1/embeddings` | OpenAI envelope; embedding vector **byte-identical** to the hand-rolled handler (576 floats) | correct |
| `POST /v1/chat/completions` | `{"error":{"message":"chat completions not supported...","type":"not_implemented"}}` (501) | correct |

**Bug B does NOT reproduce at the union pin.** The prior `Tep::Json.encode_pair_str` → `{"":"","":""}` key-blanking (last seen at `f6d5eef`/`cb23cc6`) was a Spinel regression cleared by the union — there is no `Tep_Json.escape` poly-degradation warning at codegen, and the live JSON has correct keys+values. Cross-repo `Server.use(ConcreteBackend.new)` observed-subclass dispatch is proven live (the "verify first" item from the issue body is done — again, and now JSON-clean).

### Phase 2 — the collapse: BLOCKED (distinct from Bug B)

The full swap (`Server.use + serve!` replacing toy's manual wiring) **cannot ship byte-identical**, and the "never change serve JSON" rule forbids changing the wire bytes:

1. **`ids` vs `text`.** tep's battery `CompletionsHandler` emits a `text` field; the battery `Completion` class has **no `ids` field**. But `prep/serve_gate.rb` (L202) and `prep/serve_events_gate.rb` (L206) **hard-require `choices[0].ids` as an Array** — toy speaks token IDs, not detokenized text. A straight battery swap drops `ids` → both gates fail.
2. **Other shape drifts** (would change the wire even if a gate didn't catch them): `/v1/models` battery drops `created` and uses `owned_by:"tep"` (toy: `owned_by:"toy"` + `created`); completions `finish_reason:"stop"` (toy: `"length"`), `id:"cmpl-tep"` (toy: `cmpl-<timestamp>`).
3. The vendored tep (`vendor/spinel/tep`, 0.11.2) is **generated** — no hand-edits — so the battery shapes can't be patched here.

(Events are closer than expected: tep's `Tep::Events` already emits the toy/v1 envelope with the deterministic fields `serve_events_gate` asserts — but that's moot while the completions body is incompatible.)

### What ships here
- `prep/serve_spike_tepbackend.rb` — the spike harness (evidence; not a runner).
- CHANGELOG Unreleased entry.
- **No change to toy's handlers** — `lib/toy/serve/openai/{handlers,embeddings_handler}.rb` and `lib/toy/run/serve.rb` stay as-is.

### Unblock path (tep-side)
Either a battery completion shape that can carry `ids` (toy's contract), or a toy-owned `CompletionsHandler` override mounted on top of the Backend that re-emits `ids` (keeps the Backend for models/embeddings, keeps toy's completions wire). Tracked on toy#30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)