### PR TITLE
fix(engine): pass missing qk_norm arg to realize_for_mmap

### DIFF
--- a/lib/toy/llm/engine/llama_kv_engine.rb
+++ b/lib/toy/llm/engine/llama_kv_engine.rb
@@ -874,7 +874,7 @@ class SmolLM2KVFFICache
     if is_native
       wtype = GGUFLoad.detect_weight_type(gguf_path)
       set_weight_type(wtype)
-      realize_for_mmap(gguf, cfg, max_T, flags.untied, flags.qkv_bias)
+      realize_for_mmap(gguf, cfg, max_T, flags.untied, flags.qkv_bias, flags.qk_norm)
       puts "  BYO-pointer mmap (weight_type=" + wtype.to_s + ")"
       gguf
     else


### PR DESCRIPTION
## The bug

`realize_for_mmap` gained a 6th required param (`qk_norm`) in the #65/#110 qk_norm work. The external callers were updated (`transformer_lm.rb:148` passes 6 args), but the **internal `realize_and_load_auto` self-call was left at 5 args**, silently dropping `qk_norm`:

```ruby
def realize_for_mmap(gguf_handle, cfg, max_T, untied, qkv_bias, qk_norm)   # 6 required
# ...
def realize_and_load_auto(gguf_path, max_T, cfg, flags)
  # ...
  realize_for_mmap(gguf, cfg, max_T, flags.untied, flags.qkv_bias)         # only 5!
```

Under CRuby this is an `ArgumentError (given 5, expected 6)`. Under Spinel (closed-world, no arity check) the missing arg is zero-filled as `void _t377 = 0`, and the C build then fails with `variable or field '_t377' declared void` — **the blocker for compiling `toy serve` on spinel master** (after the `Array.new` poly-size fix, [matz/spinel#1407](https://github.com/matz/spinel/pull/1407)).

## The fix

Pass `flags.qk_norm` (the `flags` object has `attr_accessor :qk_norm`), mirroring the canonical caller in `transformer_lm.rb`.

The cuda/metal engine mirrors (`llama_kv_engine_{cuda,metal}.rb`) are gitignored and regenerate from this source via `prep/gen_cuda_mirror.rb`; `--verify` passes after this change, so there's nothing to commit for them.

## Verification

`spinel-migrate --to <master> --rbs sig lib/toy/run/serve.rb` now advances past `llama_kv_engine.rb:884` (this blocker) to serve's only remaining one, a long-standing compiler bug filed separately ([spinel-dev#27](https://github.com/OriPekelman/spinel-dev/issues/27), loop-carried local → void return in tep's `backoff_for`). `toy eval` is already fully green on master.

Found via the migrate→inspect triage loop; corroborates [spinel-dev#21](https://github.com/OriPekelman/spinel-dev/issues/21) (Spinel should diagnose arity mismatch rather than silently zero-fill).

🤖 Generated with [Claude Code](https://claude.com/claude-code)