### PR TITLE
fix(#90): drain Metal residency sets at teardown — DRAFT, UNVERIFIED (needs Mac #27)

### DIFF
--- a/lib/toy/compute.rb
+++ b/lib/toy/compute.rb
@@ -123,6 +123,15 @@ module Toy
     def self.warm_start_recipe
       Toy::LLM::Recipes::WarmStart.new
     end
+
+    # toy#90 — device teardown hook. CPU has no GPU-resource lifecycle to
+    # drain, so this is a deliberate no-op; it exists only so a
+    # device-agnostic experiment body can call Toy::Device.shutdown
+    # portably before exit (the Metal entry's override is the one that
+    # actually matters — see compute_metal.rb).
+    def self.shutdown
+      nil
+    end
   end
 end
 

--- a/lib/toy/compute_cuda.rb
+++ b/lib/toy/compute_cuda.rb
@@ -92,6 +92,14 @@ module Toy
     def self.warm_start_recipe
       Toy::LLM::Recipes::WarmStartCuda.new
     end
+
+    # toy#90 — device teardown hook. CUDA frees its GPU allocations on
+    # process exit without a residency-set assert (unlike Metal), so this
+    # is a deliberate no-op; it exists for parity so a device-agnostic
+    # experiment body can call Toy::Device.shutdown portably.
+    def self.shutdown
+      nil
+    end
   end
 end
 

--- a/lib/toy/compute_metal.rb
+++ b/lib/toy/compute_metal.rb
@@ -85,6 +85,23 @@ module Toy
     def self.from_scratch_recipe
       Toy::LLM::Recipes::FromScratchMetal.new
     end
+
+    # toy#90 — device teardown hook (THE one that matters). ggml-metal
+    # keeps a process-lifetime residency-set collection on its singleton
+    # device and asserts at the C++ static-destructor device-free that the
+    # collection is empty (vendor/ggml/src/ggml-metal/ggml-metal-device.m
+    # :618). A consumer that builds experiment_metal (toy new --lib) runs
+    # the binary directly — it gets NO GGML_METAL_NO_RESIDENCY=1 (that env
+    # is injected only by toy's own CLI subprocesses), so any Metal buffer
+    # still alive at exit aborts the process (exit 134) AFTER correct
+    # compute (toy#27 runs 3-4). Spinel has no at_exit, so a device-
+    # agnostic body MUST call Toy::Device.shutdown before returning;
+    # tnn_shutdown_engines frees every live Metal session's weights_buf
+    # (removing it from the residency set), satisfying the assert.
+    # RUNTIME-UNVERIFIED on gx10 (Linux) — Mac gate proves the exit-0.
+    def self.shutdown
+      TinyNNMetal.tnn_shutdown_engines
+    end
   end
 end
 

--- a/lib/toy/core/cli/new.rb
+++ b/lib/toy/core/cli/new.rb
@@ -284,6 +284,14 @@ module Toy
             step = step + 1
           end
           puts "experiment: ok (device=" + Toy::Device.name + ")"
+
+          # toy#90 — release backend resources before exit. REQUIRED on
+          # Metal: ggml-metal asserts at device-free that its residency
+          # set is empty, and a directly-run experiment_metal gets no
+          # GGML_METAL_NO_RESIDENCY=1 (that env is injected only by toy's
+          # own CLI). No-op on cpu/cuda. Spinel has no at_exit, so this
+          # explicit call is the teardown seam.
+          Toy::Device.shutdown
         RUBY
 
         # Per-device entry shims — device chosen at COMPILE time by

--- a/lib/toy/run/eval_metal.rb
+++ b/lib/toy/run/eval_metal.rb
@@ -29,6 +29,16 @@
 require_relative "../models/arch"
 require_relative "../models/transformer_lm_metal"
 require_relative "../dev/toy_logprobs"
+require_relative "../ffi/tinynn_metal"
+
+# toy#90 — Metal teardown drain. See lib/toy/run/infer_metal.rb for the
+# full rationale: ggml-metal asserts at exit (ggml-metal-device.m:618) if
+# a Metal buffer outlives its device, and Spinel has no at_exit, so we
+# call tnn_shutdown_engines explicitly before exit. METAL-ONLY no-op
+# elsewhere. RUNTIME-UNVERIFIED on gx10 (Linux) — Mac gate proves exit-0.
+def toy_metal_teardown
+  TinyNNMetal.tnn_shutdown_engines
+end
 
 GGUF  = ENV["GGUF"] || "data/smollm2-135m-f32.gguf"
 TOP_K = (ENV["TOP_K"] || "5").to_i
@@ -65,3 +75,5 @@ while k < top_ids.length
   puts "logprob: " + top_ids[k].to_s + " " + top_vals[k].to_s
   k = k + 1
 end
+
+toy_metal_teardown     # toy#90: drain Metal residency sets before exit 0

--- a/lib/toy/run/infer_metal.rb
+++ b/lib/toy/run/infer_metal.rb
@@ -29,6 +29,22 @@
 require_relative "../models/arch"
 require_relative "../models/transformer_lm_metal"
 require_relative "../io/tokenizer"
+require_relative "../ffi/tinynn_metal"
+
+# toy#90 — Metal teardown. ggml-metal asserts at process exit
+# (ggml-metal-device.m:618, [rsets->data count]==0) if any Metal buffer is
+# still alive when its singleton device is freed by the C++ static
+# destructor. This runner never frees its session (it relies on process
+# exit), so without an explicit drain it exits 134 AFTER printing correct
+# output. tnn_shutdown_engines frees every live Metal session's
+# weights_buf (removing it from the residency set), satisfying the assert.
+# Spinel has no at_exit (lib/toy/run/serve.rb:123), so this MUST be called
+# explicitly before every exit that follows lm.load. METAL-ONLY: on
+# CPU/CUDA the registry is empty and this is a no-op-equivalent.
+# RUNTIME-UNVERIFIED on gx10 (Linux) — Mac gate proves the exit-0.
+def toy_metal_teardown
+  TinyNNMetal.tnn_shutdown_engines
+end
 
 GGUF  = ENV["GGUF"] || "data/smollm2-135m-f32.gguf"
 PROMPT = ENV["PROMPT"] || "Once upon a time"
@@ -115,5 +131,8 @@ else
   puts "toy-infer: model has no embedded tokenizer; a string prompt cannot " +
        "be tokenized. Pass numeric token IDs via --prompt-ids (PROMPT_IDS=...) " +
        "or re-convert with --with-tokenizer."
+  toy_metal_teardown   # toy#90: lm.load already allocated Metal buffers
   exit 1
 end
+
+toy_metal_teardown     # toy#90: drain Metal residency sets before exit 0

--- a/lib/toy/run/train_gpt2_metal.rb
+++ b/lib/toy/run/train_gpt2_metal.rb
@@ -83,3 +83,10 @@ while step < STEPS
   puts "step " + (step + 1).to_s + ": loss=" + loss.to_s
   step = step + 1
 end
+
+# toy#90 — Metal teardown drain. The GPT-2 Metal training session is never
+# explicitly freed; without this the ggml-metal device-free residency assert
+# (ggml-metal-device.m:618) aborts the process (exit 134) AFTER a correct
+# run. Spinel has no at_exit (lib/toy/run/serve.rb:123) so drain explicitly.
+# METAL-ONLY no-op for non-Metal. RUNTIME-UNVERIFIED on gx10 — Mac proves it.
+TinyNNMetal.tnn_shutdown_engines

--- a/lib/toy/run/train_metal.rb
+++ b/lib/toy/run/train_metal.rb
@@ -225,3 +225,13 @@ if EVENTS.length > 0 && TinyNNMetal.tnn_events_active == 1
   TinyNNMetal.tnn_events_emit(re.dump)
   TinyNNMetal.tnn_events_close
 end
+
+# toy#90 — Metal teardown drain. The training session (recipe.fs_cache.sess)
+# is never explicitly freed (the runner relies on process exit), so without
+# this the ggml-metal device-free assert (ggml-metal-device.m:618,
+# [rsets->data count]==0) fires AFTER a correct run, exiting 134. Spinel has
+# no at_exit (lib/toy/run/serve.rb:123) so we drain explicitly here.
+# tnn_shutdown_engines frees every live Metal session's weights_buf
+# (removing it from the residency set) and the CPU write session too.
+# RUNTIME-UNVERIFIED on gx10 (Linux) — Mac gate proves the exit-0.
+TinyNNMetal.tnn_shutdown_engines

--- a/tinynn/tinynn_ggml.c
+++ b/tinynn/tinynn_ggml.c
@@ -90,6 +90,68 @@ static tnn_engine *g_engine_cpu   = NULL;
 static tnn_engine *g_engine_cuda[TNN_MAX_CUDA_DEVICES] = { NULL };
 static tnn_engine *g_engine_metal = NULL;
 
+/* toy#90 — Metal residency-set teardown drain.
+ *
+ * The ggml-metal backend keeps a process-lifetime residency-set
+ * collection on its (singleton) device. Each live Metal buffer adds
+ * itself to that collection on alloc and removes itself on free
+ * (vendor/ggml/src/ggml-metal/ggml-metal-device.m:1491/1594). The
+ * device is freed ONLY by a C++ static destructor at process exit
+ * (ggml-metal-device.cpp:12-26), at which point ggml asserts the
+ * collection is empty (ggml-metal-device.m:618 — a deliberate "you
+ * leaked GPU resources" guard). toy's Metal runners (lib/toy/run/)
+ * and the consumer scaffold (Toy::Device, lib/toy/compute_metal.rb)
+ * historically rely on process exit to reclaim everything and never
+ * call tnn_session_free, so a session's weights_buf is still alive at
+ * exit → the residency set is non-empty → SIGABRT (exit 134), AFTER
+ * compute already produced correct output. The CLI subprocess paths
+ * mask this with GGML_METAL_NO_RESIDENCY=1, but a directly-run
+ * consumer binary gets no such env (toy#27 runs 3-4).
+ *
+ * Fix: track every live Metal session so tnn_shutdown_engines can free
+ * them (draining their weights_buf, hence the residency set) before the
+ * static destructor runs. The registry is METAL-ONLY by construction —
+ * tnn_session_register is called only when s->engine == g_engine_metal
+ * — so CPU and CUDA session/teardown semantics are byte-for-byte
+ * unchanged (their sessions are never registered, never drained here). */
+#define TNN_MAX_METAL_SESSIONS 256
+static void *g_metal_sessions[TNN_MAX_METAL_SESSIONS] = { NULL };
+static int   g_metal_session_count = 0;
+
+static void tnn_metal_session_register(void *sess)
+{
+    if (g_metal_session_count >= TNN_MAX_METAL_SESSIONS) {
+        /* Fail loud (never silently drop): an undrained session leaks a
+         * residency set and re-trips the device-free assert. */
+        fprintf(stderr,
+                "[tnn] WARNING: more than %d live Metal sessions; "
+                "tnn_shutdown_engines cannot track this one and the "
+                "ggml-metal device-free residency assert may fire at "
+                "exit. Bump TNN_MAX_METAL_SESSIONS or free sessions "
+                "explicitly with tnn_session_free.\n",
+                TNN_MAX_METAL_SESSIONS);
+        return;
+    }
+    g_metal_sessions[g_metal_session_count++] = sess;
+}
+
+static void tnn_metal_session_unregister(void *sess)
+{
+    for (int i = 0; i < g_metal_session_count; ++i) {
+        if (g_metal_sessions[i] == sess) {
+            /* compact: move the tail entry into the hole */
+            g_metal_sessions[i] = g_metal_sessions[g_metal_session_count - 1];
+            g_metal_sessions[g_metal_session_count - 1] = NULL;
+            --g_metal_session_count;
+            return;
+        }
+    }
+}
+
+/* Forward decl: tnn_session_free is defined further down; the drain in
+ * tnn_shutdown_engines needs it. */
+void tnn_session_free(void *sess);
+
 /* CUDA backend init with device selection. Weak stub returns NULL;
  * strong override lives in tinynn_backend_cuda.c. */
 __attribute__((weak))
@@ -199,6 +261,24 @@ static tnn_engine *tnn_engine_get_on(int backend_kind, int device)
  * GPU between phases. */
 void tnn_shutdown_engines(void)
 {
+    /* toy#90 — drain any live Metal sessions FIRST. Each session_free
+     * frees s->weights_buf, whose ggml-metal buffer removes itself from
+     * the device's residency-set collection; only once every Metal
+     * buffer is freed is the device-free assert (ggml-metal-device.m:618)
+     * satisfied. tnn_session_free unregisters as it goes, so we always
+     * drain index 0 until the list is empty (no iterator invalidation).
+     * Metal-only: CPU/CUDA sessions are never registered. */
+    while (g_metal_session_count > 0) {
+        void *sess = g_metal_sessions[0];
+        if (!sess) { /* defensive: drop a stale NULL slot */
+            g_metal_sessions[0] = g_metal_sessions[g_metal_session_count - 1];
+            g_metal_sessions[g_metal_session_count - 1] = NULL;
+            --g_metal_session_count;
+            continue;
+        }
+        tnn_session_free(sess);
+    }
+
     /* CPU + Metal: single slot each. */
     tnn_engine **scalar_slots[] = { &g_engine_cpu, &g_engine_metal };
     for (int i = 0; i < 2; ++i) {
@@ -387,6 +467,13 @@ void *tnn_session_new_on(int backend_kind, int device)
     s->weights_map_base  = NULL;
     s->weights_map_size  = 0;
     s->last_graph        = 0;
+    /* toy#90 — register Metal sessions so tnn_shutdown_engines can drain
+     * their residency-set-carrying buffers before the ggml-metal static
+     * destructor runs. Gated to the Metal engine: CPU/CUDA sessions are
+     * never tracked, keeping their lifecycle unchanged. */
+    if (e == g_engine_metal) {
+        tnn_metal_session_register((void *)s);
+    }
     return (void *)s;
 }
 
@@ -394,6 +481,9 @@ void tnn_session_free(void *sess)
 {
     if (!sess) return;
     tnn_session *s = (tnn_session *)sess;
+    /* toy#90 — drop from the Metal drain registry (no-op for CPU/CUDA
+     * sessions, which were never registered). Idempotent. */
+    tnn_metal_session_unregister(sess);
     if (s->weights_buf)      ggml_backend_buffer_free(s->weights_buf);
     if (s->weights_buf_mmap) ggml_backend_buffer_free(s->weights_buf_mmap);
     if (s->ctx)        ggml_free(s->ctx);


### PR DESCRIPTION
## ⚠️ DRAFT — UNVERIFIED ON METAL. Do NOT merge until Mac-confirmed (#27).

gx10 (Linux, no Apple frameworks) cannot build or run Metal, so this fix is **source archaeology + a Mac-verifiable patch**. It is NOT confirmed to clear the assert.

**Mac verification required before merge (#27 runs 3-4, Apple M2):**
1. `experiment_metal` (from `toy new --lib`, built `./build.sh metal`) exits **0 WITHOUT** `GGML_METAL_NO_RESIDENCY=1`.
2. `ruby prep/metal_gate.rb` stays green (infer byte-equal ids / eval top-k order / train determinism).
3. The three `libexec/toy-*-metal` runners exit 0 unset-env.

## Root cause (file:line evidence)

The Metal consumer flow trains/infers correctly but exits **134** at teardown:
```
ggml-metal-device.m:618  GGML_ASSERT([rsets->data count] == 0)   (at C++ static-destructor device free)
```

This is a **missing session free in toy, NOT a ggml bug**:
- ggml's residency-set lifecycle is symmetric: a buffer adds its rset on alloc (`ggml-metal-device.m:1491`/`1588`) and removes it on free (`ggml-metal-device.m:1594`, `ggml_metal_device_rsets_rm`).
- The Metal **device is a process-lifetime singleton** held in a function-local `static std::vector<ggml_metal_device_ptr>` (`ggml-metal-device.cpp:20-26`); it is freed ONLY by the C++ static destructor at process exit (`ggml-metal-device.cpp:12-16`). `ggml_backend_metal_free` frees the *context*, never the device.
- The assert at `:618` is a deliberate "you leaked GPU resources" guard. It fires iff a Metal buffer is still alive at exit.
- toy's Metal runners (`lib/toy/run/*_metal.rb`) and the `toy new --lib` scaffold (`Toy::Device`, `lib/toy/compute_metal.rb`) **never call `tnn_session_free`** — they rely on process exit (documented at `lib/toy/core/cli/infer.rb:102-109`). So the session's `weights_buf` (which carries the rset, freed only in `tnn_session_free` → `tinynn_ggml.c:397`) is alive at the static destructor → assert.
- The CLI subprocess paths mask this with `GGML_METAL_NO_RESIDENCY=1` (`cli/infer.rb:110`, `train.rb:230`, `eval.rb:112`), but a **directly-run** `experiment_metal` gets no such env.

`NO_RESIDENCY` is not a free win: residency sets wire GPU memory to avoid OS eviction during a keep-alive window (`ggml-metal-device.m:548-607`) — a real perf hint; disabling them also silences the leak guard.

## Disposition: #1 (toy-side), Metal-gated

Free the session before exit so its `weights_buf` drains the rset.

- **`tinynn/tinynn_ggml.c`** — a Metal-only live-session registry. `tnn_session_new_on` registers iff `s->engine == g_engine_metal`; `tnn_shutdown_engines` drains the registry (each `tnn_session_free` removes the rset) before freeing the backend; `tnn_session_free` unregisters. **CPU/CUDA sessions are never registered**, so their session/teardown semantics are byte-for-byte unchanged.
- **`lib/toy/run/{infer,eval,train,train_gpt2}_metal.rb`** — call `TinyNNMetal.tnn_shutdown_engines` before exit (Spinel has no `at_exit` — see `lib/toy/run/serve.rb:123`).
- **`lib/toy/compute_metal.rb`** — `Toy::Device.shutdown` → `tnn_shutdown_engines`; `compute.rb`/`compute_cuda.rb` get a no-op `shutdown` for a portable device-agnostic seam.
- **`lib/toy/core/cli/new.rb`** — scaffolded `experiment.rb` calls `Toy::Device.shutdown` before exit, so fresh consumer projects exit clean on Metal.

## No-regression evidence (CPU + CUDA, on gx10)

- `make gate-compute-surface SPINEL_DIR=/tmp/spinel-union-1414` → **GATE PASS** (one-require surface trains, `compute-surface: ok`).
- `ruby prep/train_gate.rb` (same SPINEL_DIR) → **all 4 arms PASS byte-for-byte**: from-scratch, lora, warm-start, vit-tiny.
- `tinynn/tinynn_ggml.c` compiles warning-free with project flags (`-O2 -fPIC -Wall -Wextra`); CUDA backend TU coexists (single `tnn_session_free`/`tnn_shutdown_engines` definitions, registry inert on CUDA).

Refs: #27 (Mac runs 3-4) · #70 (metal vendor unit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)