### PR TITLE
toy#95: adapt build for C-compiler master (SPINEL_DEPS → spinel binary; enable tep pg link)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,10 +120,16 @@ CUDA_DIR    ?= /usr/local/cuda
 # /var/lib/gems), `bundle lock` can't write the git cache without sudo —
 # that's an env-setup concern, not a toy bug.
 #
-# SPINEL_EXT_DISABLE=pg: tep's optional pg C-ext currently fails to
-# compile under spinel-compat (its libpq pkg-config cflags aren't wired
-# to the source .o compile — spinelgems#8). toy only uses tep for HTTP
-# serving, not its pg adapter, so we opt out. Drop this once #8 lands.
+# tep's pg C-ext is now built + linked (libpq). We previously
+# SPINEL_EXT_DISABLE=pg'd it (libpq pkg-config cflags weren't wired —
+# spinelgems#8), relying on the legacy backend DCE'ing the unused PG
+# surface. On spinelc/master tep's PG-integration (broadcast/presence-
+# over-PG, pulled in by tep.rb's unconditional `require "tep/pg"`) is
+# reachable, so serve emits the `tep_pg_*` externs and must link the
+# shim + libpq. spinelgems#8 has landed (libpq cflags wired), so we no
+# longer disable it. (serve doesn't use PG at runtime — the clean fix is
+# tep making the PG battery opt-in: tep#216. Drop the libpq dep here once
+# that lands.)
 vendor-tep:
 	@if [ ! -d ../spinelgems ]; then \
 	    echo ""; \
@@ -138,7 +144,7 @@ vendor-tep:
 	    exit 1; \
 	fi
 	bundle lock
-	SPINEL_EXT_DISABLE=pg SPINEL_DIR=$(HOME)/sites/spinel ../spinelgems/exe/spinel-compat vendor
+	SPINEL_DIR=$(HOME)/sites/spinel ../spinelgems/exe/spinel-compat vendor
 	@# toy#69 — fold the vendored gems' aggregated sig root (advertised
 	@# by vendor/spinel/deps.rb, spinelgems#13) into toy's own --rbs
 	@# root via a gitignored symlink: spinel accepts ONE --rbs dir and

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,11 @@ endif
 # .a in tinynn/ combined with newer Spinel C codegen can produce
 # misaligned binaries that segfault at init (Tao hit this 2026-05-26
 # after pulling Spinel 2183a92 — the lib archives weren't rebuilt).
-SPINEL_DEPS := $(SPINEL_DIR)/spinel_analyze $(SPINEL_DIR)/spinel_codegen
+# Track the compiler BINARY: post the Ruby→C rewrite there is no
+# spinel_analyze/spinel_codegen at the checkout root (the Ruby backend
+# moved to legacy/, oracle-only), just the single `spinel` binary —
+# which is the right rebuild trigger and exists on both layouts.
+SPINEL_DEPS := $(SPINEL_BIN)
 
 CC          ?= cc
 CFLAGS      ?= -O2 -fPIC -Wall -Wextra


### PR DESCRIPTION
The Makefile-adapt half of the master re-pin (toy#95). With these, **eval builds green and serve compiles+links** on spinel master.

**1. `SPINEL_DEPS` → `$(SPINEL_BIN)`** — the rebuild sentinel referenced `$(SPINEL_DIR)/spinel_analyze` + `spinel_codegen`, which don't exist on the C-compiler master (the Ruby backend moved to `legacy/`, oracle-only). Every compiled target had unsatisfiable prerequisites against master. Track the `spinel` binary instead — the right rebuild trigger, present on both the legacy and C layouts.

**2. Enable tep's pg C-ext** — drop `SPINEL_EXT_DISABLE=pg`. On master tep's PG-integration is reachable (tep.rb unconditionally requires `tep/pg`), so serve emits the `tep_pg_*` externs and must link the shim + libpq; spinelgems#8 (libpq cflags) has landed, so the re-vendor builds + links it. (serve doesn't use PG at runtime — the clean end state is tep making PG opt-in, tep#216.)

## Status
- **eval: green** on master.
- **serve: compiles + links** (2.3 MB), but **boot is blocked on a spinelc regression** — matz/spinel#1425 (a seed-then-delete str_array ivar inits NULL → `sp_StrArray_push(a=0x0)` in tep's `Response#set_cookie` at boot; legacy backend clean). The re-pin closes once #1425 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)