### PR TITLE
fix(#94): durable guard against int-truncated CUDA BYO-pointer (mmap-attach SIGSEGV)

### DIFF
--- a/tinynn/tinynn_backend_cuda.c
+++ b/tinynn/tinynn_backend_cuda.c
@@ -16,6 +16,28 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+/* toy#94 — DURABLE GUARD against an int-truncated BYO-pointer.
+ *
+ * ggml_backend_cuda_buffer_from_ptr is the vendored BYO-pointer entry
+ * (vendor-patches/0001-cuda-buffer_from_ptr.patch, which patches BOTH
+ * src/ggml-cuda/ggml-cuda.cu AND include/ggml-cuda.h). The SYMBOL is
+ * defined in libggml-cuda.a, but `make gem-prep` resets vendor/ggml to
+ * GGML_REV (Makefile $(GGML_DIR)/.patched / commit 312fae9) — which
+ * silently drops the *header* declaration while a previously-built
+ * archive still carries the symbol. With no prototype in scope, C
+ * treats the call as an implicit declaration returning `int`: on
+ * aarch64 (GB10) the 64-bit ggml_backend_buffer_t is TRUNCATED to 32
+ * bits. The truncated pointer is non-NULL, so the !buf check passes,
+ * and the next ggml_backend_buffer_get_base() dereferences garbage →
+ * SIGSEGV in the Phase-2 mmap weight-attach (the toy#94 stack:
+ * ggml_backend_buffer_get_base <- tnn_session_attach_weight_mmap <-
+ * realize_for_mmap). Declaring it here keeps a correct 64-bit prototype
+ * in scope REGARDLESS of the vendored header's post-reset state, so the
+ * pointer can never be truncated. (Identical to the header decl when
+ * the patch is applied; harmless redundancy.) */
+GGML_BACKEND_API ggml_backend_buffer_t
+ggml_backend_cuda_buffer_from_ptr(void *host_ptr, size_t size, int device);
+
 ggml_backend_t tnn_backend_cuda_init_internal(void)
 {
     return ggml_backend_cuda_init(0);


### PR DESCRIPTION
## Summary

Fixes #94 — the bench-vs-pytorch CUDA demos (`demos/qwen25_bench_cuda`, `demos/seq_train_bench_cuda`) SIGSEGV in the Phase-2 mmap BYO-pointer weight-attach:

```
ggml_backend_buffer_get_base <- tnn_session_attach_weight_mmap <- realize_for_mmap
```

## Confirmed root cause (verbatim repro)

NOT the hypothesised missing `set_weight_type` — the mmap path reads per-tensor type/offset straight from the GGUF handle (`tnn_gguf_tensor_type`/`tnn_gguf_tensor_file_offset`), so `@weight_type` is never consulted there.

The actual defect: `make gem-prep` resets `vendor/ggml` to `GGML_REV` (commit 312fae9 / the `$(GGML_DIR)/.patched` sentinel), which **drops the vendored header declaration** of `ggml_backend_cuda_buffer_from_ptr` (added by `vendor-patches/0001-cuda-buffer_from_ptr.patch`) while a previously-built `libggml-cuda.a` still carries the **symbol** (`nm` shows `T ggml_backend_cuda_buffer_from_ptr`). With no prototype in scope, `tinynn_backend_cuda.c` compiles the call as an implicit-`int` function — on aarch64 (GB10) the returned 64-bit `ggml_backend_buffer_t` is **truncated to 32 bits**. The truncated pointer is non-NULL (passes the `!buf` check), so the next `ggml_backend_buffer_get_base()` dereferences garbage → SIGSEGV.

The build emitted exactly this, ignored as a warning:
```
tinynn/tinynn_backend_cuda.c:54: warning: implicit declaration of function 'ggml_backend_cuda_buffer_from_ptr'
tinynn/tinynn_backend_cuda.c:54: warning: returning 'int' from a function with return type 'ggml_backend_buffer_t' makes pointer from integer without a cast
```
gdb stack (before fix):
```
#0 ggml_backend_buffer_is_meta
#1 ggml_backend_buffer_get_base
#2 tnn_session_attach_weight_mmap
#3 sp_SmolLM2KVFFICacheCuda_realize_for_mmap
#4 main
```

## The fix

Add a 64-bit forward declaration of `ggml_backend_cuda_buffer_from_ptr` in `tinynn/tinynn_backend_cuda.c` (identical to the patched header decl), so the prototype is always in scope **regardless** of the vendored header's post-reset state. Verified durable: with the header decl stripped (simulating post-gem-prep), the guarded source compiles with **no** truncation warning.

## Verification (after fix, union pin /tmp/spinel-union-1414, GB10)

- `demos/qwen25_bench_cuda` (smollm2-135m-native): runs clean, 82.7 tok/s decode.
- `demos/seq_train_bench_cuda` lora (75.8 ms/step) + ft (81.3 ms/step): run clean.
- `make bench-vs-pytorch` now produces the previously-unmeasurable infer ratio:
  - **`ratio_infer_toy_over_pt = 1.337x`** (toy 82.2 tok/s vs PyTorch 109.9) `[ok]`
  - `ratio_train_toy_over_pt = 1.100x` `[ok]` — "ok — toy stays within budget of PyTorch"
- `make bench` (toy-only): all `[ok]`, no regression.

## Red herring noted

`seq_train_bench_cuda.rb:50`'s 5-arg `realize_for_mmap` is **correct** — the seq engine's `realize_for_mmap` genuinely has a 5-param signature (no `qk_norm`) on both CPU and CUDA. Adding a 6th arg would break the build; no change made.

🤖 Generated with [Claude Code](https://claude.com/claude-code)