### PR TITLE
fix(eval): force IntArray codegen in decode_step + Metal perf bench (#104)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -360,6 +360,16 @@ endif
 	$(SPINEL) --cc='cc -Wl,-u,_tnn_metal_force_link -framework Foundation -framework Metal -framework MetalKit' $< -o $@
 toy-eval-metal: libexec/toy-eval-metal
 
+# Convenience: run both functional gates on the pure CPU path (no parity arm).
+# These are the byte-exact infer/eval baselines. Until this target existed the
+# CPU eval gate only ran behind gate-cuda's TOY_GATE_CUDA=1, so a CPU-only eval
+# regression could reach main unnoticed — and did once (the decode_step
+# PolyArray OOB, #104/#105). Self-builds the runners via bin/toy.
+.PHONY: gate-cpu
+gate-cpu:
+	ruby prep/infer_gate.rb
+	ruby prep/eval_gate.rb
+
 # Convenience: run both functional gates with the CUDA parity arm enabled.
 .PHONY: gate-cuda
 gate-cuda:

--- a/Makefile
+++ b/Makefile
@@ -2093,6 +2093,37 @@ bench-update: tinynn/libtinynn_ggml.a
 bench-report: tinynn/libtinynn_ggml.a
 	ruby bench/check.rb --report
 
+# Metal perf leg (macOS only; #104 part C). Times the metal-vs-cpu infer
+# runners via N-differencing — steady-state decode ms/token plus the
+# metal-vs-cpu ratio on THIS machine. The baseline (bench/baselines_metal.csv)
+# is Mac-pinned, like the metal_gate float baseline; capture it with
+# `make bench-metal-update` on a QUIESCED machine (desktop load skews the
+# numbers badly). Skips green off macOS, exactly like gate-metal.
+.PHONY: bench-metal bench-metal-update bench-metal-report
+bench-metal:
+ifneq ($(UNAME_S),Darwin)
+	@echo "bench-metal: Metal is macOS-only (uname -s = $(UNAME_S)) — skipping"; exit 0
+else
+	$(MAKE) libexec/toy-infer-metal libexec/toy-infer
+	ruby bench/check_metal.rb
+endif
+
+bench-metal-update:
+ifneq ($(UNAME_S),Darwin)
+	@echo "bench-metal-update: Metal is macOS-only (uname -s = $(UNAME_S)) — skipping"; exit 0
+else
+	$(MAKE) libexec/toy-infer-metal libexec/toy-infer
+	ruby bench/check_metal.rb --update
+endif
+
+bench-metal-report:
+ifneq ($(UNAME_S),Darwin)
+	@echo "bench-metal-report: Metal is macOS-only (uname -s = $(UNAME_S)) — skipping"; exit 0
+else
+	$(MAKE) libexec/toy-infer-metal libexec/toy-infer
+	ruby bench/check_metal.rb --report
+endif
+
 # Routine comparison vs PyTorch — the "old-stable" yardstick — in the
 # single-machine single-GPU case. Runs ON gx10: toy CUDA benches run
 # native, the PyTorch reference (bench/ref_pytorch.py) runs in the

--- a/bench/check_metal.rb
+++ b/bench/check_metal.rb
@@ -1,0 +1,153 @@
+# bench/check_metal.rb — Metal (Apple GPU) perf leg. macOS-only.
+#
+# THE GAP this fills: toy has a Metal numeric *parity* gate (prep/metal_gate.rb)
+# but no Metal *perf* bench — no baselines, no regression signal. This is the
+# lightweight first leg: it times the ALREADY-BUILT metal/cpu infer runners
+# (libexec/toy-infer-metal, libexec/toy-infer) and reports on-device decode
+# throughput, plus the Metal-vs-CPU ratio on the same machine.
+#
+# METHOD — N-differencing (why it's honest): a single `toy infer` process pays
+# a large fixed cost (process spawn + GGUF mmap + graph realize/compile) that
+# dwarfs the per-token decode for a 135M model. We time the SAME runner at two
+# token counts (N_LO, N_HI) and take (t_hi - t_lo)/(N_HI - N_LO): the fixed cost
+# cancels, leaving a clean steady-state decode ms/token. best-of-REPS run to
+# damp scheduler noise. (Cross-check: the CPU number this yields matches
+# bench/check.rb's infer_step_ms to ~1%.)
+#
+# Usage:
+#   ruby bench/check_metal.rb            # run + compare vs baselines_metal.csv
+#   ruby bench/check_metal.rb --update   # run + (re)write the Mac baseline
+#   ruby bench/check_metal.rb --report   # run + print, no gate
+#
+# Baseline file: bench/baselines_metal.csv (same schema as baselines.csv). The
+# baseline is Mac-pinned (Apple GPUs differ per chip) — it is an A/B anchor for
+# THIS machine, not a cross-machine truth, exactly like the metal_gate float
+# baseline note. Commit the baseline from a known-good machine; treat a cross-
+# machine compare as informational.
+#
+# SCOPE / next legs (deliberately NOT built here — see issue #104 part C):
+#   * train wallclock: libexec/toy-train-metal runs but emits no timing; a real
+#     train leg wants BENCH-line instrumentation INSIDE the runner (per-step ms),
+#     not process-level wallclock (startup dominates a 5-step from-scratch run).
+#   * per-op Metal timing already exists via tinynn's P6 sched eval callback
+#     (Chrome-Trace) — wire that for a flame view when chasing a specific op.
+#   * a heavier model (qwen2.5-1.5B) would show Metal WINNING; 135M decode is
+#     dispatch-bound so CPU leads. Add when a larger native gguf is on the Mac.
+
+require "csv"
+
+ROOT = File.expand_path("../..", __FILE__)
+BASELINES_PATH = File.expand_path("../baselines_metal.csv", __FILE__)
+
+if RUBY_PLATFORM !~ /darwin/
+  puts "SKIP [check_metal]: Metal is macOS-only (platform #{RUBY_PLATFORM})."
+  exit 0
+end
+
+GGUF   = ENV["GGUF"]   || "data/smollm2-135m-f32.gguf"
+N_LO   = (ENV["N_LO"]  || "8").to_i
+N_HI   = (ENV["N_HI"]  || "72").to_i
+REPS   = (ENV["REPS"]  || "3").to_i
+PROMPT_IDS = ENV["PROMPT_IDS"] || "6403 1980 253 655 28"
+
+INFER_METAL = File.join(ROOT, "libexec", "toy-infer-metal")
+INFER_CPU   = File.join(ROOT, "libexec", "toy-infer")
+
+# best-of-REPS wallclock (ms) of one runner at N tokens.
+def time_ms(bin, n)
+  best = nil
+  REPS.times do
+    t0 = Time.now
+    system({ "GGUF" => GGUF, "PROMPT_IDS" => PROMPT_IDS, "N_NEW" => n.to_s },
+           bin, out: File::NULL, err: File::NULL)
+    dt = (Time.now - t0) * 1000.0
+    best = dt if best.nil? || dt < best
+  end
+  best
+end
+
+# steady-state decode ms/token via N-differencing.
+def decode_ms_per_tok(bin)
+  lo = time_ms(bin, N_LO)
+  hi = time_ms(bin, N_HI)
+  (hi - lo) / (N_HI - N_LO).to_f
+end
+
+[["toy-infer-metal", INFER_METAL], ["toy-infer", INFER_CPU]].each do |name, bin|
+  unless File.executable?(bin)
+    warn "check_metal: missing #{name} (run `make libexec/#{name}`#{name.include?("metal") ? " — needs `make setup-ggml-metal` first" : ""})"
+    exit 2
+  end
+end
+unless File.file?(File.join(ROOT, GGUF))
+  warn "check_metal: GGUF not found: #{GGUF}"
+  exit 2
+end
+
+puts "== toy metal perf bench (N-diff #{N_LO}->#{N_HI}, best-of-#{REPS}, #{File.basename(GGUF)}) =="
+metal_ms = decode_ms_per_tok(INFER_METAL)
+cpu_ms   = decode_ms_per_tok(INFER_CPU)
+speedup  = cpu_ms / metal_ms   # >1 => metal faster; <1 => cpu faster
+
+observed = {
+  "infer_metal_decode_ms_per_tok" => metal_ms,
+  "infer_cpu_decode_ms_per_tok"   => cpu_ms,
+  "metal_vs_cpu_decode_speedup"   => speedup,
+}
+
+# --- baseline I/O (mirror bench/check.rb) ---------------------------------
+def infer_dir(m);  m.include?("speedup") ? "higher" : "lower"; end
+def infer_unit(m); m.include?("speedup") ? "x" : "ms"; end
+
+update_mode = ARGV.include?("--update")
+report_only = ARGV.include?("--report")
+
+baselines = {}
+if File.exist?(BASELINES_PATH) && !update_mode
+  CSV.foreach(BASELINES_PATH, headers: true) do |r|
+    baselines[r["metric"]] = { value: r["value"].to_f, unit: r["unit"],
+                               direction: r["direction"], tolerance_pct: r["tolerance_pct"].to_f }
+  end
+end
+
+if update_mode
+  rows = observed.map do |metric, value|
+    e = baselines[metric] || {}
+    { "metric" => metric, "value" => sprintf("%.6f", value),
+      "unit" => e[:unit] || infer_unit(metric),
+      "direction" => e[:direction] || infer_dir(metric),
+      "tolerance_pct" => (e[:tolerance_pct] || 20.0).to_s }
+  end
+  CSV.open(BASELINES_PATH, "w", write_headers: true,
+           headers: %w[metric value unit direction tolerance_pct]) do |csv|
+    rows.each { |r| csv << r.values_at(*csv.headers) }
+  end
+  puts "wrote #{BASELINES_PATH} (#{rows.length} rows)"
+  exit 0
+end
+
+def evaluate(metric, observed, baseline)
+  return [sprintf("  %-34s = %10.4f  (no baseline — run --update)", metric, observed), true] if baseline.nil?
+  b = baseline[:value]
+  rel = b.zero? ? 0.0 : 100.0 * (observed - b) / b
+  bad = baseline[:direction] == "lower" ? rel > baseline[:tolerance_pct] : -rel > baseline[:tolerance_pct]
+  [sprintf("  %-34s = %10.4f %-2s (baseline %.4f, %+6.2f %%, tol ±%.1f %%)  [%s]",
+           metric, observed, baseline[:unit], b, rel, baseline[:tolerance_pct], bad ? "REGRESS" : "ok"), !bad]
+end
+
+puts "results:"
+regress = 0
+observed.each do |metric, value|
+  line, ok = evaluate(metric, value, baselines[metric])
+  puts line
+  regress += 1 unless ok
+end
+
+if report_only
+  puts "(report mode — not gating)"; exit 0
+end
+if regress > 0
+  puts "\nFAIL: #{regress} metric(s) regressed past tolerance"; exit 1
+end
+puts "\nok — metal perf within baselines"
+exit 0

--- a/lib/toy/llm/engine/llama_kv_engine.rb
+++ b/lib/toy/llm/engine/llama_kv_engine.rb
@@ -1584,7 +1584,15 @@ module SmolLM2KV
     TinyNN.tnn_reset_for_rebuild(kv_cache.sess)
     step = kv_cache.build_decode_step(pos)
     TinyNN.tnn_realize(kv_cache.sess, step.kv_step_logits)
-    TinyNN.upload_int_array(kv_cache.sess, step.t_token_id, [token_id])
+    # Spinel landmine: in whole-program inference contexts where `token_id`
+    # poly-collapses to sp_RbVal (e.g. the eval runner, where generate's
+    # sampler-fed `last_id` unifies decode_step's param to RbVal), the literal
+    # `[token_id]` compiles to a PolyArray. upload_int_array takes :int_array
+    # (sp_IntArray), so the PolyArray is then mis-read as an IntArray → garbage
+    # length → ggml "tensor write out of bounds" abort. Narrowing to a clean
+    # mrb_int via `.to_i` forces the IntArray codegen (as `[pos]` already gets).
+    tid = token_id.to_i
+    TinyNN.upload_int_array(kv_cache.sess, step.t_token_id, [tid])
     TinyNN.upload_int_array(kv_cache.sess, step.t_pos,      [pos])
     TinyNN.tnn_compute(kv_cache.sess)
     kv_cache.dump_trace


### PR DESCRIPTION
Closes the Mac/Metal validation work from #104. After this, `make gate-metal` is **fully green (all 3 arms)** — the #1449 Metal-training fix is confirmed on Apple GPU.

## 1. Fix: CPU eval OOB crash (the ARM2 blocker)
`toy eval` aborted with `GGML_ASSERT(offset+size <= ggml_nbytes) "tensor write out of bounds"` in `tnn_upload_from_int_array`. The committed `prep/eval_gate.rb` confirmed it was a real regression on `main` (not environmental), and it survived a full clean rebuild.

**Root cause (Spinel poly-collapse):** in the *eval* runner's whole-program inference, `decode_step`'s `token_id` poly-collapses to `sp_RbVal` (generate's sampler-fed `last_id` unifies the param), so the literal `[token_id]` compiles to a **`PolyArray`** — which `upload_int_array` (`:int_array` = `sp_IntArray`) then mis-reads as an IntArray → garbage length → OOB. The *infer* runner compiles the identical line as `IntArray` (token_id stays `mrb_int`). Diagnosed by diffing the generated C (`spinel --rbs sig -c <runner>.rb`): `sp_PolyArray_new()` in eval vs `sp_IntArray_new()` in infer.

**Fix:** `tid = token_id.to_i` before `[tid]` in `SmolLM2KV.decode_step`, forcing IntArray codegen (as `[pos]` already gets). 1 line + an explanatory comment so it isn't "simplified" away.

**Verified:**
- `prep/eval_gate.rb` → PASS (top-k id order byte-exact; logprob floats within the macOS non-canonical tolerance, drift ~7e-6)
- `prep/infer_gate.rb` → PASS (byte-exact, unchanged)
- `make gate-metal` → **ALL 3 ARMS PASS** (infer bit-identical, eval top-k identical, train/#1449 deterministic + loss-decrease + ckpt round-trip)

## 2. `make gate-cpu` — close the gap that let this regression land
The CPU eval gate previously only ran behind `gate-cuda` (gated by `TOY_GATE_CUDA=1`); there's no CI and no CPU gate umbrella, so a CPU-only eval regression could reach `main` unnoticed — which is exactly how this bug landed. Adds a `gate-cpu` target running `prep/infer_gate.rb` + `prep/eval_gate.rb` on the pure CPU path (self-builds the runners). Run it before pushing.

## 3. Metal perf-bench leg (#104 part C)
Adds `bench/check_metal.rb` + `make bench-metal{,-update,-report}`. Times the already-built `libexec/toy-infer-metal` vs `libexec/toy-infer` using **N-differencing** (`(t@N_hi − t@N_lo)/(N_hi−N_lo)`) so process spawn + GGUF mmap + graph-realize cancel, leaving a clean steady-state decode ms/token plus the metal-vs-cpu ratio on the same machine. Cross-check: the CPU number matches `bench/check.rb`'s `infer_step_ms` to ~1%. macOS-only, skips green off Darwin exactly like `gate-metal`.

First clean Mac numbers: **Metal ≈ 23.5 ms/tok, CPU ≈ 16.0 ms/tok** — CPU leads at this size (135M single-token decode is Metal-dispatch-bound; Metal wins on larger models / batched prefill). No `baselines_metal.csv` committed: it's Mac-pinned and a contaminated baseline is worse than none — capture via `make bench-metal-update` on a quiesced machine. Deliberately deferred (documented in the file header): a Metal *train* leg (needs BENCH-line instrumentation inside the runner, not process wallclock) and a heavier-model leg.

## Notes (no code change)
- The **"16-22× LoRA slowdown"** reported mid-investigation was a measurement artifact (bench ran during the `setup-ggml-metal` compile; LoRA runs first/contaminated, inference runs after/clean). Clean number is ~65-81 ms vs gx10's 53 ms (~1.3×, normal). `GGML_ACCELERATE=ON` made no meaningful difference.

## Test plan
- [x] `make gate-cpu` — both gates PASS
- [x] `make gate-metal` — all 3 arms PASS
- [x] `make bench-metal-report` — runs (builds deps, prints metrics)

🤖 Generated with [Claude Code](https://claude.com/claude-code)